### PR TITLE
fix: respect Obsidian REST protocol setting

### DIFF
--- a/src/background/__tests__/obsidianClient-secure-fetch.test.ts
+++ b/src/background/__tests__/obsidianClient-secure-fetch.test.ts
@@ -1,7 +1,7 @@
 /**
  * obsidianClient-secure-fetch.test.ts
- * HTTPS通信の強制に関するテスト
- * HTTP URLが自動的にHTTPSに変換されることを検証
+ * Obsidian Local REST API のプロトコル設定に関するテスト
+ * HTTP/HTTPS の選択が通信時に尊重されることを検証
  */
 
 import { ObsidianClient } from '../obsidianClient.js';
@@ -9,7 +9,7 @@ import * as storage from '../../utils/storage.js';
 
 vi.mock('../../utils/storage.js');
 
-describe('ObsidianClient: HTTPS通信の強制', () => {
+describe('ObsidianClient: Obsidian REST API プロトコル設定', () => {
   let obsidianClient: ObsidianClient;
 
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe('ObsidianClient: HTTPS通信の強制', () => {
     };
   });
 
-  describe('_fetchExistingContent - HTTPS強制', () => {
+  describe('_fetchExistingContent - プロトコル設定', () => {
     beforeEach(() => {
       global.fetch = vi.fn();
     });
@@ -70,7 +70,7 @@ describe('ObsidianClient: HTTPS通信の強制', () => {
       );
     });
 
-    it('HTTP URLがHTTPSに変換されること', async () => {
+    it('HTTP URLがHTTPのまま使用されること', async () => {
       // @ts-expect-error - vi.fn() type narrowing issue
       storage.getSettings.mockResolvedValue({
         OBSIDIAN_API_KEY: 'test_key',
@@ -91,9 +91,8 @@ describe('ObsidianClient: HTTPS通信の強制', () => {
 
       expect(result).toBe('Existing content');
 
-      // fetchがHTTPSで呼ばれていること
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://127.0.0.1:27123/vault/test.md',
+        'http://127.0.0.1:27123/vault/test.md',
         expect.objectContaining({
           method: 'GET',
           headers: expect.any(Object)
@@ -110,7 +109,7 @@ describe('ObsidianClient: HTTPS通信の強制', () => {
     });
   });
 
-  describe('_writeContent - HTTPS強制', () => {
+  describe('_writeContent - プロトコル設定', () => {
     beforeEach(() => {
       global.fetch = vi.fn();
     });
@@ -139,7 +138,7 @@ describe('ObsidianClient: HTTPS通信の強制', () => {
       );
     });
 
-    it('HTTP URLで_writeContentが呼ばれてもHTTPSに変換される', async () => {
+    it('HTTP URLで_writeContentが呼ばれた場合はHTTPのまま使用される', async () => {
       // @ts-expect-error - vi.fn() type narrowing issue
       global.fetch.mockResolvedValue({
         ok: true
@@ -150,7 +149,7 @@ describe('ObsidianClient: HTTPS通信の強制', () => {
       }, 'Test content');
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://127.0.0.1:27123/vault/test.md',
+        'http://127.0.0.1:27123/vault/test.md',
         expect.objectContaining({
           method: 'PUT',
           headers: expect.any(Object),
@@ -160,7 +159,7 @@ describe('ObsidianClient: HTTPS通信の強制', () => {
     });
   });
 
-  describe('testConnection - HTTPS強制', () => {
+  describe('testConnection - プロトコル設定', () => {
     beforeEach(() => {
       global.fetch = vi.fn();
     });
@@ -189,7 +188,7 @@ describe('ObsidianClient: HTTPS通信の強制', () => {
   });
 
   describe('プロトコル設定の検証', () => {
-    it('設定にhttpが含まれている場合でもHTTPSに変換される', async () => {
+    it('設定にhttpが含まれている場合はHTTPでfetchされる', async () => {
       // @ts-expect-error - vi.fn() type narrowing issue
       storage.getSettings.mockResolvedValue({
         OBSIDIAN_API_KEY: 'test_key',
@@ -210,13 +209,27 @@ describe('ObsidianClient: HTTPS通信の強制', () => {
         { 'Authorization': 'Bearer test_key' }
       );
 
-      // HTTP ではなく HTTPS で fetch されること
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://127.0.0.1:27123/vault/test.md',
+        'http://127.0.0.1:27123/vault/test.md',
         expect.any(Object)
       );
 
       (global.fetch as vi.Mock).mockRestore();
+    });
+
+    it('無効なプロトコル設定は拒否される', async () => {
+      // @ts-expect-error - vi.fn() type narrowing issue
+      storage.getSettings.mockResolvedValue({
+        OBSIDIAN_API_KEY: 'test_key',
+        OBSIDIAN_PROTOCOL: 'ftp',
+        OBSIDIAN_PORT: '27123',
+        OBSIDIAN_DAILY_PATH: ''
+      });
+
+      const result = await obsidianClient.testConnection();
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Protocol must be "http" or "https"');
     });
   });
 });

--- a/src/background/__tests__/obsidianClient.test.ts
+++ b/src/background/__tests__/obsidianClient.test.ts
@@ -402,6 +402,10 @@ describe('ObsidianClient: FEATURE-001 エラーハンドリングの一貫性と
 
       expect(result.success).toBe(false);
       expect(result.message).toContain('Endpoint not found');
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('http://127.0.0.1:27123/'),
+        expect.any(Object)
+      );
     });
 
     it('overrideで500の場合は接続エラーを返す', async () => {
@@ -419,6 +423,18 @@ describe('ObsidianClient: FEATURE-001 エラーハンドリングの一貫性と
 
       expect(result.success).toBe(false);
       expect(result.message).toContain('Connection failed');
+    });
+
+    it('overrideで無効なプロトコルの場合はエラーを返す', async () => {
+      const result = await obsidianClient.testConnection({
+        protocol: 'ftp',
+        port: 27123,
+        apiKey: 'test_key'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Protocol must be "http" or "https"');
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 
@@ -514,8 +530,8 @@ describe('ObsidianClient: FEATURE-001 エラーハンドリングの一貫性と
       }, 20000);
     });
 
-  describe('enforceHttps', () => {
-    it('HTTP接続をHTTPSに強制変換する', async () => {
+  describe('protocol handling', () => {
+    it('HTTP設定ではHTTP接続をそのまま使用する', async () => {
       storage.getSettings.mockResolvedValue({
         OBSIDIAN_API_KEY: 'test_key',
         OBSIDIAN_PROTOCOL: 'http',
@@ -530,7 +546,7 @@ describe('ObsidianClient: FEATURE-001 エラーハンドリングの一貫性と
       });
 
       global.fetch.mockImplementation((url, options) => {
-        if (url.startsWith('https://')) {
+        if (url.startsWith('http://')) {
           if (options.method === 'GET') {
             return Promise.resolve({
               ok: true,
@@ -546,9 +562,20 @@ describe('ObsidianClient: FEATURE-001 エラーハンドリングの一貫性と
 
       expect(global.fetch).toHaveBeenCalled();
       const calledUrl = global.fetch.mock.calls[0][0];
-      expect(calledUrl).toContain('https://');
+      expect(calledUrl).toContain('http://');
 
       global.fetch.mockRestore();
+    });
+
+    it('無効なプロトコル設定は拒否する', async () => {
+      storage.getSettings.mockResolvedValue({
+        OBSIDIAN_API_KEY: 'test_key',
+        OBSIDIAN_PROTOCOL: 'ftp',
+        OBSIDIAN_PORT: '27123',
+        OBSIDIAN_DAILY_PATH: ''
+      });
+
+      await expect(obsidianClient._getConfig()).rejects.toThrow('Protocol must be "http" or "https"');
     });
   });
   describe('testConnection override defaults to https', () => {

--- a/src/background/obsidianClient.ts
+++ b/src/background/obsidianClient.ts
@@ -33,6 +33,8 @@ const DEFAULT_PORT = '27123';
 const MAX_QUEUE_SIZE = 50;
 const MUTEX_TIMEOUT_MS = 30000; // 30秒
 
+type ObsidianProtocol = 'http' | 'https';
+
 /**
  * Mutexのインスタンス（クロージャ経由で共有）
  * 日次ノートごとではなく、全体的な書き込み操作をシリアライズ
@@ -58,24 +60,6 @@ export interface ObsidianClientOptions {
 }
 
 /**
- * HTTP → HTTPS 強制変換
- * Obsidian Local REST API への安全な接続を保証する
- * @param {string} url - リクエストURL
- * @returns {string} HTTPS URL
- */
-function enforceHttps(url: string): string {
-    if (url.startsWith('http://')) {
-        const httpsUrl = url.replace(/^http:\/\//, 'https://');
-        addLog(LogType.WARN, 'HTTP detected, upgrading to HTTPS for secure connection', {
-            original: url,
-            upgraded: httpsUrl
-        });
-        return httpsUrl;
-    }
-    return url;
-}
-
-/**
  * Problem #1: タイムアウト付きfetchのラッパー関数
  * @param {string} url - リクエストURL
  * @param {object} options - fetchオプション
@@ -83,15 +67,14 @@ function enforceHttps(url: string): string {
  * @throws {Error} タイムアウト時にエラーをスロー
  */
 async function _fetchWithTimeout(url: string, options: RequestInit = {}): Promise<Response> {
-    const secureUrl = enforceHttps(url);
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
         controller.abort();
-        addLog(LogType.ERROR, `Obsidian request timed out after ${FETCH_TIMEOUT_MS}ms`, { url: secureUrl });
+        addLog(LogType.ERROR, `Obsidian request timed out after ${FETCH_TIMEOUT_MS}ms`, { url });
     }, FETCH_TIMEOUT_MS);
 
     try {
-        const response = await fetch(secureUrl, { ...options, signal: controller.signal });
+        const response = await fetch(url, { ...options, signal: controller.signal });
         clearTimeout(timeoutId);
         return response;
     } catch (error: unknown) {
@@ -123,7 +106,7 @@ export class ObsidianClient {
         const settings = await getSettings();
 
         const s = settings as Record<string, unknown>;
-        const protocol = String(s[StorageKeys.OBSIDIAN_PROTOCOL] ?? 'https') || 'https';
+        const protocol = this._validateProtocol(s[StorageKeys.OBSIDIAN_PROTOCOL] as string | undefined | null);
         const rawPort = (s[StorageKeys.OBSIDIAN_PORT] ?? DEFAULT_PORT) as string | number;
         const port = this._validatePort(rawPort);
         const apiKey = s[StorageKeys.OBSIDIAN_API_KEY] as string | undefined;
@@ -154,6 +137,25 @@ export class ObsidianClient {
             },
             settings
         };
+    }
+
+    /**
+     * プロトコルの検証
+     * @param {string|undefined|null} protocol - Obsidian Local REST API のプロトコル
+     * @returns {'http'|'https'} 有効なプロトコル
+     * @throws {Error} プロトコルが無効な場合
+     */
+    _validateProtocol(protocol: string | undefined | null): ObsidianProtocol {
+        if (protocol === undefined || protocol === null || protocol === '') {
+            return 'https';
+        }
+
+        const normalized = String(protocol).trim().toLowerCase();
+        if (normalized !== 'http' && normalized !== 'https') {
+            throw new Error('Invalid protocol. Protocol must be "http" or "https".');
+        }
+
+        return normalized;
     }
 
     /**
@@ -273,7 +275,7 @@ export class ObsidianClient {
             let baseUrl: string;
             let headers: HeadersInit;
             if (override) {
-                const protocol = override.protocol || 'https';
+                const protocol = this._validateProtocol(override.protocol);
                 const port = this._validatePort(override.port);
                 const apiKey = override.apiKey;
                 if (!apiKey) {


### PR DESCRIPTION
## Summary

Obsidian Local REST API connection now respects the configured protocol setting.

Previously, selecting `http` still resulted in requests being upgraded to `https` inside the background Obsidian client. This made the `http` option ineffective for users running the Local REST API over HTTP.

<img width="720" height="363" alt="image" src="https://github.com/user-attachments/assets/ad1a9f30-bfa7-4cca-a98a-8e155c1ff501" />

## Changes

- Removed the HTTP-to-HTTPS forced conversion in Obsidian request handling.
- Added protocol validation so only `http` and `https` are accepted.
- Applied the same validation to connection-test overrides.
- Updated Obsidian client tests to verify that HTTP remains HTTP and HTTPS remains HTTPS.

## Verification

- `npm run type-check`
- `npm test -- src/background/__tests__/obsidianClient-secure-fetch.test.ts src/background/__tests__/obsidianClient.test.ts src/utils/__tests__/storage-buildAllowedUrls.test.ts`
- `npm run validate`
- `npm run build`


