### PR TITLE
fix(dashboard): 記録条件の保存をsaveSettings経由に変更

### DIFF
--- a/src/dashboard/__tests__/recordingConditionsSettings.test.ts
+++ b/src/dashboard/__tests__/recordingConditionsSettings.test.ts
@@ -7,18 +7,28 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
-// Chrome API mock
+// Hoisted mocks for storage module
 // ---------------------------------------------------------------------------
-const mockStorageGet = vi.fn();
-const mockStorageSet = vi.fn();
+const { mockGetSettings, mockSaveSettings } = vi.hoisted(() => ({
+  mockGetSettings: vi.fn(),
+  mockSaveSettings: vi.fn(),
+}));
 
-vi.stubGlobal('chrome', {
-  storage: {
-    local: {
-      get: mockStorageGet,
-      set: mockStorageSet,
-    },
+vi.mock('../../utils/storage.js', () => ({
+  getSettings: mockGetSettings,
+  saveSettings: mockSaveSettings,
+  StorageKeys: {
+    MIN_VISIT_DURATION: 'minVisitDuration',
+    MIN_SCROLL_DEPTH: 'minScrollDepth',
+    MAX_TOKENS_PER_PROMPT: 'maxTokensPerPrompt',
+    AI_TIMEOUT_MS: 'aiTimeoutMs',
   },
+}));
+
+// ---------------------------------------------------------------------------
+// Chrome API mock (for i18n)
+// ---------------------------------------------------------------------------
+vi.stubGlobal('chrome', {
   i18n: {
     getMessage: vi.fn().mockReturnValue(''),
   },
@@ -72,8 +82,8 @@ describe('recordingConditionsSettings', () => {
     vi.clearAllMocks();
   });
 
-  it('loads and renders recording conditions with defaults', async () => {
-    mockStorageGet.mockResolvedValue({});
+  it('loads and renders recording conditions with defaults when no settings exist', async () => {
+    mockGetSettings.mockResolvedValue({});
     await initRecordingConditionsSettings();
 
     const minVisitInput = document.getElementById('minVisitDuration') as HTMLInputElement;
@@ -85,16 +95,94 @@ describe('recordingConditionsSettings', () => {
     expect(maxTokensInput?.value).toBe('1000');
   });
 
-  it('saves recording conditions to storage on save click', async () => {
-    mockStorageGet.mockResolvedValue({});
-    mockStorageSet.mockResolvedValue(undefined);
+  it('loads previously saved values from getSettings', async () => {
+    mockGetSettings.mockResolvedValue({
+      minVisitDuration: 10,
+      minScrollDepth: 75,
+      maxTokensPerPrompt: 2000,
+      aiTimeoutMs: 30000,
+    });
+    await initRecordingConditionsSettings();
+
+    const minVisitInput = document.getElementById('minVisitDuration') as HTMLInputElement;
+    const minScrollInput = document.getElementById('minScrollDepth') as HTMLInputElement;
+    const maxTokensInput = document.getElementById('maxTokensPerPrompt') as HTMLInputElement;
+    const aiTimeoutInput = document.getElementById('aiTimeoutSeconds') as HTMLInputElement;
+
+    expect(minVisitInput?.value).toBe('10');
+    expect(minScrollInput?.value).toBe('75');
+    expect(maxTokensInput?.value).toBe('2000');
+    expect(aiTimeoutInput?.value).toBe('30');
+  });
+
+  it('saves recording conditions via saveSettings on save click', async () => {
+    mockGetSettings.mockResolvedValue({});
+    mockSaveSettings.mockResolvedValue(undefined);
+    await initRecordingConditionsSettings();
+
+    const minVisitInput = document.getElementById('minVisitDuration') as HTMLInputElement;
+    const maxTokensInput = document.getElementById('maxTokensPerPrompt') as HTMLInputElement;
+    minVisitInput.value = '15';
+    maxTokensInput.value = '3000';
+
+    const saveBtn = document.getElementById('save-conditions-settings') as HTMLButtonElement;
+    saveBtn.click();
+
+    await vi.waitFor(() => {
+      expect(mockSaveSettings).toHaveBeenCalled();
+    });
+
+    expect(mockSaveSettings).toHaveBeenCalledWith({
+      minVisitDuration: 15,
+      minScrollDepth: 50,
+      maxTokensPerPrompt: 3000,
+      aiTimeoutMs: 0,
+    });
+  });
+
+  it('shows success message after save', async () => {
+    mockGetSettings.mockResolvedValue({});
+    mockSaveSettings.mockResolvedValue(undefined);
     await initRecordingConditionsSettings();
 
     const saveBtn = document.getElementById('save-conditions-settings') as HTMLButtonElement;
     saveBtn.click();
 
     await vi.waitFor(() => {
-      expect(mockStorageSet).toHaveBeenCalled();
+      const successMsg = document.getElementById('conditions-save-success');
+      expect(successMsg?.style.display).toBe('');
+    });
+  });
+
+  it('shows validation error for invalid min visit duration', async () => {
+    mockGetSettings.mockResolvedValue({});
+    await initRecordingConditionsSettings();
+
+    const minVisitInput = document.getElementById('minVisitDuration') as HTMLInputElement;
+    minVisitInput.value = '0';
+
+    const saveBtn = document.getElementById('save-conditions-settings') as HTMLButtonElement;
+    saveBtn.click();
+
+    await vi.waitFor(() => {
+      const errorMsg = document.getElementById('conditions-validation-error');
+      expect(errorMsg?.style.display).toBe('');
+    });
+
+    expect(mockSaveSettings).not.toHaveBeenCalled();
+  });
+
+  it('handles saveSettings error gracefully', async () => {
+    mockGetSettings.mockResolvedValue({});
+    mockSaveSettings.mockRejectedValue(new Error('Storage full'));
+    await initRecordingConditionsSettings();
+
+    const saveBtn = document.getElementById('save-conditions-settings') as HTMLButtonElement;
+    saveBtn.click();
+
+    await vi.waitFor(() => {
+      const errorMsg = document.getElementById('conditions-validation-error');
+      expect(errorMsg?.style.display).toBe('');
     });
   });
 });

--- a/src/dashboard/recordingConditionsSettings.ts
+++ b/src/dashboard/recordingConditionsSettings.ts
@@ -4,7 +4,7 @@
  * Note: Recording triggers (scroll/time/snapshot) are no longer configurable.
  */
 
-import { StorageKeys, getSettings } from '../utils/storage.js';
+import { StorageKeys, getSettings, saveSettings } from '../utils/storage.js';
 import { errorMessage } from '../utils/errorUtils.js';
 import { getMessage, applyI18n } from '../popup/i18n.js';
 
@@ -125,8 +125,9 @@ function wireEvents(container: HTMLElement): void {
     }
 
     try {
-      // Save recording conditions
-      await chrome.storage.local.set({
+      // Save recording conditions via saveSettings so values are written
+      // to the 'settings' object, matching what getSettings reads.
+      await saveSettings({
         [StorageKeys.MIN_VISIT_DURATION]: minVisitVal,
         [StorageKeys.MIN_SCROLL_DEPTH]: minScrollVal,
         [StorageKeys.MAX_TOKENS_PER_PROMPT]: maxTokensVal,


### PR DESCRIPTION
## Summary
- Obsidian設定など他の設定が既に保存されている状態（`settings`オブジェクトが存在する状態）で記録条件（最小滞在時間など）を変更しても、値が反映されない不具合を修正
- `recordingConditionsSettings.ts` の保存処理を `chrome.storage.local.set()` の直接キー保存から `saveSettings()` 経由に変更し、`getSettings()` の読み取り優先順位（`settings`オブジェクト優先）と一致させた

Closes #15

## Test plan
- [x] `npm run type-check` 通過
- [x] `npm test` 全件パス（6977 passed / 20 skipped）
- [x] 手動確認: ダッシュボードで他の設定を保存後、記録条件（最小滞在時間）を15秒に変更→保存→リロードしても値が保持されることを確認
- [x] DevTools の Extension Storage で `settings.minVisitDuration` に正しく格納されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)