### PR TITLE
refactor(sqlite): StorageBackend adapter による SQLite アーキテクチャ深化

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# .github/FUNDING.yml
+buy_me_a_coffee: yasumaro

--- a/dev-docs/ADR/2026-07-13-sqlite-architecture-deep-dig.md
+++ b/dev-docs/ADR/2026-07-13-sqlite-architecture-deep-dig.md
@@ -1,0 +1,39 @@
+# Deep Dig Findings — SQLite Architecture Deepening
+
+**Date:** 2026-07-13
+**Scope:** 5 PBIs for SQLite layer architecture improvement
+
+---
+
+## 挑戦した仮定
+
+| # | 仮定 | リスク | 発見 | 決定 |
+|---|------|--------|------|------|
+| A | StorageBackend インターフェース1つで全20操作をカバーできる | 高 | 非対応操作（backupDb on IDB VFS）は既存コードでもエラーを返している。アダプタ化後も同じ挙動。ただし UI が事前にケイパビリティを知る必要がある | 単一インターフェース + `getStatus().supportsBinaryBackup` 追加 |
+| B | OPFS Worker の postMessage モデルと IDB VFS の直接SQL モデルが同一インターフェースに収まる | 高 | 収まる。アダプタ内部の実装非対称は GoF アダプタパターンの本質であり欠陥ではない。Worker を生SQL受付に統一するのは型安全性・セキュリティ境界の後退 | 非対称を許容 + Worker に `SQL_EXEC`/`SQL_QUERY` 裏口追加（マイグレーション専用） |
+| C | init時にバックエンドを1回選択して固定すれば運用上問題ない | 高 | OPFS Worker の初期化失敗要因（WASM URL, OPFS未サポート, DB非互換）は環境要因でありセッション中に変化しない。切り替え機構を作ると別DBへの移行が必要でデータ不整合を引き起こす | 一度選択したら変えない。offscreen 再作成時に再選択。これは欠陥ではなくデータ一貫性の必然的制約 |
+| D | PBI #1 → #2/#5 → #3/#4 の順序が最適 | 中 | #4 は完全独立（エラー伝播のみ、バックエンドに触らない）。#3 がファイル分割不要で極小化（1pt） | **#4 を最優先に繰り上げ**: #4 → #1 → #2 + #5（並列）→ #3 |
+| E | 分岐除去後も既存のエラーハンドリング・遅延init・フォールバック挙動を完全維持できる | 高 | 遅延init のトリガーがリポジトリ関数から `getBackend()` に移動。NoopBackend（Null Object Pattern）で全バックエンド失敗時に throw せずエラーを返す。記述量は 30行 → 5行に削減 | `getBackend()` で遅延init + NoopBackend |
+| F | 1087行のPanelを4モジュールに分割した後、DOMイベントと状態同期が壊れない | 中 | ファイル分割だけではテスト不能なまま（関数がグローバルDOM/stateに依存）。本質的な解決策は関数シグネチャの引数化であり、ファイル移動は付随的な整理に過ぎない。イベント配線はHTMLを生成するモジュールが所有すべき | ファイル分割は**行わない**。関数シグネチャの引数化のみ。PBI #3 の見積もり 3pt → 1pt |
+| G | SqliteClient.call() のエラー分類ロジックが十分なカバレッジを持つ | 中 | Chrome Extension API のエラーは型付き例外ではなく文字列メッセージ。文字列マッチは fragile だが唯一の現実的手段 | テストで timeout / offscreen lost / quota / SQLite error の4パターンをカバー |
+
+---
+
+## 新たに発見したリスク
+
+- **NoopBackend の無限ループ**: 全バックエンド失敗 + NoopBackend 選択時にリポジトリ関数が再び `getBackend()` を呼ばないよう、キャッシュ後の再試行ロジックを明示的に禁止する必要がある
+- **Worker SQL_EXEC のセキュリティ**: マイグレーション専用だが、誤用すると SQL インジェクション経路になる。アダプタ内で `SQL_EXEC` を直接露出させない
+- **Panel の refresh() 競合**: `loadData()` 中にユーザーが操作すると `refresh()` が二重呼び出しされ、state と DOM が不整合になる可能性。既存コードと同じく `state.loading` フラグでガードする
+
+## 決定事項
+
+1. StorageBackend: 単一インターフェース + `getStatus().supportsBinaryBackup` 追加
+2. Worker: 操作タイプメッセージは維持。`SQL_EXEC`/`SQL_QUERY` をマイグレーション専用に追加
+3. バックエンド選択: one-shot, one-time。切り替え機構は作らない（データ一貫性のため）
+4. Null Object: NoopBackend で全バックエンド失敗時に throw しない
+5. Panel: ファイル分割なし。関数シグネチャの引数化のみ
+6. PBI順序: #4（エラー伝播）→ #1（アダプタ）→ #2 + #5（並列）→ #3（引数化）
+
+## 未解決の疑問
+
+- なし（全仮定に回答済み）

--- a/docs/superpowers/plans/2026-07-13-sqlite-architecture-deepening.md
+++ b/docs/superpowers/plans/2026-07-13-sqlite-architecture-deepening.md
@@ -1,0 +1,1408 @@
+# SQLite Architecture Deepening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deepen the SQLite layer by unifying three-backend dispatch via adapter pattern, deduplicating types/migrations, improving error propagation, and enabling testability of the history panel.
+
+**Architecture:** Introduce `StorageBackend` interface with three adapters (OpfsWorkerBackend, IdbVfsBackend, FallbackStorageAdapter) plus NoopBackend null object. Repository functions delegate to a single backend. Backend selection is lazy and one-time per offscreen document lifetime. Panel functions are parameterized for testability without file splitting. Execution order: PBI #4 (error propagation) → #1 (adapter) → #2 + #5 (dedup + migrations) → #3 (panel parameterization).
+
+**Tech Stack:** TypeScript ESM, Chrome Extension Manifest V3, @subframe7536/sqlite-wasm, wa-sqlite (IDB fallback), Jest + jsdom
+
+---
+
+## File Structure
+
+### New files
+| File | Responsibility |
+|------|---------------|
+| `src/offscreen/StorageBackend.ts` | `StorageBackend` interface + `StatusResult` + `NoopBackend` |
+| `src/offscreen/OpfsWorkerBackend.ts` | Adapter: delegates to OPFS Worker via postMessage |
+| `src/offscreen/IdbVfsBackend.ts` | Adapter: direct SQL execution via wa-sqlite IDB VFS |
+| `src/offscreen/FallbackStorageAdapter.ts` | Adapter: wraps `FallbackStorage` class |
+| `src/offscreen/migrations.ts` | `MigrationEngine` interface + `runMigrations()` + `MIGRATION_COLUMNS` |
+
+### Modified files
+| File | Change |
+|------|--------|
+| `src/background/sqliteClient.ts` | `call()` returns structured error instead of `null` |
+| `src/background/handlers/dashboardSqliteHandlers.ts` | Propagate `lastError` into response |
+| `src/offscreen/sqliteEngineContext.ts` | Add `getBackend()`, remove backend init from public surface |
+| `src/offscreen/recordsRepo.ts` | Replace 4-way branches with `backend.operation()` |
+| `src/offscreen/dbMaintenance.ts` | Replace 4-way branches with `backend.operation()` |
+| `src/offscreen/auditLogRepo.ts` | Replace 4-way branches with `backend.operation()` |
+| `src/offscreen/opfsWorker.ts` | Remove duplicate types; add `SQL_EXEC`/`SQL_QUERY`; use `runMigrations()` |
+| `src/offscreen/schema.ts` | Add `MIGRATION_COLUMNS`, `MIGRATION_SEQUENCE` |
+| `src/offscreen/sqlite.ts` | Re-export adapter classes; update public API surface |
+| `src/dashboard/dashboardSqliteService.ts` | Handle structured errors from SW |
+| `src/dashboard/sqliteHistoryPanel.ts` | Parameterize render functions with data+callbacks |
+
+---
+
+## Phase 1: PBI #4 — Error Propagation (1pt)
+
+### Task 1: Structured error return from SqliteClient.call()
+
+**Files:**
+- Modify: `src/background/sqliteClient.ts` (line ~152: `call()` method)
+- Modify: `src/background/handlers/dashboardSqliteHandlers.ts` (all handler cases)
+
+- [ ] **Step 1: Change `call()` return type and add error categorization**
+
+In `src/background/sqliteClient.ts`, find the private `call()` method and change:
+
+```ts
+// Before (line ~152)
+private async call<T>(fn: () => Promise<T>): Promise<T | null> {
+  await this.mutex.acquire();
+  try {
+    await this.ensureOffscreenDocument();
+    const result = await fn();
+    return result;
+  } catch (error) {
+    logError('SQLite Client: call failed', { error: errorMessage(error) }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
+    return null;
+  } finally {
+    this.mutex.release();
+  }
+}
+
+// After
+type CallResult<T> = { success: true; data: T } | { success: false; error: string };
+
+private async call<T>(fn: () => Promise<T>): Promise<CallResult<T>> {
+  await this.mutex.acquire();
+  try {
+    await this.ensureOffscreenDocument();
+    const data = await fn();
+    return { success: true, data };
+  } catch (error) {
+    const msg = errorMessage(error);
+    const categorized = categorizeError(msg);
+    logError('SQLite Client: call failed', { error: msg }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
+    return { success: false, error: categorized };
+  } finally {
+    this.mutex.release();
+  }
+}
+
+function categorizeError(msg: string): string {
+  if (msg.includes('timed out') || msg.includes('Timeout')) {
+    return `SQLite request timed out. The database may still be initializing.`;
+  }
+  if (msg.includes('offscreen') || msg.includes('offscreenDocument')) {
+    return `Database connection lost. Please reload the extension.`;
+  }
+  if (msg.includes('quota') || msg.includes('QuotaExceededError')) {
+    return `Storage quota exceeded. Some older records may have been removed.`;
+  }
+  if (msg.includes('SQLITE_') || msg.includes('disk I/O')) {
+    return `Database error: ${msg}`;
+  }
+  return `Unexpected error: ${msg}`;
+}
+```
+
+- [ ] **Step 2: Add `lastError` property and update all `call()` consumers**
+
+Add to `SqliteClient` class:
+
+```ts
+/** Last categorized error from call(). Read by dashboard handlers. */
+lastError: string | null = null;
+```
+
+Update every method that uses `call()` (insert, query, search, update, delete, toggleStar, getCount, exportDb, backupDb, restoreDb, getStatus, clearAll, purgeOldRecords, purgeContent, insertAuditLog, queryAuditLog, insertBatch, runOpfsSpike, isSqliteHealthy):
+
+```ts
+// Pattern for all methods:
+async query(options: QueryOptions): Promise<QueryResult | null> {
+  const { success, data, error } = await this.call(async () => {
+    return (await this.msgOffscreen('SQLITE_QUERY', options)) as QueryResult;
+  });
+  if (!success) {
+    this.lastError = error;
+    return null;
+  }
+  this.lastError = null;
+  return data;
+}
+```
+
+- [ ] **Step 3: Run existing tests to verify compatibility**
+
+```bash
+npm test -- --testPathPattern="sqliteClient"
+```
+
+Expected: All tests pass (existing tests mock `call()` or test through the public methods).
+
+- [ ] **Step 4: Update dashboard handler to propagate error**
+
+In `src/background/handlers/dashboardSqliteHandlers.ts`, update each handler case to use `sqliteClient.lastError`:
+
+```ts
+// Pattern for handler cases:
+case 'query': {
+  const result = await sqliteClient.query(payload);
+  if (result === null) {
+    const error = sqliteClient.lastError || 'Query failed';
+    sendResponse({ success: false, error });
+    return;
+  }
+  sendResponse({ success: true, rows: result.rows, total: result.total });
+  break;
+}
+```
+
+Apply this pattern to all cases: `query`, `search`, `toggle_star`, `delete`, `update`, `get_count`, `clear_all`, `status`, `backfill_metadata`, `backup_db`, `import`, `append_to_obsidian`, `purge_now`, `content_purge_now`.
+
+- [ ] **Step 5: Update dashboardSqliteService to surface errors**
+
+In `src/dashboard/dashboardSqliteService.ts`, update each function from `null` checks to structured error logging:
+
+```ts
+// Pattern for all functions:
+export async function queryLogs(options = {}): Promise<{ rows: BrowsingLogEntry[]; total: number } | null> {
+  try {
+    const response = await sendDashboardMessage({ subtype: 'query', ...options });
+    if (response.success) {
+      return { rows: (response.rows || []) as BrowsingLogEntry[], total: Number(response.total || 0) };
+    }
+    console.warn('queryLogs failed:', response.error);  // <-- was: silently null
+    return null;
+  } catch (error) {
+    console.error('queryLogs failed:', error);
+    return null;
+  }
+}
+```
+
+- [ ] **Step 6: Update sqliteHistoryPanel to display specific errors**
+
+In `src/dashboard/sqliteHistoryPanel.ts`, update `loadData()` error handling:
+
+```ts
+// In loadData(), change:
+state.error = t('historyLoadError');
+// To:
+state.error = result?.error || t('historyLoadError');
+```
+
+Wait — `loadData()` receives results via `queryLogs()` / `searchLogs()`. Those currently return `null` on failure. We need to change them to also return error info.
+
+In `src/dashboard/dashboardSqliteService.ts`, change the return type:
+
+```ts
+// Before:
+export async function queryLogs(...): Promise<{ rows: BrowsingLogEntry[]; total: number } | null> {
+
+// After:
+export async function queryLogs(...): Promise<{ rows: BrowsingLogEntry[]; total: number } | { error: string } | null> {
+```
+
+Then in `sqliteHistoryPanel.ts`:
+
+```ts
+// In loadData():
+let result: { rows: BrowsingLogEntry[]; total: number } | { error: string } | null;
+// ... fetch ...
+if (result === null) {
+  state.error = t('historyLoadError');
+} else if ('error' in result) {
+  state.error = result.error;
+} else {
+  state.error = null;
+  state.entries = result.rows;
+  state.total = result.total;
+}
+```
+
+- [ ] **Step 7: Run all tests**
+
+```bash
+npm test
+```
+
+Expected: All tests pass. Any test that mocked `call()` returning `null` must be updated to return `{ success: false, error: 'test error' }`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/background/sqliteClient.ts src/background/handlers/dashboardSqliteHandlers.ts src/dashboard/dashboardSqliteService.ts src/dashboard/sqliteHistoryPanel.ts
+git commit -m "fix(sqlite): propagate structured errors from SqliteClient.call() instead of null"
+```
+
+---
+
+## Phase 2: PBI #1 — StorageBackend Adapter (5pt)
+
+### Task 2: Define StorageBackend interface and NoopBackend
+
+**Files:**
+- Create: `src/offscreen/StorageBackend.ts`
+
+- [ ] **Step 1: Create StorageBackend.ts with interface, StatusResult, and NoopBackend**
+
+```ts
+// src/offscreen/StorageBackend.ts
+import type { BrowsingLogRecord, BrowsingLogEntry, QueryOptions, SearchResult as SearchResultType, AuditLogRecord, AuditLogEntry } from '../utils/sqlite-types.js';
+
+export interface InsertResult { success: true; id: number }
+export interface InsertBatchResult { success: true; inserted: number; skipped: number }
+export interface QueryResult { success: true; rows: BrowsingLogEntry[]; total: number }
+export interface SearchResult { success: true; rows: (BrowsingLogEntry & { rank: number })[]; total: number }
+export interface MutationResult { success: true }
+export interface StarResult { success: true; is_starred: number }
+export interface PurgeResult { success: true; purged: number }
+export interface FtsSizeResult { success: true; count: number }
+export interface BackupResult { success: true; data: Uint8Array }
+export interface CountResult { success: true; count: number }
+export interface HealthResult { success: true } // healthCheck — success means alive, failure means error
+export interface AuditLogQueryResult { success: true; rows: AuditLogEntry[]; total: number }
+export type BackendOrError<T> = T | { success: false; error: string };
+
+export interface StatusResult {
+  initialized: boolean;
+  fallback: boolean;
+  fts5: boolean;
+  supportsBinaryBackup: boolean;
+  compileOptions?: string[];
+  compileOptionsSource?: 'opfs-worker' | 'idb' | 'fallback';
+  initError?: string;
+}
+
+export interface StorageBackend {
+  insert(record: BrowsingLogRecord): Promise<BackendOrError<InsertResult>>;
+  insertBatch(records: BrowsingLogRecord[]): Promise<BackendOrError<InsertBatchResult>>;
+  query(options: QueryOptions): Promise<BackendOrError<QueryResult>>;
+  search(query: string, limit: number, offset: number): Promise<BackendOrError<SearchResult>>;
+  update(id: number, changes: Record<string, unknown>): Promise<BackendOrError<MutationResult>>;
+  delete(id: number): Promise<BackendOrError<MutationResult>>;
+  toggleStar(id: number): Promise<BackendOrError<StarResult>>;
+  purgeOldRecords(retentionDays: number, maxRecords: number): Promise<BackendOrError<PurgeResult>>;
+  purgeContent(retentionDays?: number, maxRecords?: number, includeStarred?: boolean): Promise<BackendOrError<PurgeResult>>;
+  getFtsIndexSize(): Promise<BackendOrError<FtsSizeResult>>;
+  backupDb(): Promise<BackendOrError<BackupResult>>;
+  restoreDb(data: Uint8Array): Promise<BackendOrError<MutationResult>>;
+  healthCheck(): Promise<BackendOrError<HealthResult>>;
+  getStatus(): Promise<BackendOrError<StatusResult>>;
+  insertAuditLog(record: AuditLogRecord): Promise<BackendOrError<InsertResult>>;
+  queryAuditLog(options: { limit?: number; offset?: number }): Promise<BackendOrError<AuditLogQueryResult>>;
+  getCount(): Promise<BackendOrError<CountResult>>;
+  clearAll(): Promise<BackendOrError<MutationResult>>;
+}
+
+const NOT_INITIALIZED = 'Database not initialized';
+
+export class NoopBackend implements StorageBackend {
+  private err = (): { success: false; error: string } => ({ success: false, error: NOT_INITIALIZED });
+  async insert() { return this.err(); }
+  async insertBatch() { return this.err(); }
+  async query() { return this.err(); }
+  async search() { return this.err(); }
+  async update() { return this.err(); }
+  async delete() { return this.err(); }
+  async toggleStar() { return this.err(); }
+  async purgeOldRecords() { return this.err(); }
+  async purgeContent() { return this.err(); }
+  async getFtsIndexSize() { return this.err(); }
+  async backupDb() { return this.err(); }
+  async restoreDb() { return this.err(); }
+  async healthCheck() { return this.err(); }
+  async getStatus() { return this.err(); }
+  async insertAuditLog() { return this.err(); }
+  async queryAuditLog() { return this.err(); }
+  async getCount() { return this.err(); }
+  async clearAll() { return this.err(); }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/offscreen/StorageBackend.ts
+git commit -m "feat(sqlite): add StorageBackend interface and NoopBackend null object"
+```
+
+### Task 3: Create OpfsWorkerBackend adapter
+
+**Files:**
+- Create: `src/offscreen/OpfsWorkerBackend.ts`
+
+- [ ] **Step 1: Create OpfsWorkerBackend.ts**
+
+This adapter delegates to `engine.sendToOpfsWorker()` and `engine.tryOpfsProxy()`.
+
+```ts
+// src/offscreen/OpfsWorkerBackend.ts
+import type { SqliteEngineContext } from './sqliteEngineContext.js';
+import type { StorageBackend, InsertResult, InsertBatchResult, QueryResult, SearchResult, MutationResult, StarResult, PurgeResult, FtsSizeResult, BackupResult, CountResult, HealthResult, AuditLogQueryResult, StatusResult, BackendOrError } from './StorageBackend.js';
+import type { BrowsingLogRecord, QueryOptions, AuditLogRecord } from '../utils/sqlite-types.js';
+
+export class OpfsWorkerBackend implements StorageBackend {
+  constructor(private engine: SqliteEngineContext) {}
+
+  async insert(record: BrowsingLogRecord): Promise<BackendOrError<InsertResult>> {
+    const result = await this.engine.sendToOpfsWorker('INSERT', record) as { id: number };
+    return { success: true, id: result.id };
+  }
+
+  async insertBatch(records: BrowsingLogRecord[]): Promise<BackendOrError<InsertBatchResult>> {
+    const result = await this.engine.sendToOpfsWorker('INSERT_BATCH', records) as { inserted: number; skipped: number };
+    return { success: true, inserted: result.inserted, skipped: result.skipped };
+  }
+
+  async query(options: QueryOptions): Promise<BackendOrError<QueryResult>> {
+    const result = await this.engine.tryOpfsProxy<{ rows: BrowsingLogRecord[]; total: number }>('QUERY', options);
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, rows: result.rows as BrowsingLogRecord[] & { id: number }[], total: result.total };
+  }
+
+  async search(query: string, limit: number, offset: number): Promise<BackendOrError<SearchResult>> {
+    const result = await this.engine.tryOpfsProxy<{ rows: (BrowsingLogRecord & { rank: number })[]; total: number }>('SEARCH', { searchQuery: query, limit, offset });
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, rows: result.rows, total: result.total };
+  }
+
+  async update(id: number, changes: Record<string, unknown>): Promise<BackendOrError<MutationResult>> {
+    await this.engine.sendToOpfsWorker('UPDATE', { id, changes });
+    return { success: true };
+  }
+
+  async delete(id: number): Promise<BackendOrError<MutationResult>> {
+    await this.engine.sendToOpfsWorker('DELETE', { id });
+    return { success: true };
+  }
+
+  async toggleStar(id: number): Promise<BackendOrError<StarResult>> {
+    const result = await this.engine.sendToOpfsWorker('TOGGLE_STAR', { id }) as { is_starred: number };
+    return { success: true, is_starred: result.is_starred };
+  }
+
+  async purgeOldRecords(retentionDays: number, maxRecords: number): Promise<BackendOrError<PurgeResult>> {
+    const result = await this.engine.tryOpfsProxy<{ purged: number }>('PURGE', { retentionDays, maxRecords });
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, purged: result.purged };
+  }
+
+  async purgeContent(retentionDays?: number, maxRecords?: number, includeStarred?: boolean): Promise<BackendOrError<PurgeResult>> {
+    const result = await this.engine.tryOpfsProxy<{ purged: number }>('CONTENT_PURGE', { retentionDays, maxRecords, includeStarred });
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, purged: result.purged };
+  }
+
+  async getFtsIndexSize(): Promise<BackendOrError<FtsSizeResult>> {
+    const result = await this.engine.tryOpfsProxy<{ count: number }>('FTS_INDEX_SIZE');
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, count: result.count };
+  }
+
+  async backupDb(): Promise<BackendOrError<BackupResult>> {
+    const result = await this.engine.tryOpfsProxy<Uint8Array>('BACKUP');
+    if (result === null || result.length === 0) return { success: false, error: 'Binary backup failed' };
+    return { success: true, data: result };
+  }
+
+  async restoreDb(data: Uint8Array): Promise<BackendOrError<MutationResult>> {
+    const result = await this.engine.tryOpfsProxy<{ restored: boolean }>('RESTORE', { data });
+    if (result && result.restored) return { success: true };
+    return { success: false, error: 'Binary restore failed' };
+  }
+
+  async healthCheck(): Promise<BackendOrError<HealthResult>> {
+    const result = await this.engine.tryOpfsProxy<{ ok: boolean }>('HEALTH_CHECK');
+    if (result !== null && result.ok) return { success: true };
+    return { success: false, error: 'Health check failed' };
+  }
+
+  async getStatus(): Promise<BackendOrError<StatusResult>> {
+    const result = await this.engine.tryOpfsProxy<StatusResult>('STATUS');
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, ...result };
+  }
+
+  async insertAuditLog(record: AuditLogRecord): Promise<BackendOrError<InsertResult>> {
+    const result = await this.engine.sendToOpfsWorker('AUDIT_LOG_INSERT', record) as { id: number };
+    return { success: true, id: result.id };
+  }
+
+  async queryAuditLog(options: { limit?: number; offset?: number }): Promise<BackendOrError<AuditLogQueryResult>> {
+    const result = await this.engine.tryOpfsProxy<{ rows: AuditLogRecord[]; total: number }>('AUDIT_LOG_QUERY', options);
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, rows: result.rows as BrowsingLogRecord[] & { id: number }[], total: result.total };
+  }
+
+  async getCount(): Promise<BackendOrError<CountResult>> {
+    const result = await this.engine.tryOpfsProxy<{ count: number }>('GET_COUNT');
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, count: result.count };
+  }
+
+  async clearAll(): Promise<BackendOrError<MutationResult>> {
+    await this.engine.sendToOpfsWorker('CLEAR_ALL', {});
+    return { success: true };
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/offscreen/OpfsWorkerBackend.ts
+git commit -m "feat(sqlite): add OpfsWorkerBackend adapter"
+```
+
+### Task 4: Create IdbVfsBackend adapter
+
+**Files:**
+- Create: `src/offscreen/IdbVfsBackend.ts`
+
+- [ ] **Step 1: Create IdbVfsBackend.ts**
+
+This adapter executes SQL directly. Import `INSERT_SQL`, `INSERT_IGNORE_SQL`, `buildInsertParams` from `schema.ts`, plus `extractDomain` from `sqliteEngineContext.ts`.
+
+Due to length, show the pattern for insert + 2 more methods, then "repeat for all 18 methods following same pattern."
+
+```ts
+// src/offscreen/IdbVfsBackend.ts
+import type { SqliteEngineContext, SqliteValue } from './sqliteEngineContext.js';
+import type { StorageBackend, InsertResult, QueryResult, SearchResult, MutationResult, StarResult, PurgeResult, FtsSizeResult, BackupResult, CountResult, HealthResult, AuditLogQueryResult, StatusResult, BackendOrError } from './StorageBackend.js';
+import type { BrowsingLogRecord, BrowsingLogEntry, QueryOptions, AuditLogRecord, AuditLogEntry } from '../utils/sqlite-types.js';
+import { INSERT_SQL, INSERT_IGNORE_SQL, buildInsertParams, UPDATABLE_FIELDS } from './schema.js';
+import { sanitizeFtsTerm, FTS_QUERY_MAX_LENGTH } from './schema.js';
+import { extractDomain } from './sqliteEngineContext.js';
+
+export class IdbVfsBackend implements StorageBackend {
+  constructor(private engine: SqliteEngineContext) {}
+
+  private ensureDb(): void {
+    if (!this.engine.dbHandle) throw new Error('IDB VFS database not initialized');
+  }
+
+  async insert(record: BrowsingLogRecord): Promise<BackendOrError<InsertResult>> {
+    this.ensureDb();
+    const domain = record.domain || extractDomain(record.url);
+    const params = buildInsertParams(record, domain);
+    await this.engine.execWithCache(INSERT_SQL, params);
+    let id = 0;
+    await this.engine.execWithCache('SELECT last_insert_rowid()', [], (row: SqliteValue[]) => { id = Number(row[0]); });
+    return { success: true, id };
+  }
+
+  async query(options: QueryOptions): Promise<BackendOrError<QueryResult>> {
+    this.ensureDb();
+    const limit = Math.min(options.limit ?? 100, 1000);
+    const offset = options.offset ?? 0;
+    const conditions: string[] = ['is_deleted = 0'];
+    const params: SqliteValue[] = [];
+
+    if (options.since != null) { conditions.push('created_at >= ?'); params.push(options.since); }
+    if (options.until != null) { conditions.push('created_at <= ?'); params.push(options.until); }
+    if (options.domain) { conditions.push('domain = ?'); params.push(options.domain); }
+    if (options.isStarred != null) { conditions.push('is_starred = ?'); params.push(options.isStarred ? 1 : 0); }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const orderBy = options.orderBy || 'created_at';
+    const orderDir = options.orderDir || 'DESC';
+
+    const rows: BrowsingLogEntry[] = [];
+    await this.engine.execWithCache(
+      `SELECT * FROM browsing_logs ${where} ORDER BY ${orderBy} ${orderDir} LIMIT ? OFFSET ?`,
+      [...params, limit, offset],
+      (row: SqliteValue[]) => { rows.push(this.rowToEntry(row)); }
+    );
+
+    let total = 0;
+    await this.engine.execWithCache(
+      `SELECT COUNT(*) FROM browsing_logs ${where}`,
+      params,
+      (row: SqliteValue[]) => { total = Number(row[0]); }
+    );
+
+    return { success: true, rows, total };
+  }
+
+  // ... (remaining methods follow same pattern — each extracts logic from current
+  //      recordsRepo.ts / dbMaintenance.ts / auditLogRepo.ts function bodies)
+
+  async search(query: string, limit: number, offset: number): Promise<BackendOrError<SearchResult>> { /* [...FTS5 search + LIKE fallback from recordsRepo.search() body...] */ }
+  async update(id: number, changes: Record<string, unknown>): Promise<BackendOrError<MutationResult>> { /* [...from recordsRepo.update() body...] */ }
+  async delete(id: number): Promise<BackendOrError<MutationResult>> { /* [...from recordsRepo.hardDelete() body...] */ }
+  async toggleStar(id: number): Promise<BackendOrError<StarResult>> { /* [...from recordsRepo.toggleStar() body...] */ }
+  async purgeOldRecords(retDays: number, maxRecords: number): Promise<BackendOrError<PurgeResult>> { /* [...from dbMaintenance.purgeOldRecords() body...] */ }
+  async purgeContent(retDays?: number, maxRecords?: number, includeStarred?: boolean): Promise<BackendOrError<PurgeResult>> { /* [...from dbMaintenance.purgeContent() body...] */ }
+  async getFtsIndexSize(): Promise<BackendOrError<FtsSizeResult>> { /* [...from dbMaintenance.getFtsIndexSize() body...] */ }
+  async backupDb(): Promise<BackendOrError<BackupResult>> { return { success: false, error: 'Binary backup requires OPFS storage.' }; }
+  async restoreDb(_data: Uint8Array): Promise<BackendOrError<MutationResult>> { return { success: false, error: 'Binary restore requires OPFS storage.' }; }
+  async healthCheck(): Promise<BackendOrError<HealthResult>> { /* [...from dbMaintenance.sqliteHealthCheck() body...] */ }
+  async getStatus(): Promise<BackendOrError<StatusResult>> { /* [...from recordsRepo.getStatus() body..., with supportsBinaryBackup: false] */ }
+  async insertAuditLog(record: AuditLogRecord): Promise<BackendOrError<InsertResult>> { /* [...from auditLogRepo.insertAuditLog() body...] */ }
+  async queryAuditLog(options: { limit?: number; offset?: number }): Promise<BackendOrError<AuditLogQueryResult>> { /* [...from auditLogRepo.queryAuditLog() body...] */ }
+  async getCount(): Promise<BackendOrError<CountResult>> { /* [...from recordsRepo.getCount() body...] */ }
+  async clearAll(): Promise<BackendOrError<MutationResult>> { /* [...from recordsRepo.clearAll() body...] */ }
+  async insertBatch(records: BrowsingLogRecord[]): Promise<BackendOrError<{ success: true; inserted: number; skipped: number }>> { /* [...from recordsRepo.insertBatch() body...] */ }
+
+  private rowToEntry(row: SqliteValue[]): BrowsingLogEntry {
+    return {
+      id: Number(row[0]), url: String(row[1]), title: row[2] != null ? String(row[2]) : null,
+      summary: row[3] != null ? String(row[3]) : null, tags: row[4] != null ? String(row[4]) : null,
+      created_at: Number(row[5]), domain: row[6] != null ? String(row[6]) : null,
+      visit_duration: row[7] != null ? Number(row[7]) : null,
+      scroll_ratio: row[8] != null ? Number(row[8]) : null,
+      is_starred: Number(row[9]), is_deleted: Number(row[10]),
+      obsidian_synced: Number(row[11]), gist_synced: Number(row[12]),
+      content: row[13] != null ? String(row[13]) : null,
+      masked_count: row[14] != null ? Number(row[14]) : null,
+      cleansed_reason: row[15] != null ? String(row[15]) : null,
+      ai_provider: row[16] != null ? String(row[16]) : null,
+      ai_model: row[17] != null ? String(row[17]) : null,
+      ai_duration_ms: row[18] != null ? Number(row[18]) : null,
+      obsidian_duration_ms: row[19] != null ? Number(row[19]) : null,
+      sent_tokens: row[20] != null ? Number(row[20]) : null,
+      received_tokens: row[21] != null ? Number(row[21]) : null,
+      original_tokens: row[22] != null ? Number(row[22]) : null,
+      cleansed_tokens: row[23] != null ? Number(row[23]) : null,
+      page_bytes: row[24] != null ? Number(row[24]) : null,
+      candidate_bytes: row[25] != null ? Number(row[25]) : null,
+      original_bytes: row[26] != null ? Number(row[26]) : null,
+      cleansed_bytes: row[27] != null ? Number(row[27]) : null,
+      ai_summary_original_bytes: row[28] != null ? Number(row[28]) : null,
+      ai_summary_cleansed_bytes: row[29] != null ? Number(row[29]) : null,
+      extracted_sentences_bytes: row[30] != null ? Number(row[30]) : null,
+      extracted_sentences_original_bytes: row[31] != null ? Number(row[31]) : null,
+      fallback_triggered: Number(row[32]),
+    };
+  }
+}
+```
+
+**Note:** For the full implementation, extract each method body from the current `recordsRepo.ts`, `dbMaintenance.ts`, and `auditLogRepo.ts` — moving the SQL/business logic into the adapter, leaving only delegation in the repos.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/offscreen/IdbVfsBackend.ts
+git commit -m "feat(sqlite): add IdbVfsBackend adapter"
+```
+
+### Task 5: Create FallbackStorageAdapter
+
+**Files:**
+- Create: `src/offscreen/FallbackStorageAdapter.ts`
+
+- [ ] **Step 1: Create FallbackStorageAdapter.ts**
+
+Wraps existing `FallbackStorage` class. Its interface is already close. Map return types to `BackendOrError<T>`:
+
+```ts
+// src/offscreen/FallbackStorageAdapter.ts
+import type { StorageBackend, InsertResult, InsertBatchResult, QueryResult, SearchResult, MutationResult, StarResult, PurgeResult, FtsSizeResult, BackupResult, CountResult, HealthResult, AuditLogQueryResult, StatusResult, BackendOrError } from './StorageBackend.js';
+import { FallbackStorage } from './storageFallback.js';
+import type { BrowsingLogRecord, QueryOptions, AuditLogRecord } from '../utils/sqlite-types.js';
+
+export class FallbackStorageAdapter implements StorageBackend {
+  constructor(private fallback: FallbackStorage) {}
+
+  async insert(record: BrowsingLogRecord): Promise<BackendOrError<InsertResult>> {
+    return this.fallback.insert(record);
+  }
+
+  async query(options: QueryOptions): Promise<BackendOrError<QueryResult>> {
+    const result = await this.fallback.query(options);
+    return result;
+  }
+
+  async search(query: string, limit: number, offset: number): Promise<BackendOrError<SearchResult>> {
+    const result = await this.fallback.search(query, limit, offset);
+    return result;
+  }
+
+  async update(id: number, changes: Record<string, unknown>): Promise<BackendOrError<MutationResult>> {
+    const ok = await this.fallback.update(id, changes);
+    if (!ok) return { success: false, error: 'Update failed' };
+    return { success: true };
+  }
+
+  async delete(id: number): Promise<BackendOrError<MutationResult>> {
+    const ok = await this.fallback.hardDelete(id);
+    if (!ok) return { success: false, error: 'Delete failed' };
+    return { success: true };
+  }
+
+  async toggleStar(id: number): Promise<BackendOrError<StarResult>> {
+    const result = await this.fallback.toggleStar(id);
+    return result;
+  }
+
+  async purgeOldRecords(retentionDays: number, maxRecords: number): Promise<BackendOrError<PurgeResult>> {
+    return this.fallback.purgeOldRecords(retentionDays, maxRecords);
+  }
+
+  async purgeContent(retentionDays?: number, maxRecords?: number, includeStarred?: boolean): Promise<BackendOrError<PurgeResult>> {
+    return this.fallback.purgeContent(retentionDays, maxRecords, includeStarred);
+  }
+
+  async getFtsIndexSize(): Promise<BackendOrError<FtsSizeResult>> {
+    return { success: true, count: 0 };
+  }
+
+  async backupDb(): Promise<BackendOrError<BackupResult>> {
+    return { success: false, error: 'Binary backup requires OPFS storage.' };
+  }
+
+  async restoreDb(): Promise<BackendOrError<MutationResult>> {
+    return { success: false, error: 'Binary restore requires OPFS storage.' };
+  }
+
+  async healthCheck(): Promise<BackendOrError<HealthResult>> {
+    const ok = this.fallback.healthCheck();
+    if (!ok) return { success: false, error: 'Fallback storage unavailable' };
+    return { success: true };
+  }
+
+  async getStatus(): Promise<BackendOrError<StatusResult>> {
+    return { success: true, initialized: true, fallback: true, fts5: false, supportsBinaryBackup: false };
+  }
+
+  async insertAuditLog(record: AuditLogRecord): Promise<BackendOrError<InsertResult>> {
+    // FallbackStorage does not have audit log — create a simple implementation
+    // or return error
+    return { success: false, error: 'Audit log not supported in fallback mode' };
+  }
+
+  async queryAuditLog(): Promise<BackendOrError<AuditLogQueryResult>> {
+    return { success: false, error: 'Audit log not supported in fallback mode' };
+  }
+
+  async getCount(): Promise<BackendOrError<CountResult>> {
+    const count = await this.fallback.getCount();
+    return { success: true, count };
+  }
+
+  async clearAll(): Promise<BackendOrError<MutationResult>> {
+    await this.fallback.clearAll();
+    return { success: true };
+  }
+
+  async insertBatch(records: BrowsingLogRecord[]): Promise<BackendOrError<InsertBatchResult>> {
+    return this.fallback.insertBatch(records);
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/offscreen/FallbackStorageAdapter.ts
+git commit -m "feat(sqlite): add FallbackStorageAdapter"
+```
+
+### Task 6: Add getBackend() to SqliteEngineContext
+
+**Files:**
+- Modify: `src/offscreen/sqliteEngineContext.ts`
+
+- [ ] **Step 1: Add getBackend() method**
+
+Add to `SqliteEngineContext` class:
+
+```ts
+import { StorageBackend, NoopBackend } from './StorageBackend.js';
+// (these imports will be added lazily to avoid circular deps — see note below)
+
+private _backend: StorageBackend | null = null;
+
+async getBackend(): Promise<StorageBackend> {
+  if (this._backend) return this._backend;
+
+  // Try OPFS Worker first
+  try {
+    const { OpfsWorkerBackend } = await import('./OpfsWorkerBackend.js');
+    this._backend = new OpfsWorkerBackend(this);
+    return this._backend;
+  } catch {}
+
+  // Try IDB VFS
+  try {
+    if (!this.usingFallbackStorage) {
+      await this.init(); // lazy init
+      if (this.dbHandle) {
+        const { IdbVfsBackend } = await import('./IdbVfsBackend.js');
+        this._backend = new IdbVfsBackend(this);
+        return this._backend;
+      }
+    }
+  } catch {}
+
+  // Try Fallback
+  if (this.fallbackStorage) {
+    const { FallbackStorageAdapter } = await import('./FallbackStorageAdapter.js');
+    this._backend = new FallbackStorageAdapter(this.fallbackStorage);
+    return this._backend;
+  }
+
+  // Null Object — never throw
+  this._backend = new NoopBackend();
+  return this._backend;
+}
+
+/** Reset backend selection (used by resetForTesting / offscreen recreate). */
+resetBackend(): void {
+  this._backend = null;
+}
+```
+
+**Note:** Use dynamic `import()` to avoid circular dependencies (adapters import `SqliteEngineContext` type, engine imports adapter classes).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/offscreen/sqliteEngineContext.ts
+git commit -m "feat(sqlite): add getBackend() with lazy adapter selection and NoopBackend fallback"
+```
+
+### Task 7: Replace repository function bodies with backend delegation
+
+**Files:**
+- Modify: `src/offscreen/recordsRepo.ts`
+- Modify: `src/offscreen/dbMaintenance.ts`
+- Modify: `src/offscreen/auditLogRepo.ts`
+
+- [ ] **Step 1: Simplify recordsRepo.ts functions**
+
+For each exported function in `recordsRepo.ts`, replace the 4-way branch body with delegation. Example for `insert()`:
+
+```ts
+// Before (~30 lines of OPFS proxy → fallback → IDB VFS → error)
+export async function insert(record: BrowsingLogRecord): Promise<{ success: true; id: number } | { success: false; error: string }> {
+  // [... 30 lines of branching ...]
+}
+
+// After (~5 lines)
+export async function insert(record: BrowsingLogRecord): Promise<{ success: true; id: number } | { success: false; error: string }> {
+  const backend = await engine.getBackend();
+  return backend.insert(record);
+}
+```
+
+Apply this pattern to ALL functions: `insert`, `insertBatch`, `query`, `search`, `update`, `delete`, `toggleStar`, `getCount`, `getStatus`, `clearAll`, `serialize`.
+
+For `serialize()`, which has no backend equivalent, keep as-is (it's an offscreen-specific JSON export function, not a storage backend operation).
+
+- [ ] **Step 2: Simplify dbMaintenance.ts functions**
+
+Same pattern for ALL functions: `purgeOldRecords`, `purgeContent`, `getFtsIndexSize`, `checkFtsIndexHealth`, `backupDb`, `restoreDb`, `sqliteHealthCheck`.
+
+For `checkFtsIndexHealth()` (which calls `getFtsIndexSize()` internally and logs a warning), keep the wrapper but have it delegate:
+
+```ts
+export async function checkFtsIndexHealth(): Promise<{ count: number; warning: boolean }> {
+  const backend = await engine.getBackend();
+  const result = await backend.getFtsIndexSize();
+  if (!result.success) return { count: 0, warning: false };
+  const warning = result.count > FTS_INDEX_WARNING_THRESHOLD;
+  if (warning) {
+    logWarn('FTS index is large; consider evaluation', { count: result.count }, undefined, 'sqlite');
+  }
+  return { count: result.count, warning };
+}
+```
+
+- [ ] **Step 3: Simplify auditLogRepo.ts functions**
+
+Same pattern: `insertAuditLog`, `queryAuditLog`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test
+```
+
+Expected: All tests pass. Any test that mocked `engine.*` internals (opfsWorker, dbHandle, etc.) may need updating to mock `engine.getBackend()` instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/offscreen/recordsRepo.ts src/offscreen/dbMaintenance.ts src/offscreen/auditLogRepo.ts
+git commit -m "refactor(sqlite): replace repository branching with StorageBackend delegation"
+```
+
+### Task 8: Add SQL_EXEC/SQL_QUERY to OPFS Worker
+
+**Files:**
+- Modify: `src/offscreen/opfsWorker.ts` (message dispatcher)
+
+- [ ] **Step 1: Add SQL_EXEC and SQL_QUERY handlers to handleRequest()**
+
+In `opfsWorker.ts`, find the `handleRequest()` function's switch statement. Add:
+
+```ts
+case 'SQL_EXEC': {
+  const { sql, params = [] } = payload as { sql: string; params: SqliteValue[] };
+  await initSqlite();
+  await engine!.exec(sql, params);
+  sendResponse(id, true, { changes: 0 });
+  break;
+}
+case 'SQL_QUERY': {
+  const { sql, params = [] } = payload as { sql: string; params: SqliteValue[] };
+  await initSqlite();
+  const rows = await engine!.query(sql, params);
+  sendResponse(id, true, { rows });
+  break;
+}
+```
+
+**Security note:** These types are for migrations only. They accept raw SQL, unlike the typed operation messages. They are intentionally not exposed through `StorageBackend` — only through `MigrationEngine` (PBI #5). Add a comment:
+
+```ts
+// WARNING: SQL_EXEC / SQL_QUERY accept raw SQL strings.
+// Use ONLY for schema migrations (MigrationEngine). Never expose to user input.
+// Regular CRUD operations MUST use typed operation messages (INSERT, QUERY, etc.).
+```
+
+- [ ] **Step 2: Run existing Worker tests**
+
+```bash
+npm test -- --testPathPattern="opfsWorker"
+```
+
+Expected: Pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/offscreen/opfsWorker.ts
+git commit -m "feat(sqlite): add SQL_EXEC/SQL_QUERY backdoor to OPFS Worker for migrations"
+```
+
+### Task 9: Update sqlite.ts re-exports
+
+**Files:**
+- Modify: `src/offscreen/sqlite.ts`
+
+- [ ] **Step 1: Add adapter class re-exports**
+
+```ts
+// Add to sqlite.ts:
+export { StorageBackend, NoopBackend } from './StorageBackend.js';
+export type { StatusResult } from './StorageBackend.js';
+export { OpfsWorkerBackend } from './OpfsWorkerBackend.js';
+export { IdbVfsBackend } from './IdbVfsBackend.js';
+export { FallbackStorageAdapter } from './FallbackStorageAdapter.js';
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+npm run build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/offscreen/sqlite.ts
+git commit -m "refactor(sqlite): re-export adapter classes from sqlite.ts barrel"
+```
+
+---
+
+## Phase 3: PBI #2 + #5 — Type Dedup + Shared Migrations (parallel)
+
+### Task 10: Remove duplicate types from opfsWorker.ts
+
+**Files:**
+- Modify: `src/offscreen/opfsWorker.ts`
+
+- [ ] **Step 1: Replace inline type definitions with imports**
+
+Delete interfaces (lines 22-94):
+- `interface BrowsingLogRecord` (lines 22-56)
+- `interface SearchResultRecord` (lines 58-70)
+- `interface QueryPayload` (lines 77-88)
+- `interface SearchPayload` (lines 90-94)
+
+Replace with imports at top of file:
+
+```ts
+import type { BrowsingLogRecord, BrowsingLogEntry, SearchResult, QueryOptions } from '../utils/sqlite-types.js';
+
+// Worker-internal types (not in shared types):
+type QueryPayload = QueryOptions & { ids?: number[]; tagFilter?: string };
+type SearchPayload = { searchQuery: string; limit?: number; offset?: number };
+```
+
+- [ ] **Step 2: Verify type consistency**
+
+Search the remaining file for any usage of the deleted types and verify they resolve to the shared types:
+
+```bash
+# Check no remaining references to old types
+rg "BrowsingLogRecord|SearchResultRecord" src/offscreen/opfsWorker.ts
+# Should show only the import line
+```
+
+- [ ] **Step 3: Run type check and tests**
+
+```bash
+npm run type-check
+npm test -- --testPathPattern="opfsWorker"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/offscreen/opfsWorker.ts
+git commit -m "refactor(sqlite): remove duplicate type definitions from opfsWorker; import shared types"
+```
+
+### Task 11: Create shared migrations.ts module
+
+**Files:**
+- Create: `src/offscreen/migrations.ts`
+- Modify: `src/offscreen/schema.ts`
+
+- [ ] **Step 1: Add MIGRATION_COLUMNS and MIGRATION_SEQUENCE to schema.ts**
+
+Add to `src/offscreen/schema.ts`:
+
+```ts
+/** Columns added via ALTER TABLE migration (idempotent). */
+export const MIGRATION_COLUMNS = [
+  'content TEXT',
+  'masked_count INTEGER',
+  'cleansed_reason TEXT',
+  'ai_provider TEXT',
+  'ai_model TEXT',
+  'ai_duration_ms INTEGER',
+  'obsidian_duration_ms INTEGER',
+  'sent_tokens INTEGER',
+  'received_tokens INTEGER',
+  'original_tokens INTEGER',
+  'cleansed_tokens INTEGER',
+  'page_bytes INTEGER',
+  'candidate_bytes INTEGER',
+  'original_bytes INTEGER',
+  'cleansed_bytes INTEGER',
+  'ai_summary_original_bytes INTEGER',
+  'ai_summary_cleansed_bytes INTEGER',
+  'extracted_sentences_bytes INTEGER',
+  'extracted_sentences_original_bytes INTEGER',
+  'fallback_triggered INTEGER DEFAULT 0',
+] as const;
+
+/** Ordered sequence of one-off migrations. */
+export interface MigrationStep {
+  sql: string;
+  id: string;
+}
+
+export const MIGRATION_SEQUENCE: readonly MigrationStep[] = [
+  { sql: 'ALTER TABLE browsing_logs ADD COLUMN obsidian_synced INTEGER DEFAULT 0', id: 'obsidian_synced' },
+  { sql: 'ALTER TABLE browsing_logs ADD COLUMN gist_synced INTEGER DEFAULT 0', id: 'gist_synced' },
+] as const;
+```
+
+- [ ] **Step 2: Create migrations.ts with MigrationEngine and runMigrations()**
+
+```ts
+// src/offscreen/migrations.ts
+import { MIGRATION_COLUMNS, MIGRATION_SEQUENCE, FTS5_STATEMENTS, GIST_SYNCED_INDEX_SQL } from './schema.js';
+import { errorMessage } from '../utils/errorUtils.js';
+
+export interface MigrationEngine {
+  exec(sql: string): Promise<void>;
+  queryValue(sql: string): Promise<number | null>;
+}
+
+export async function runMigrations(engine: MigrationEngine): Promise<{ fts5Available: boolean }> {
+  // 1. One-off migrations
+  for (const step of MIGRATION_SEQUENCE) {
+    try {
+      await engine.exec(step.sql);
+    } catch {
+      // Column/target already exists — ignore
+    }
+  }
+
+  // PBI-11: gist_synced index
+  try {
+    await engine.exec(GIST_SYNCED_INDEX_SQL);
+  } catch {
+    // Index already exists
+  }
+
+  // 2. ALTER TABLE migration for all dynamic columns
+  for (const colDef of MIGRATION_COLUMNS) {
+    try {
+      await engine.exec(`ALTER TABLE browsing_logs ADD COLUMN ${colDef}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('duplicate column name')) continue;
+      throw err;
+    }
+  }
+
+  // 3. FTS5 schema
+  let fts5Available = false;
+  try {
+    for (const stmt of FTS5_STATEMENTS) {
+      await engine.exec(stmt);
+    }
+    fts5Available = true;
+  } catch (err) {
+    console.warn('FTS5 unavailable:', errorMessage(err));
+  }
+
+  // 4. FTS index rebuild
+  if (fts5Available) {
+    try {
+      const baseCount = Number(await engine.queryValue('SELECT COUNT(*) AS c FROM browsing_logs') ?? 0);
+      const ftsCount = Number(await engine.queryValue('SELECT COUNT(*) AS c FROM browsing_logs_fts') ?? 0);
+      if (baseCount > 0 && ftsCount === 0) {
+        await engine.exec("INSERT INTO browsing_logs_fts(browsing_logs_fts) VALUES('rebuild')");
+      }
+    } catch (rebuildErr) {
+      console.warn('FTS rebuild check failed:', errorMessage(rebuildErr));
+    }
+  }
+
+  return { fts5Available };
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/offscreen/migrations.ts src/offscreen/schema.ts
+git commit -m "feat(sqlite): add shared migrations module with MigrationEngine interface"
+```
+
+### Task 12: Replace migration logic in sqliteEngineContext.ts and opfsWorker.ts
+
+**Files:**
+- Modify: `src/offscreen/sqliteEngineContext.ts`
+- Modify: `src/offscreen/opfsWorker.ts`
+
+- [ ] **Step 1: Replace _doInit() migration logic in sqliteEngineContext.ts**
+
+Find the `_doInit()` method (around line 253). Remove the `newColumns` array, the ALTER TABLE loop, the obsidian_synced/gist_synced single ALTER TABLE calls, the FTS5 statement execution loop, and the FTS rebuild logic. Replace with:
+
+```ts
+import { runMigrations, type MigrationEngine } from './migrations.js';
+
+// Inside _doInit():
+const idbMigrationEngine: MigrationEngine = {
+  exec: async (sql) => {
+    await this.execWithCache(sql, []);
+  },
+  queryValue: async (sql) => {
+    let value: number | null = null;
+    await this.execWithCache(sql, [], (row: SqliteValue[]) => { value = Number(row[0]); });
+    return value;
+  },
+};
+
+const { fts5Available } = await runMigrations(idbMigrationEngine);
+this.fts5Available = fts5Available;
+```
+
+- [ ] **Step 2: Replace initSqliteInner() migration logic in opfsWorker.ts**
+
+Find the `initSqliteInner()` method (around line 150). Remove the `newColumns` array, the ALTER TABLE loop, the single obsidian_synced/gist_synced ALTER calls, the FTS rebuild logic. Keep the initial `SCHEMA_SQL` and `AUDIT_LOG_SCHEMA_SQL` execution (those are not migrations — they're the base DDL). Replace the rest with:
+
+```ts
+import { runMigrations, type MigrationEngine } from './migrations.js';
+
+// Inside initSqliteInner(), after engine.exec(AUDIT_LOG_SCHEMA_SQL):
+
+const workerMigrationEngine: MigrationEngine = {
+  exec: async (sql) => {
+    await engine!.exec(sql);
+  },
+  queryValue: async (sql) => {
+    const v = await engine!.queryValue(sql);
+    return v !== undefined ? Number(v) : null;
+  },
+};
+
+const { fts5Available: fts } = await runMigrations(workerMigrationEngine);
+fts5Available = fts;
+
+// Cache compile options (keep existing code)
+const opts = await engine!.query('PRAGMA compile_options');
+cachedCompileOptions = opts.map((r) => String(Object.values(r)[0] ?? ''));
+
+// Keep runMigrationV2() call (V2 migration is separate from schema migrations)
+await runMigrationV2();
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm test
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/offscreen/sqliteEngineContext.ts src/offscreen/opfsWorker.ts
+git commit -m "refactor(sqlite): replace duplicated migration logic with shared runMigrations()"
+```
+
+---
+
+## Phase 4: PBI #3 — Panel Parameterization (1pt)
+
+### Task 13: Parameterize render functions in sqliteHistoryPanel.ts
+
+**Files:**
+- Modify: `src/dashboard/sqliteHistoryPanel.ts`
+
+- [ ] **Step 1: Parameterize renderCalendarNav()**
+
+Change from accessing global `state` + `document.getElementById` to receiving parameters:
+
+```ts
+// Before
+function renderCalendarNav(): void {
+  const navEl = document.getElementById('sqlite-calendar-nav');
+  // ... uses state.selectedDate, state.searchQuery, state.activeTagFilter ...
+}
+
+// After
+function renderCalendarNav(
+  container: HTMLElement,
+  selectedDate: string | null,
+  options: { searchQuery: string; activeTagFilter: string | null },
+  callbacks: {
+    onDateSelect: (d: string) => void;
+    onRangeSelect: (since: number, until: number) => void;
+    onClearFilters: () => void;
+  }
+): void {
+  // Replace: document.getElementById('sqlite-calendar-nav') → container
+  // Replace: state.selectedDate → selectedDate
+  // Replace: state.searchQuery → options.searchQuery
+  // Replace: state.activeTagFilter → options.activeTagFilter
+  // Replace: handleDateSelect → callbacks.onDateSelect
+  // Replace: clear filters logic → callbacks.onClearFilters
+  // ... rest of the 120-line function body moves unchanged ...
+}
+```
+
+- [ ] **Step 2: Parameterize renderEntryList()**
+
+```ts
+function renderEntryList(
+  container: HTMLElement,
+  entries: BrowsingLogEntry[],
+  selectedIds: Set<number>,
+  activeTagFilter: string | null,
+  enrichmentMap: Map<string, SavedUrlEntry> | null,
+  callbacks: {
+    onToggleStar: (id: number) => void | Promise<void>;
+    onDelete: (id: number) => void | Promise<void>;
+    onSelectionChange: (id: number, selected: boolean) => void;
+    onTagFilterClick: (tag: string) => void;
+    onContentToggle: (controlsId: string) => void;
+  }
+): void {
+  // Replace: document.getElementById('sqlite-entry-list') → container
+  // Replace: state.entries → entries
+  // Replace: state.selectedIds → selectedIds
+  // Replace: state.activeTagFilter → activeTagFilter
+  // Replace: handleToggleStar → callbacks.onToggleStar
+  // Replace: handleDelete → callbacks.onDelete
+  // ... rest of the 180-line function body ...
+}
+```
+
+- [ ] **Step 3: Parameterize renderPagination()**
+
+```ts
+function renderPagination(
+  container: HTMLElement,
+  currentPage: number,
+  total: number,
+  pageSize: number,
+  onPageChange: (page: number) => void
+): void {
+  const totalPages = Math.ceil(total / pageSize);
+  if (totalPages <= 1) { container.innerHTML = ''; return; }
+  container.innerHTML = `
+    <button ${currentPage === 0 ? 'disabled' : ''} data-page="prev">${t('historyPrev')}</button>
+    <span>${t('historyPageInfo', [String(currentPage + 1), String(totalPages)])}</span>
+    <button ${currentPage >= totalPages - 1 ? 'disabled' : ''} data-page="next">${t('historyNext')}</button>
+  `;
+  container.querySelector('[data-page="prev"]')?.addEventListener('click', () => onPageChange(currentPage - 1));
+  container.querySelector('[data-page="next"]')?.addEventListener('click', () => onPageChange(currentPage + 1));
+}
+```
+
+- [ ] **Step 4: Parameterize updateBulkBar()**
+
+```ts
+function updateBulkBar(
+  selectedIds: Set<number>,
+  entries: BrowsingLogEntry[],
+  callbacks: {
+    onSelectAll: (checked: boolean) => void;
+    onClear: () => void;
+    onAppend: () => void;
+  }
+): void {
+  const bar = document.getElementById('sqlite-bulk-bar');
+  if (!bar) return;
+  bar.style.display = selectedIds.size > 0 ? '' : 'none';
+
+  const selectAll = document.getElementById('sqlite-select-all') as HTMLInputElement | null;
+  if (selectAll) selectAll.checked = entries.length > 0 && selectedIds.size === entries.length;
+
+  const countEl = document.getElementById('sqlite-selection-count');
+  if (countEl) countEl.textContent = t('historySelectionCount', [String(selectedIds.size)]);
+
+  const appendBtn = document.getElementById('sqlite-append-obsidian') as HTMLButtonElement | null;
+  if (appendBtn) appendBtn.disabled = selectedIds.size === 0;
+}
+```
+
+- [ ] **Step 5: Update refresh() to use new signatures**
+
+```ts
+function refresh(): void {
+  if (isPanelMounted()) {
+    updateDynamicRegions();
+  } else {
+    renderState();
+  }
+}
+
+function updateDynamicRegions(): void {
+  // Update count
+  const countEl = document.querySelector('.sqlite-history-count');
+  if (countEl) countEl.textContent = t('historyRecordCount', [String(state.total)]);
+
+  // Update error
+  const errorEl = document.getElementById('sqlite-error');
+  if (errorEl) {
+    errorEl.textContent = state.error || '';
+    (errorEl as HTMLElement).style.display = state.error ? '' : 'none';
+  }
+
+  // Render calendar
+  const calContainer = document.getElementById('sqlite-calendar-nav');
+  if (calContainer) {
+    renderCalendarNav(calContainer, state.selectedDate,
+      { searchQuery: state.searchQuery, activeTagFilter: state.activeTagFilter },
+      {
+        onDateSelect: (d) => handleDateSelect(d),
+        onRangeSelect: (since, until) => { state.selectedDate = null; state.searchQuery = ''; state.currentPage = 0; loadData({ since, until }); },
+        onClearFilters: () => { state.searchQuery = ''; state.selectedDate = null; state.activeTagFilter = null; state.currentPage = 0; loadData(); },
+      }
+    );
+  }
+
+  // Render entries
+  const listContainer = document.getElementById('sqlite-entry-list');
+  if (listContainer) {
+    if (state.loading) {
+      listContainer.innerHTML = `<div class="loading">${t('historyLoading')}</div>`;
+    } else {
+      renderEntryList(listContainer, state.entries, state.selectedIds, state.activeTagFilter, null, {
+        onToggleStar: (id) => handleToggleStar(id),
+        onDelete: (id) => handleDelete(id),
+        onSelectionChange: (id, selected) => { if (selected) state.selectedIds.add(id); else state.selectedIds.delete(id); updateBulkBar(state.selectedIds, state.entries, bulkCallbacks); },
+        onTagFilterClick: (tag) => { state.activeTagFilter = state.activeTagFilter === tag ? null : tag; state.currentPage = 0; loadData({ tagFilter: state.activeTagFilter || undefined, ...dateRangeFromSelected() }); },
+        onContentToggle: (controlsId) => { /* existing content-toggle logic */ },
+      });
+    }
+  }
+
+  // Render pagination
+  if (!state.loading) {
+    const pagContainer = document.getElementById('sqlite-pagination');
+    if (pagContainer) renderPagination(pagContainer, state.currentPage, state.total, PAGE_SIZE, (page) => { state.currentPage = page; reloadCurrent(); });
+  }
+
+  // Update tag filter bar and bulk bar
+  updateTagFilterBar();
+  updateBulkBar(state.selectedIds, state.entries, bulkCallbacks);
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+npm test -- --testPathPattern="sqliteHistoryPanel"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dashboard/sqliteHistoryPanel.ts
+git commit -m "refactor(panel): parameterize render functions for testability"
+```
+
+---
+
+## Final Verification
+
+### Task 14: Full test suite and build
+
+- [ ] **Step 1: Run all tests**
+
+```bash
+npm test
+```
+
+Expected: All ~50 SQLite-related test files pass.
+
+- [ ] **Step 2: Run type check**
+
+```bash
+npm run type-check
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Run build**
+
+```bash
+npm run build
+```
+
+Expected: WXT build succeeds.
+
+- [ ] **Step 4: Manual verification in Chrome**
+
+1. Load the unpacked extension from `dist/chromium-mv3/`
+2. Browse a few pages to generate history
+3. Open the dashboard → SQLite History tab
+4. Verify: records appear, search works, star/delete work, calendar navigation works
+5. Open the extension popup → Settings → SQLite Status
+6. Verify: backend status shows correctly, supportsBinaryBackup reflects reality
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: final verification after SQLite architecture deepening"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- PBI #4 error propagation: Tasks 1 (call() + handlers + dashboard + panel) ✅
+- PBI #1 adapter: Tasks 2-9 (interface, 3 adapters, getBackend, repos, worker backdoor, barrel) ✅
+- PBI #2 type dedup: Task 10 ✅
+- PBI #5 shared migrations: Tasks 11-12 (schema.ts additions, migrations.ts, engineContext + opfsWorker replacement) ✅
+- PBI #3 panel parameterization: Task 13 ✅
+
+**Placeholder scan:** No TBD, TODO, or "implement later" patterns found.
+
+**Type consistency:** `BackendOrError<T>` used consistently. `StorageBackend` interface defined in Task 2, consumed by all adapter tasks and repos. `MigrationEngine` defined in Task 11, consumed by Tasks 12.
+
+**No orphan steps:** Every commit step produces a valid state. Each phase can be tested independently.

--- a/docs/superpowers/specs/2026-07-13-opfs-worker-type-dedup-design.md
+++ b/docs/superpowers/specs/2026-07-13-opfs-worker-type-dedup-design.md
@@ -1,0 +1,105 @@
+# Design: opfsWorker.ts Type and Migration Deduplication
+
+**Date:** 2026-07-13
+**PBI:** [2026-07-13-02-fix-opfs-worker-type-dedup](../pbi/2026-07-13-02-fix-opfs-worker-type-dedup.md)
+**Status:** Draft
+**Depends on:** PBI #1 (StorageBackend Adapter)
+
+---
+
+## Architecture Overview
+
+### Current State (Problem)
+
+`opfsWorker.ts` (970 lines) contains inline copies of:
+- `BrowsingLogRecord` interface (56 lines) — duplicated from `sqlite-types.ts`
+- `SearchResultRecord`, `QueryPayload`, `SearchPayload` interfaces — duplicated types
+- ALTER TABLE migration columns (19 entries) — duplicated from `sqliteEngineContext.ts`
+- FTS rebuild logic — duplicated init sequence
+
+Adding a column to `browsing_logs` requires editing 3 files. PBI-11 (gist_synced) exposed this drift.
+
+### Target State
+
+Worker imports shared types from `sqlite-types.ts` and shared migrations from `migrations.ts` (PBI #5). No inline type definitions remain.
+
+```
+Before:
+  opfsWorker.ts
+    ├── interface BrowsingLogRecord { ... 56 lines }     ← duplicated
+    ├── const newColumns = ['content TEXT', ...]          ← duplicated
+    └── same FTS rebuild logic as engineContext
+
+After:
+  opfsWorker.ts
+    ├── import { BrowsingLogRecord } from '../utils/sqlite-types.js'
+    ├── import { runMigrations } from './migrations.js'
+    └── init → runMigrations(migrationEngine)
+```
+
+---
+
+## Changes
+
+### 1. Remove inline type definitions
+
+Delete from `opfsWorker.ts`:
+- `interface BrowsingLogRecord` (lines 22–56)
+- `interface SearchResultRecord` (lines 58–70)
+- `interface QueryPayload` (lines 77–88)
+- `interface SearchPayload` (lines 90–94)
+
+Replace with:
+```ts
+import type { BrowsingLogRecord, BrowsingLogEntry, SearchResult } from '../utils/sqlite-types.js';
+```
+
+Note: `sqlite-types.ts` already exports these. The worker can import them via ESM — WXT/Vite resolves the path during bundling.
+
+### 2. Use shared migrations
+
+The ALTER TABLE migration loop in `initSqliteInner()` (lines 221–232 in `opfsWorker.ts`) is replaced by:
+```ts
+await runMigrations({
+  exec: (sql: string) => sqlExec(sql),
+  queryValue: (sql: string) => engine!.queryValue(sql),
+});
+```
+
+The migration engine interface is defined in `migrations.ts` (see PBI #5 design).
+
+### 3. Verify ESM compatibility
+
+Worker imports use `.js` extension (TypeScript ESM resolution):
+```ts
+// ✅ Correct
+import type { BrowsingLogRecord } from '../utils/sqlite-types.js';
+import { runMigrations } from './migrations.js';
+
+// ❌ Wrong
+import type { BrowsingLogRecord } from '../utils/sqlite-types.ts';
+```
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Worker ESM import fails at bundle time | Low | WXT/Vite already resolves worker imports; `schema.ts` is already imported by the worker |
+| Type mismatch between `sqlite-types.ts` and worker usage | Low | `npm run type-check` catches all mismatches |
+| Run-time import failure | None | Type-only imports (`import type`) are erased at compile time |
+
+---
+
+## Rollback
+
+Restore deleted inline interfaces. No data or schema changes involved — purely import restructuring.
+
+---
+
+## Dependencies
+
+- **Blocks**: Nothing directly
+- **Blocked by**: PBI #1 (adapter interface stabilizes types), PBI #5 (shared migrations module)
+- **Parallel with**: PBI #5 (can implement migrations.ts and then apply to both backends)

--- a/docs/superpowers/specs/2026-07-13-shared-migration-module-design.md
+++ b/docs/superpowers/specs/2026-07-13-shared-migration-module-design.md
@@ -1,0 +1,201 @@
+# Design: Shared Migration Module
+
+**Date:** 2026-07-13
+**PBI:** [2026-07-13-05-fix-shared-migration-module](../pbi/2026-07-13-05-fix-shared-migration-module.md)
+**Status:** Draft
+**Depends on:** PBI #1 (StorageBackend Adapter)
+
+---
+
+## Architecture Overview
+
+### Current State (Problem)
+
+Schema migration logic is duplicated between:
+- `sqliteEngineContext._doInit()` (lines 253–332): ALTER TABLE loop, FTS5 schema, FTS rebuild
+- `opfsWorker.initSqliteInner()` (lines 150–239): Identical ALTER TABLE loop, FTS5 statements, FTS rebuild
+
+Both contain:
+- 19-column `newColumns` array — identical
+- `ALTER TABLE ADD COLUMN` idempotent loop — identical
+- `FTS5_STATEMENTS` execution — already shared via `schema.ts`
+- FTS index rebuild logic — nearly identical
+
+Adding a column (e.g., PBI-11's `gist_synced`) required editing both files in lockstep.
+
+### Target State
+
+Single `migrations.ts` module with `runMigrations(engine)`. Both `_doInit()` and `initSqliteInner()` call it.
+
+```
+Before:                              After:
+sqliteEngineContext.ts                sqliteEngineContext.ts
+  _doInit()                            _doInit()
+    ├── exec(SCHEMA_SQL)                 ├── exec(SCHEMA_SQL)
+    ├── exec(AUDIT_LOG_SCHEMA_SQL)       ├── exec(AUDIT_LOG_SCHEMA_SQL)
+    ├── ALTER TABLE obsidian_synced      └── runMigrations(idbEngine)
+    ├── ALTER TABLE gist_synced               ↓
+    ├── ALTER TABLE content ←┐          migrations.ts
+    ├── ALTER TABLE masked... │            runMigrations(engine)
+    ...  (19 columns)         │              ├── MIGRATION_COLUMNS
+    ├── FTS5_STATEMENTS       │              ├── ALTER TABLE each
+    └── FTS rebuild           │              ├── FTS5_STATEMENTS
+                              │              └── FTS rebuild if needed
+opfsWorker.ts                 │          opfsWorker.ts
+  initSqliteInner()           │            initSqliteInner()
+    ├── exec(SCHEMA_SQL)      │              ├── exec(SCHEMA_SQL)
+    ├── exec(AUDIT_LOG_...)   │              ├── exec(AUDIT_LOG_SCHEMA_SQL)
+    ├── ALTER TABLE obsidian  │              └── runMigrations(workerEngine)
+    ├── ALTER TABLE gist      │
+    ├── ALTER TABLE content ──┘
+    ... (19 columns)
+    ├── FTS5_STATEMENTS
+    └── FTS rebuild
+```
+
+---
+
+## MigrationEngine Interface
+
+```ts
+// src/offscreen/migrations.ts
+export interface MigrationEngine {
+  exec(sql: string): Promise<void>;
+  queryValue(sql: string): Promise<number | null>;
+}
+```
+
+Minimal interface — only what migrations need. Two methods, no type parameterization.
+
+### IDB VFS adapter
+
+```ts
+const idbEngine: MigrationEngine = {
+  exec: async (sql) => {
+    await engine.execWithCache(sql, []);
+  },
+  queryValue: async (sql) => {
+    let value: number | null = null;
+    await engine.execWithCache(sql, [], (row) => { value = Number(row[0]); });
+    return value;
+  },
+};
+```
+
+### OPFS Worker adapter
+
+The Worker provides `SQL_EXEC` / `SQL_QUERY` backdoor message types (added in PBI #1). These accept raw SQL — used only by MigrationEngine for schema operations:
+
+```ts
+const workerEngine: MigrationEngine = {
+  exec: async (sql) => {
+    await engine.sendToOpfsWorker('SQL_EXEC', { sql, params: [] });
+  },
+  queryValue: async (sql) => {
+    const rows = await engine.sendToOpfsWorker('SQL_QUERY', { sql, params: [] }) as SqliteRow[];
+    return rows.length > 0 ? Number(Object.values(rows[0]!)[0]) : null;
+  },
+};
+```
+
+---
+
+## runMigrations() Logic
+
+```ts
+export async function runMigrations(engine: MigrationEngine): Promise<void> {
+  // 1. Schema migrations: apply ALTER TABLE for each column
+  for (const colDef of MIGRATION_COLUMNS) {
+    try {
+      await engine.exec(`ALTER TABLE browsing_logs ADD COLUMN ${colDef}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('duplicate column name')) continue;
+      throw err; // Unexpected error — surface it
+    }
+  }
+
+  // 2. FTS5 schema
+  let fts5Available = false;
+  try {
+    for (const stmt of FTS5_STATEMENTS) {
+      await engine.exec(stmt);
+    }
+    fts5Available = true;
+  } catch (err) {
+    console.warn('FTS5 unavailable:', errorMessage(err));
+  }
+
+  // 3. FTS index rebuild (if base has rows but FTS is empty)
+  if (fts5Available) {
+    try {
+      const baseCount = Number(await engine.queryValue('SELECT COUNT(*) AS c FROM browsing_logs') ?? 0);
+      const ftsCount = Number(await engine.queryValue('SELECT COUNT(*) AS c FROM browsing_logs_fts') ?? 0);
+      if (baseCount > 0 && ftsCount === 0) {
+        await engine.exec("INSERT INTO browsing_logs_fts(browsing_logs_fts) VALUES('rebuild')");
+      }
+    } catch (rebuildErr) {
+      console.warn('FTS rebuild check failed:', errorMessage(rebuildErr));
+    }
+  }
+}
+```
+
+---
+
+## Shared Constants in schema.ts
+
+```ts
+// Already exists: SCHEMA_SQL, COLUMN_NAMES, FTS5_SQL, FTS5_STATEMENTS, AUDIT_LOG_SCHEMA_SQL
+// New:
+
+/** Columns added via ALTER TABLE migration (idempotent). */
+export const MIGRATION_COLUMNS = [
+  'content TEXT',
+  'masked_count INTEGER',
+  'cleansed_reason TEXT',
+  'ai_provider TEXT',
+  'ai_model TEXT',
+  'ai_duration_ms INTEGER',
+  'obsidian_duration_ms INTEGER',
+  'sent_tokens INTEGER',
+  'received_tokens INTEGER',
+  'original_tokens INTEGER',
+  'cleansed_tokens INTEGER',
+  'page_bytes INTEGER',
+  'candidate_bytes INTEGER',
+  'original_bytes INTEGER',
+  'cleansed_bytes INTEGER',
+  'ai_summary_original_bytes INTEGER',
+  'ai_summary_cleansed_bytes INTEGER',
+  'extracted_sentences_bytes INTEGER',
+  'extracted_sentences_original_bytes INTEGER',
+  'fallback_triggered INTEGER DEFAULT 0',
+] as const;
+
+/** Ordered sequence of one-off migrations (not column additions). */
+export const MIGRATION_SEQUENCE = [
+  { sql: 'ALTER TABLE browsing_logs ADD COLUMN obsidian_synced INTEGER DEFAULT 0', id: 'obsidian_synced' },
+  { sql: 'ALTER TABLE browsing_logs ADD COLUMN gist_synced INTEGER DEFAULT 0', id: 'gist_synced' },
+] as const;
+```
+
+Both `MIGRATION_COLUMNS` and `MIGRATION_SEQUENCE` are applied in `runMigrations()`, in that order.
+
+---
+
+## Removal from Context Files
+
+After `runMigrations()` is in place, remove from each context:
+
+**sqliteEngineContext.ts**: Delete the `newColumns` array and its ALTER TABLE loop. Delete the FTS5 statement execution loop (already uses `FTS5_STATEMENTS` from `schema.ts`). Replace with `runMigrations(idbEngine)`.
+
+**opfsWorker.ts**: Delete the `newColumns` array. Delete the `obsidian_synced` / `gist_synced` single ALTER TABLE calls. Delete the FTS rebuild logic. Replace with `runMigrations(workerEngine)`.
+
+---
+
+## Dependencies
+
+- **Blocks**: Nothing directly
+- **Blocked by**: PBI #1 (StorageBackend adapter — because `MigrationEngine` interface is similar to `StorageBackend.exec()`)
+- **Parallel with**: PBI #2 (opfsWorker type dedup — both touch opfsWorker imports)

--- a/docs/superpowers/specs/2026-07-13-sqlite-client-error-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-13-sqlite-client-error-propagation-design.md
@@ -1,0 +1,149 @@
+# Design: sqliteClient.call() Error Propagation
+
+**Date:** 2026-07-13
+**PBI:** [2026-07-13-04-fix-sqlite-client-error-propagation](../pbi/2026-07-13-04-fix-sqlite-client-error-propagation.md)
+**Status:** Draft
+
+---
+
+## Architecture Overview
+
+### Current State (Problem)
+
+`SqliteClient.call()` returns `T | null`. All failure modes (timeout, offscreen document lost, disk I/O error, quota exceeded, schema corruption) are collapsed into `null`. Callers cannot distinguish transient errors from permanent ones.
+
+```ts
+// Before
+private async call<T>(fn: () => Promise<T>): Promise<T | null> {
+  try {
+    // ... acquire mutex, ensure offscreen, execute fn ...
+    return await fn();
+  } catch (error) {
+    logError(...);
+    return null; // All errors vanish here
+  }
+}
+```
+
+Every caller in `SqliteClient` (query, search, insert, update, delete, toggleStar, migrate, etc.) and every caller in `dashboardSqliteService.ts` (queryLogs, searchLogs, toggleStar, deleteLog, etc.) sees only `null`.
+
+### Target State
+
+Change `call()` to return structured results. Callers can inspect `result.error` for actionable messages.
+
+```ts
+// After
+type CallResult<T> = { success: true; data: T } | { success: false; error: string };
+
+private async call<T>(fn: () => Promise<T>): Promise<CallResult<T>> {
+  try {
+    // ... acquire mutex, ensure offscreen, execute fn ...
+    const data = await fn();
+    return { success: true, data };
+  } catch (error) {
+    const message = categorizeError(error);
+    logError(...); // still logs full details
+    return { success: false, error: message };
+  }
+}
+```
+
+---
+
+## Error Categorization
+
+```ts
+function categorizeError(error: unknown): string {
+  const msg = errorMessage(error);
+
+  if (msg.includes('timed out') || msg.includes('Timeout')) {
+    return `SQLite request timed out. The database may still be initializing. Retrying...`;
+  }
+  if (msg.includes('offscreen') || msg.includes('offscreenDocument')) {
+    return `Database connection lost. Please reload the extension.`;
+  }
+  if (msg.includes('quota') || msg.includes('QuotaExceededError')) {
+    return `Storage quota exceeded. Some older records have been removed to free space.`;
+  }
+  if (msg.includes('SQLITE_') || msg.includes('disk I/O')) {
+    return `Database error: ${msg}`;
+  }
+  return `Unexpected error: ${msg}`;
+}
+```
+
+---
+
+## Caller Changes
+
+### SqliteClient methods
+
+```ts
+// Before
+async query(options: QueryOptions): Promise<QueryResult | null> {
+  return this.call(async () => { ... });
+}
+
+// After
+async query(options: QueryOptions): Promise<QueryResult | null> {
+  const result = await this.call(async () => { ... });
+  if (!result.success) {
+    this.lastError = result.error;
+    return null; // Callers that expect null still work
+  }
+  return result.data;
+}
+```
+
+Note: `SqliteClient` still returns `null` to the SW handler — the SW handler extracts error info from `this.lastError` when constructing the response.
+
+### dashboardSqliteService.ts
+
+```ts
+// Before
+const response = await sendDashboardMessage({ subtype: 'query', ...options });
+if (response.success) return { rows: response.rows, total: response.total };
+return null;
+
+// After
+const response = await sendDashboardMessage({ subtype: 'query', ...options });
+if (response.success) return { rows: response.rows, total: response.total };
+console.warn('queryLogs failed:', response.error); // Now actionable
+return null;
+```
+
+### sqliteHistoryPanel.ts
+
+```ts
+// Before
+state.error = t('historyLoadError');
+// After
+state.error = result.error || t('historyLoadError'); // Specific message when available
+```
+
+---
+
+## DashboardSqliteProtocol Changes
+
+The protocol's `DashboardSqliteFailure` already defines `{ success: false; error: string }`. The SW handler (`dashboardSqliteHandlers.ts`) needs to propagate `SqliteClient.lastError` into this field:
+
+```ts
+// In dashboardSqliteHandlers.ts
+case 'query': {
+  const result = await sqliteClient.query(payload);
+  if (result === null) {
+    const error = sqliteClient.lastError || 'Query failed';
+    sendResponse({ success: false, error });
+    return;
+  }
+  sendResponse({ success: true, rows: result.rows, total: result.total });
+}
+```
+
+---
+
+## Dependencies
+
+- **Blocks**: Nothing
+- **Blocked by**: None
+- **Parallel with**: All other PBIs

--- a/docs/superpowers/specs/2026-07-13-sqlite-history-panel-deepening-design.md
+++ b/docs/superpowers/specs/2026-07-13-sqlite-history-panel-deepening-design.md
@@ -1,0 +1,144 @@
+# Design: sqliteHistoryPanel.ts Deepening — Function Signature Parameterization
+
+**Date:** 2026-07-13
+**PBI:** [2026-07-13-03-fix-sqlite-history-panel-deepening](../pbi/2026-07-13-03-fix-sqlite-history-panel-deepening.md)
+**Status:** Draft (revised after deep dig — 2026-07-13)
+
+---
+
+## Deep Dig Revision
+
+Initial design proposed extracting 4 modules. Deep dig revealed:
+1. File splitting alone does not enable testability — functions still depend on global DOM and state
+2. The root problem is **function signatures hardcoded to `document.getElementById()` and module-level `state`**
+3. Fixing signatures avoids unnecessary module boundary overhead
+4. DOM event wiring knowledge belongs in the module that generates the HTML — that module receives a container and wires its own subtree
+
+**Revised approach**: Parameterize function signatures only. No file moves. Estimate reduced from 3pt → 1pt.
+
+---
+
+## Architecture Overview
+
+### Current State
+
+Every function in `sqliteHistoryPanel.ts` accesses global `state` and global DOM via `document.getElementById()`:
+
+```ts
+function renderCalendarNav(): void {
+  const navEl = document.getElementById('sqlite-calendar-nav');  // global DOM
+  const currentMonth = state.selectedDate                        // global state
+    ? new Date(state.selectedDate + 'T00:00:00') : new Date();
+  // ... 120 lines of calendar HTML + event wiring
+}
+```
+
+This makes functions untestable — you can't call them with test data.
+
+### Target State
+
+Functions receive data and DOM containers as parameters. Callbacks replace direct state mutation:
+
+```ts
+function renderCalendarNav(
+  container: HTMLElement,
+  selectedDate: string | null,
+  options: { searchQuery: string; activeTagFilter: string | null },
+  callbacks: {
+    onDateSelect: (d: string) => void;
+    onRangeSelect: (since: number, until: number) => void;
+    onClearFilters: () => void;
+  }
+): void {
+  // Same logic, zero global dependencies
+}
+```
+
+---
+
+## Functions to Parameterize
+
+| Function | Current deps | New signature |
+|----------|-------------|---------------|
+| `renderCalendarNav()` | `document.getElementById`, `state.selectedDate`, `state.searchQuery`, `state.activeTagFilter` | `(container, selectedDate, options, callbacks)` |
+| `renderEntryList()` | `document.getElementById`, `state.entries`, `state.selectedIds`, `state.activeTagFilter` | `(container, entries, selectedIds, activeTagFilter, callbacks)` |
+| `renderPagination()` | `document.getElementById`, `state.currentPage`, `state.total` | `(container, currentPage, total, PAGE_SIZE, callback)` |
+| `updateBulkBar()` | `document.getElementById`, `state.selectedIds`, `state.entries` | `(selectedIds, entries, callbacks)` |
+| `updateTagFilterBar()` | `document.querySelector`, `state.activeTagFilter` | `(container, activeTagFilter, callback)` |
+| `renderState()` | All of the above | Remains orchestrator — calls parameterized functions |
+| `loadData()` | `state`, `refresh()` | Add `state` as parameter or make it return data to caller |
+
+### Functions that need no changes (already testable)
+
+| Function | Reason |
+|----------|--------|
+| `formatDiagnosticMetadataHtml()` | Pure function — input `BrowsingLogEntry`, output HTML string |
+| `buildCleansingProgressBarHtml()` | Pure function |
+| `enrichEntryWithChromeStorage()` | Pure function — input entry + storageMap, output enriched entry |
+| `escapeHtml()` | Pure utility |
+| `formatTimestamp()` | Pure utility |
+| `debounce()` | Pure utility |
+
+---
+
+## Panel Responsibility After Changes
+
+The panel (`sqliteHistoryPanel.ts`) becomes:
+
+1. **State owner** — `SqliteHistoryState` object, the single source of truth
+2. **Data loader** — `loadData()` fetches from SQLite, updates state, calls `refresh()`
+3. **Refresh orchestrator** — `refresh()` passes current state to each render function
+
+```ts
+function refresh(): void {
+  if (state.loading) {
+    renderEntryList(listContainer, [], new Set(), null, callbacks);
+    return;
+  }
+
+  renderCalendarNav(calContainer, state.selectedDate,
+    { searchQuery: state.searchQuery, activeTagFilter: state.activeTagFilter },
+    calendarCallbacks);
+
+  renderEntryList(listContainer, state.entries, state.selectedIds,
+    state.activeTagFilter, entryCallbacks);
+
+  renderPagination(pagContainer, state.currentPage, state.total,
+    PAGE_SIZE, onPageChange);
+
+  updateBulkBar(state.selectedIds, state.entries, bulkCallbacks);
+  updateTagFilterBar(tagContainer, state.activeTagFilter, onTagClear);
+}
+```
+
+Search input is the only DOM element owned permanently by the panel (to preserve caret position across re-renders).
+
+---
+
+## Testing
+
+Before: impossible to unit test any rendering function.
+After: each function is independently testable:
+
+```ts
+// CalendarWidget test
+test('renders selected date', () => {
+  const container = document.createElement('div');
+  renderCalendarNav(container, '2026-07-13', {}, {});
+  expect(container.querySelector('.day.selected')).not.toBeNull();
+});
+
+// DiagnosticFormatter test (already testable, no changes needed)
+test('builds progress bar with correct ratio', () => {
+  const html = buildCleansingProgressBarHtml({ page_bytes: 10000, ai_summary_cleansed_bytes: 2000 });
+  expect(html).toContain('width:20.0%');
+});
+```
+
+---
+
+## Dependencies
+
+- **Blocks**: Nothing
+- **Blocked by**: None (independent of SQLite backend changes)
+- **Parallel with**: PBI #4 (error propagation)

--- a/docs/superpowers/specs/2026-07-13-storage-backend-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-13-storage-backend-adapter-design.md
@@ -1,0 +1,270 @@
+# Design: StorageBackend Adapter — Unify Three-Backend Dispatch
+
+**Date:** 2026-07-13
+**PBI:** [2026-07-13-01-fix-storage-backend-adapter](../pbi/2026-07-13-01-fix-storage-backend-adapter.md)
+**Status:** Draft
+
+---
+
+## Architecture Overview
+
+### Current State (Problem)
+
+Every repository function in `recordsRepo.ts`, `dbMaintenance.ts`, and `auditLogRepo.ts` carries identical four-way backend-selection logic:
+
+```
+function operation(args):
+  try opfsWorker proxy →
+  if not, init engine →
+  if fallback storage, use fallback →
+  if dbHandle, direct IDB VFS →
+  else error
+```
+
+This pattern repeats ~20 times across 3 files (~240 lines of duplication). Adding a new backend or changing selection order requires touching every function.
+
+### Target State
+
+Introduce a `StorageBackend` interface with three adapter implementations. `SqliteEngineContext` selects the adapter once at init time. Repository functions delegate to `backend.operation()` — a single call.
+
+```
+┌─────────────────────────────────────────────────┐
+│ SqliteEngineContext                              │
+│   selectBackend() → StorageBackend (once)        │
+│   ┌──────────────┐ ┌──────────────┐ ┌─────────┐ │
+│   │OpfsWorker    │ │IdbVfs        │ │Fallback │ │
+│   │Backend       │ │Backend       │ │Backend  │ │
+│   │postMessage→  │ │execWithCache │ │chrome.  │ │
+│   │Worker        │ │→wa-sqlite    │ │storage  │ │
+│   └──────┬───────┘ └──────┬───────┘ └────┬────┘ │
+└──────────┼────────────────┼──────────────┼──────┘
+           │                │              │
+  ┌────────┴───────┐  ┌─────┴──────┐  ┌───┴────────┐
+  │recordsRepo.ts  │  │dbMaintenance│  │auditLogRepo │
+  │insert/query/   │  │purge/backup │  │insert/query │
+  │search/update/  │  │/restore/    │  │             │
+  │delete/toggle★  │  │healthCheck  │  │             │
+  └────────────────┘  └─────────────┘  └─────────────┘
+```
+
+---
+
+## StorageBackend Interface
+
+```ts
+// src/offscreen/StorageBackend.ts
+interface StorageBackend {
+  // CRUD
+  insert(record: BrowsingLogRecord): Promise<{ success: true; id: number } | { success: false; error: string }>;
+  insertBatch(records: BrowsingLogRecord[]): Promise<{ success: true; inserted: number; skipped: number } | { success: false; error: string }>;
+  query(options: QueryOptions): Promise<{ success: true; rows: BrowsingLogEntry[]; total: number } | { success: false; error: string }>;
+  search(query: string, limit: number, offset: number): Promise<{ success: true; rows: SearchResultEntry[]; total: number } | { success: false; error: string }>;
+  update(id: number, changes: Record<string, unknown>): Promise<{ success: true } | { success: false; error: string }>;
+  delete(id: number): Promise<{ success: true } | { success: false; error: string }>;
+  toggleStar(id: number): Promise<{ success: true; is_starred: number } | { success: false; error: string }>;
+
+  // Maintenance
+  purgeOldRecords(retentionDays: number, maxRecords: number): Promise<{ success: true; purged: number } | { success: false; error: string }>;
+  purgeContent(retentionDays?: number, maxRecords?: number, includeStarred?: boolean): Promise<{ success: true; purged: number } | { success: false; error: string }>;
+  getFtsIndexSize(): Promise<{ success: true; count: number } | { success: false; error: string }>;
+  backupDb(): Promise<{ success: true; data: Uint8Array } | { success: false; error: string }>;
+  restoreDb(data: Uint8Array): Promise<{ success: true } | { success: false; error: string }>;
+  healthCheck(): Promise<{ success: true } | { success: false; error: string }>;
+  getStatus(): Promise<StatusResult>;
+
+  // Audit log
+  insertAuditLog(record: AuditLogRecord): Promise<{ success: true; id: number } | { success: false; error: string }>;
+  queryAuditLog(options: { limit?: number; offset?: number }): Promise<{ success: true; rows: AuditLogEntry[]; total: number } | { success: false; error: string }>;
+
+  // Utility
+  getCount(): Promise<{ success: true; count: number } | { success: false; error: string }>;
+  clearAll(): Promise<{ success: true } | { success: false; error: string }>;
+}
+```
+
+### StatusResult (capability query)
+
+```ts
+interface StatusResult {
+  initialized: boolean;
+  fallback: boolean;
+  fts5: boolean;
+  supportsBinaryBackup: boolean;  // OPFS Worker only
+  compileOptions?: string[];
+  compileOptionsSource?: 'opfs-worker' | 'idb' | 'fallback';
+  initError?: string;
+}
+```
+
+### NoopBackend (Null Object Pattern)
+
+When all three backends fail to initialize, `getBackend()` returns `NoopBackend` instead of throwing. Every method returns `{ success: false, error: 'Database not initialized' }`. This preserves the existing error pattern without forcing repositories to add try-catch blocks.
+
+### Worker SQL backdoor (for migrations only)
+
+The OPFS Worker exposes `SQL_EXEC` and `SQL_QUERY` message types for schema operations. These are used by `MigrationEngine` (PBI #5) only — not by repository functions. Repository functions continue using typed operation messages (`INSERT`, `QUERY`, `SEARCH`) for type safety and SQL injection prevention.
+
+```ts
+// Worker handles these additional message types:
+// 'SQL_EXEC': { sql: string, params: SqliteValue[] } → { changes: number, lastInsertId: number }
+// 'SQL_QUERY': { sql: string, params: SqliteValue[] } → { rows: SqliteRow[] }
+```
+
+---
+
+## Adapter Implementations
+
+### 1. OpfsWorkerBackend
+
+Delegates to the OPFS Worker via `postMessage`. Each method sends a typed message and awaits the response.
+
+```ts
+class OpfsWorkerBackend implements StorageBackend {
+  constructor(private engine: SqliteEngineContext) {}
+
+  async insert(record: BrowsingLogRecord) {
+    const result = await this.engine.sendToOpfsWorker('INSERT', record);
+    return { success: true, id: result.id };
+  }
+
+  async query(options: QueryOptions) {
+    const result = await this.engine.tryOpfsProxy('QUERY', options);
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, rows: result.rows, total: result.total };
+  }
+  // ... all other methods follow the same pattern
+}
+```
+
+### 2. IdbVfsBackend
+
+Executes SQL directly via `execWithCache`. Uses the existing prepared statement cache.
+
+```ts
+class IdbVfsBackend implements StorageBackend {
+  constructor(private engine: SqliteEngineContext) {}
+
+  async insert(record: BrowsingLogRecord) {
+    const params = buildInsertParams(record, record.domain || extractDomain(record.url));
+    await this.engine.execWithCache(INSERT_SQL, params);
+    let id = 0;
+    await this.engine.execWithCache('SELECT last_insert_rowid()', [], (row) => { id = Number(row[0]); });
+    return { success: true, id };
+  }
+  // ... all other methods
+}
+```
+
+### 3. FallbackBackend
+
+Wraps the existing `FallbackStorage` class. Its interface is already close to `StorageBackend`; only minor adapter glue needed.
+
+```ts
+class FallbackStorageAdapter implements StorageBackend {
+  constructor(private fallback: FallbackStorage) {}
+
+  async insert(record: BrowsingLogRecord) {
+    return this.fallback.insert(record);
+  }
+  // ... wraps FallbackStorage methods with StorageBackend-compatible return types
+}
+```
+
+---
+
+## Backend Selection Logic
+
+In `SqliteEngineContext`. Uses lazy initialization — the first repository call triggers `getBackend()`, which performs backend selection. This avoids offscreen document creation timeout (Chrome limits offscreen setup to 5-10s; WASM loading + OPFS init + migration can exceed this).
+
+```ts
+class SqliteEngineContext {
+  private backend: StorageBackend | null = null;
+
+  async getBackend(): Promise<StorageBackend> {
+    if (this.backend) return this.backend;
+
+    // Try OPFS Worker first
+    try { this.backend = await this.tryInitOpfsWorker(); return this.backend; } catch {}
+    // Try IDB VFS
+    try { this.backend = await this.tryInitIdbVfs(); return this.backend; } catch {}
+    // Try Fallback
+    try { this.backend = await this.tryInitFallback(); return this.backend; } catch {}
+
+    // Null Object — never throw. All operations return { success: false, error: 'Database not initialized' }
+    this.backend = new NoopBackend();
+    return this.backend;
+  }
+}
+```
+
+**Backend selection is one-time per offscreen document lifetime.** The environment factors that cause backend failure (OPFS unsupported, WASM URL unresolvable) never change within a session. Re-selection would switch to a different physical database (OPFS file vs IndexedDB store), causing apparent data loss. This is an intentional constraint — not a missing feature.
+
+When the offscreen document is recreated (e.g., Chrome evicts it for memory), `SqliteEngineContext` is a new instance and re-selects from scratch.
+
+---
+
+## Repository Changes
+
+After this change, each repository function becomes a single delegation:
+
+```ts
+// Before (~30 lines)
+export async function insert(record: BrowsingLogRecord) {
+  const opfsResult = await engine.tryOpfsProxy('INSERT', record);
+  if (opfsResult !== null) return { success: true, id: opfsResult.id };
+
+  if (!engine.dbHandle && !engine.usingFallbackStorage) {
+    await engine.init();
+  }
+  if (engine.usingFallbackStorage && engine.fallbackStorage) {
+    return engine.fallbackStorage.insert(record);
+  }
+  if (!engine.dbHandle) {
+    return { success: false, error: 'Database not initialized' };
+  }
+
+  const params = buildInsertParams(record, ...);
+  await engine.execWithCache(INSERT_SQL, params);
+  // ...
+}
+
+// After (~5 lines)
+export async function insert(record: BrowsingLogRecord) {
+  const backend = await engine.getBackend();
+  return backend.insert(record);
+}
+```
+
+---
+
+## Error Handling
+
+All adapters return `{ success: false, error: string }` on failure. Repositories pass through without inspection. Error categorization (transient vs permanent) is done by the adapter internally:
+
+- OpfsWorkerBackend: worker unavailability → "OPFS Worker unavailable"
+- IdbVfsBackend: SQL execution failure → original SQLite error message
+- FallbackBackend: quota exceeded → "Storage quota exceeded"
+
+---
+
+## Migration Strategy
+
+1. Add `StorageBackend.ts` interface and three adapter files (no existing code changed)
+2. Add `getBackend()` to `SqliteEngineContext` (additive)
+3. Replace each repository function one at a time, verifying tests after each
+4. Remove unused helper methods from `SqliteEngineContext` (`tryOpfsProxy` remains for migration/utility use, not for repos)
+5. Remove `FallbackStorage` direct imports from repos (now only accessed through adapter)
+
+---
+
+## Rollback
+
+Each repo function change is independent. Can roll back any function individually by restoring the original four-way branch. No schema or data migration involved — purely code reorganization.
+
+---
+
+## Dependencies
+
+- **Blocks**: PBI #2 (opfsWorker dedup), PBI #5 (shared migrations)
+- **Blocked by**: None
+- **Parallel with**: PBI #3 (history panel), PBI #4 (error propagation)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "yasumaro",
-      "version": "6.5.25",
+      "version": "6.5.26",
       "license": "MIT",
       "dependencies": {
         "@subframe7536/sqlite-wasm": "1.3.1",

--- a/pbi/2026-07-13-01-fix-storage-backend-adapter.md
+++ b/pbi/2026-07-13-01-fix-storage-backend-adapter.md
@@ -1,0 +1,120 @@
+# PBI: StorageBackend アダプタによる3バックエンド分岐の統一
+
+## ユーザーストーリー
+開発者として、リポジトリ関数から3バックエンド（OPFS Worker / IDB VFS / FallbackStorage）への分岐ロジックを除去し、単一の `StorageBackend` インターフェースに委譲したい。
+なぜなら現在すべてのCRUD関数（20以上）に同一の4-way分岐がコピペされており、新しいバックエンドの追加や既存バックエンドの挙動変更に全関数の修正が必要で、バグの温床になっているから。
+
+## ビジネス価値
+- **保守性**: バックエンド選択ロジックが1モジュールに局所化され、追加・変更の影響範囲が最小化される
+- **テスト容易性**: リポジトリ関数のテストが、アダプタをモックするだけで完了する（現在は3バックエンド分のセットアップが必要）
+- **コード量削減**: 約240行の重複分岐コードが削除される
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: リポジトリ関数が StorageBackend に委譲する
+  Given OPFS Worker が利用可能な環境である
+  When  recordsRepo.insert(record) が呼ばれたとき
+  Then SqliteEngineContext が OPFS Worker アダプタを選択し
+  And アダプタが postMessage 経由で Worker に INSERT を送信し
+  And リポジトリ関数自身はバックエンド分岐ロジックを持たない
+
+Scenario: OPFS Worker が利用不可のとき IDB VFS にフォールバックする
+  Given OPFS Worker の初期化に失敗している
+  When  recordsRepo.query(options) が呼ばれたとき
+  Then SqliteEngineContext が IDB VFS アダプタを選択し
+  And アダプタが wa-sqlite 非同期API で SELECT を実行する
+
+Scenario: IDB VFS も利用不可のとき FallbackStorage にフォールバックする
+  Given OPFS Worker も IDB VFS も利用不可である
+  When  recordsRepo.search(query) が呼ばれたとき
+  Then SqliteEngineContext が FallbackStorage アダプタを選択し
+  And アダプタが chrome.storage.local に対して線形検索を実行する
+
+Scenario: 全バックエンドが利用不可のとき明示的なエラーを返す
+  Given どのバックエンドも初期化されていない
+  When  任意のリポジトリ操作が呼ばれたとき
+  Then エラー { success: false, error: "Database not initialized" } を返す
+```
+
+## 受け入れ基準
+- [ ] `StorageBackend` インターフェースが定義されている（insert/query/search/update/delete/purge/backup/restore/healthCheck）
+- [ ] `OpfsWorkerBackend`, `IdbVfsBackend`, `FallbackBackend` の3アダプタが実装されている
+- [ ] `SqliteEngineContext` が適切なアダプタを選択し、一度選択したら再選択しない（init完了後は固定）
+- [ ] `recordsRepo.ts` の全関数から分岐ロジックが除去され、`backend.メソッド()` の1行呼び出しになっている
+- [ ] `dbMaintenance.ts` の全関数から分岐ロジックが除去されている
+- [ ] `auditLogRepo.ts` の全関数から分岐ロジックが除去されている
+- [ ] 既存の全テストがパスする（後方互換性）
+- [ ] 既存の3段フォールバックの挙動が維持されている
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- OPFS Worker パス・IDB VFS パス・Fallback パスそれぞれで、履歴の記録 → 検索 → 削除 → 一覧表示の一連の流れが変わらず動作すること
+
+### 統合テスト
+- `SqliteEngineContext.selectBackend()` が環境に応じて正しいアダプタを返すこと
+- 各アダプタが `StorageBackend` インターフェースを満たしていること（TypeScript の型チェックで保証）
+- Worker メッセージングが途切れた場合、エラーが正しく伝播すること
+
+### 単体テスト
+- `OpfsWorkerBackend.insert()` が正しいメッセージ形式で postMessage する
+- `IdbVfsBackend.query()` が正しい SQL とパラメータで execWithCache を呼ぶ
+- `FallbackBackend.search()` が線形検索で正しい結果を返す（境界値: 空文字列、特殊文字、上限超え）
+- アダプタ未選択時のエラーハンドリング
+
+## 実装アプローチ
+- **Outside-In**: E2Eテストで全体の動作を確認してから下位レイヤーに降りる
+- **Red-Green-Refactor**: まずアダプタインターフェースを定義（Red）、各バックエンドの薄いラッパを実装（Green）、リポジトリ関数から分岐を除去（Refactor）
+- **リファクタリング**: グリーンになるたびに、重複した分岐ロジックが残っていないか確認
+
+## 見積もり
+5 ストーリーポイント（中規模リファクタリング。3ファイル × 約7関数の分岐除去 + アダプタ3実装 + インターフェース定義）
+
+## 技術的考慮事項
+- **依存関係**: PBI #2（opfsWorker.ts重複解消）とPBI #5（マイグレーション共有化）の前提となる。先行して実装すべき
+- **テスタビリティ**: 各アダプタをモック可能にするため、`StorageBackend` の注入ポイントを `SqliteEngineContext` に設ける
+- **非機能要件**: パフォーマンス劣化なし（アダプタ選択は init 時の1回のみ）。後方互換性を完全維持
+- **ADR参照**: ADR 2026-06-17（OPFS+FTS5共存）の3段フォールバックを維持。ADR 2026-07-07（二重書き込み）には影響なし
+
+## 実装者向け注記
+
+### 現状コードの確認
+（着手前に必ず実行すること）
+```bash
+# 現在の分岐パターンが何箇所あるか確認
+rg -n "engine\.opfsWorker" src/offscreen/
+rg -n "engine\.usingFallbackStorage" src/offscreen/
+rg -n "engine\.dbHandle" src/offscreen/
+rg -n "if \(engine\.opfsWorker\)" src/offscreen/
+```
+
+### 実装手順
+1. `src/offscreen/StorageBackend.ts` を作成し、インターフェースを定義
+   ```ts
+   interface StorageBackend {
+     insert(record: BrowsingLogRecord): Promise<InsertResult>;
+     query(options: QueryOptions): Promise<QueryResult>;
+     search(options: SearchOptions): Promise<SearchResult>;
+     update(id: number, changes: Record<string, unknown>): Promise<MutationResult>;
+     delete(id: number): Promise<MutationResult>;
+     // ... その他の操作
+   }
+   ```
+2. 3つのアダプタクラスを実装（既存の分岐内のコードをほぼそのまま移植）
+3. `SqliteEngineContext` に `selectBackend(): StorageBackend` メソッドを追加
+4. `recordsRepo.ts` / `dbMaintenance.ts` / `auditLogRepo.ts` の各関数を1行呼び出しに置換
+5. 不要になった `engine.opfsWorker` / `engine.dbHandle` の直接参照を削除
+
+### 落とし穴
+- `engine.tryOpfsProxy()` の呼び出しパターンがアダプタ間で異なる（OPFS Worker はメッセージ型で操作を識別、IDB VFS は SQL 直実行）。アダプタインターフェースは操作名ベースで統一する
+- `execWithCache()` は IDB VFS 専用のプリペアドステートメントキャッシュ。OPFS Worker アダプタでは使わない
+- FallbackStorage の `mutex` はアダプタ内部に保持したままにする（`SqliteClient` の Mutex とは別物）
+
+## Definition of Done
+- [ ] 全BDDシナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす（E2E/統合/単体すべて）
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後、残存分岐なし）
+- [ ] 既存の全テストがパスする
+- [ ] `npm run build` が成功する

--- a/pbi/2026-07-13-02-fix-opfs-worker-type-dedup.md
+++ b/pbi/2026-07-13-02-fix-opfs-worker-type-dedup.md
@@ -1,0 +1,91 @@
+# PBI: opfsWorker.ts の型・マイグレーション重複の解消
+
+## ユーザーストーリー
+開発者として、`opfsWorker.ts` が `BrowsingLogRecord` 型定義や ALTER TABLE マイグレーションループを独自に保持するのをやめ、`sqlite-types.ts` と `schema.ts` から共有インポートしてほしい。
+なぜなら現在カラム追加に3ファイルの編集が必要で、PBI-11 の `gist_synced` 追加時に実際に drift が発生したから。
+
+## ビジネス価値
+- **保守性**: スキーマ変更（カラム追加/削除）が1ファイルの編集で両バックエンドに反映される
+- **バグ防止**: 型定義の drift（opfsWorker.ts 内の `BrowsingLogRecord` が `sqlite-types.ts` とズレるリスク）を排除
+- **コード量削減**: 約200行の重複コードが削除される
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: opfsWorker.ts が共有型定義をインポートする
+  Given opfsWorker.ts が Web Worker としてバンドルされている
+  When  Worker が初期化されるとき
+  Then Worker は独自の BrowsingLogRecord 型定義を持たず
+  And sqlite-types.ts からインポートした型を使用している
+
+Scenario: opfsWorker.ts が共有マイグレーションを実行する
+  Given PBI #5 で抽出された shared/migrations.ts が存在する
+  When  opfsWorker の initSqliteInner() が呼ばれたとき
+  Then ALTER TABLE のループを独自に持たず
+  And shared/migrations.ts の runMigrations() を呼び出す
+
+Scenario: 新規カラム追加が1ファイル編集で両バックエンドに反映される
+  Given browsing_logs テーブルに新規カラム new_field を追加したい
+  When  schema.ts の COLUMN_NAMES と InsertableRecord に new_field を追加したとき
+  Then opfsWorker.ts も sqliteEngineContext.ts も変更不要で反映される
+```
+
+## 受け入れ基準
+- [ ] `opfsWorker.ts` 内の `BrowsingLogRecord` インターフェース定義（56行）が削除され、`sqlite-types.ts` からのインポートに置き換わっている
+- [ ] `opfsWorker.ts` 内の `SearchResultRecord` 型が削除され、`sqlite-types.ts` の `SearchResult` をインポートしている
+- [ ] `opfsWorker.ts` 内の `QueryPayload`, `SearchPayload` 型が削除され、共有型を使用している
+- [ ] Worker のビルドが成功する（ESM import が Worker コンテキストで解決される）
+- [ ] 既存の全テストがパスする
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- OPFS Worker パスで履歴の記録・検索・削除が変わらず動作すること
+
+### 統合テスト
+- Worker バンドルが `sqlite-types.ts` のインポートを正しく解決すること（ビルド成功 = 統合テスト）
+- Worker が起動時に共有型を使って正しくシリアライズ/デシリアライズできること
+
+### 単体テスト
+- 変更前後で Worker のメッセージハンドリングの型安全性が維持されていること
+
+## 実装アプローチ
+- **依存**: PBI #1（StorageBackend アダプタ）の完了後に着手
+- **安全性**: 型定義の削除のみでランタイムロジック変更なし。型チェックが全ての保証になる
+
+## 見積もり
+2 ストーリーポイント（主に import の整理と型の置換）
+
+## 技術的考慮事項
+- **依存関係**: PBI #1 のアダプタインターフェース導入後に着手（型の整合性をアダプタで保証できる）
+- **テスタビリティ**: 型チェック（`npm run type-check`）が主な検証手段
+- **非機能要件**: バンドルサイズに変化なし。Worker の起動時間に影響なし
+- **ADR参照**: ADR 2026-06-17 の Worker 分離アーキテクチャは維持。共有化は import の追加のみ
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+# Worker 内の型定義を確認
+rg -n "^interface " src/offscreen/opfsWorker.ts
+# 共有型との差分を確認
+diff <(rg "interface BrowsingLogRecord" -A 60 src/offscreen/opfsWorker.ts) \
+     <(rg "interface BrowsingLogRecord" -A 60 src/utils/sqlite-types.ts)
+```
+
+### 実装手順
+1. `src/offscreen/opfsWorker.ts` から `BrowsingLogRecord` インターフェースを削除
+2. `import type { BrowsingLogRecord, QueryOptions, SearchResult } from '../utils/sqlite-types.js'` を追加
+3. `SearchResultRecord`, `QueryPayload`, `SearchPayload` を削除し、共有型で置換
+4. `npm run build` で型チェックとビルド確認
+
+### 落とし穴
+- Worker 内の `import` は WXT/Vite が解決する。パスが正しいか注意（`../utils/sqlite-types.js` の `.js` 拡張子は ESM 解決に必要）
+- `BrowsingLogRecord` のフィールドが `sqlite-types.ts` と Worker 内で使われている箇所で型が一致しているか確認（特に optional/nullable の扱い）
+
+## Definition of Done
+- [ ] opfsWorker.ts から重複型定義が全て削除されている
+- [ ] `npm run type-check` が成功する
+- [ ] `npm run build` が成功する
+- [ ] 既存の全テストがパスする
+- [ ] コードレビュー完了

--- a/pbi/2026-07-13-03-fix-sqlite-history-panel-deepening.md
+++ b/pbi/2026-07-13-03-fix-sqlite-history-panel-deepening.md
@@ -1,0 +1,111 @@
+# PBI: sqliteHistoryPanel.ts の深化 — カレンダー・診断・エンリッチメント分離
+
+## ユーザーストーリー
+開発者として、1087行の `sqliteHistoryPanel.ts` からカレンダー操作、診断メタデータ整形、chrome.storage エンリッチメントを独立したモジュールに分離してほしい。
+なぜなら現在1ファイルに8つの関心事が混在しており、カレンダーのバグ修正に全ファイルを読む必要があり、各機能の単体テストも不可能だから。
+
+## ビジネス価値
+- **テスタビリティ**: カレンダーウィジェット、診断フォーマッタ、エントリレンダラが独立して単体テスト可能になる
+- **再利用性**: `CalendarWidget` が他のダッシュボードパネルでも使えるようになる
+- **保守性**: 各モジュールが 50〜200 行に収まり、1つの関心事を理解するのにファイル全体を読む必要がなくなる
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: カレンダーウィジェットが独立して動作する
+  Given CalendarWidget が初期化されている
+  When  ユーザーが日付ボタンをクリックしたとき
+  Then  選択日がコールバックで呼び出し元に通知され
+  And  カレンダーUIが選択状態を反映して再描画される
+
+Scenario: 診断フォーマッタがエントリデータからHTMLを生成する
+  Given トークン数・バイト数・クレンジング率を含む BrowsingLogEntry がある
+  When  DiagnosticFormatter.format(entry) が呼ばれたとき
+  Then  プログレスバー付きの診断HTMLが返され
+  And  データが欠落している場合は空文字列が返される
+
+Scenario: ストレージエンリッチャが欠損データを補完する
+  Given SQLite エントリに sent_tokens が null だが chrome.storage に該当データがある
+  When  StorageEnricher.enrich(entry, storageMap) が呼ばれたとき
+  Then  sent_tokens が chrome.storage の値で補完され
+  And  既に値があるフィールドは上書きされない
+
+Scenario: パネルが分離後も全機能を維持する
+  Given sqliteHistoryPanel.ts が CalendarWidget + DiagnosticFormatter + EntryRenderer + StorageEnricher を使用している
+  When  ユーザーが履歴を検索・フィルタ・ページネーションするとき
+  Then  分離前と完全に同じUIと動作が提供される
+```
+
+## 受け入れ基準
+- [ ] `CalendarWidget` モジュールが抽出され、`renderCalendarNav()` / `handleDateSelect()` / `dateRangeFromSelected()` を含む
+- [ ] `DiagnosticFormatter` モジュールが抽出され、`formatDiagnosticMetadataHtml()` / `buildCleansingProgressBarHtml()` を含む
+- [ ] `StorageEnricher` モジュールが抽出され、`enrichEntryWithChromeStorage()` / `getChromeStorageLookup()` を含む
+- [ ] `EntryRenderer` モジュールが抽出され、`renderEntryList()` を含む（ただし DOM アクセスはパネルに残す）
+- [ ] `sqliteHistoryPanel.ts` が 400 行以下になる
+- [ ] 各抽出モジュールが対応する単体テストを持つ
+- [ ] 既存の全テストがパスする
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- ダッシュボードの履歴パネルが分離前と同一のUI・動作を提供すること
+
+### 統合テスト
+- `CalendarWidget` がパネルのデータ読み込み（`loadData`）と正しく連携すること
+- `StorageEnricher` が `chrome.storage` のキャッシュ機構と正しく連携すること
+
+### 単体テスト
+- `CalendarWidget.getMonthDateRange(year, month)` が正しい since/until を返す（境界値: 月末、閏年）
+- `DiagnosticFormatter.format()` が全フィールド欠損時に空文字列、全フィールド存在時に完全な HTML を返す
+- `DiagnosticFormatter.buildProgressBar()` が base=0 で空文字列を返す
+- `StorageEnricher.enrich()` が既存値の上書きをしない
+- `StorageEnricher.getLookup()` がキャッシュTTLを守る（5秒以内は再構築しない）
+
+## 実装アプローチ
+- **依存**: PBI #1（StorageBackend アダプタ）の完了後に着手（パネルのデータアクセスがアダプタ経由になる可能性があるため）
+- **抽出のみ**: ロジックの変更は一切行わず、関数を別ファイルに移動して import する純粋なリファクタリング
+- **段階的**: 1モジュールずつ抽出し、各段階でテストがパスすることを確認
+
+## 深掘り結果（2026-07-13）
+ファイル分割は不要。関数シグネチャの引数化で十分。変更量が最小でテスト可能になる。
+→ 詳細は [設計ドキュメント](../docs/superpowers/specs/2026-07-13-sqlite-history-panel-deepening-design.md) 参照
+
+## 見積もり
+1 ストーリーポイント（関数シグネチャの引数化 + 単体テスト追加）
+
+## 技術的考慮事項
+- **依存関係**: PBI #1 完了後が望ましいが、独立して着手可能
+- **テスタビリティ**: 抽出後の各モジュールは DOM 非依存でテスト可能
+- **非機能要件**: UI のパフォーマンス劣化なし（関数呼び出しのオーバーヘッドは無視できる）
+- **ADR参照**: 特になし
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+# 抽出対象の関数を確認
+rg -n "^function " src/dashboard/sqliteHistoryPanel.ts
+# 各行数のおおよその分布
+wc -l src/dashboard/sqliteHistoryPanel.ts
+```
+
+### 実装手順
+1. `src/dashboard/CalendarWidget.ts` を作成: `renderCalendarNav`, `handleDateSelect`, `dateRangeFromSelected`, `formatDate`, `_getMonthDateRange` を抽出
+2. `src/dashboard/DiagnosticFormatter.ts` を作成: `formatDiagnosticMetadataHtml`, `buildCleansingProgressBarHtml` を抽出
+3. `src/dashboard/StorageEnricher.ts` を作成: `enrichEntryWithChromeStorage`, `getChromeStorageLookup`, `_invalidateChromeStorageCache` を抽出
+4. `src/dashboard/EntryRenderer.ts` を作成: `renderEntryList` を抽出（ただし DOM アクセス用の要素IDは引数で受け取る）
+5. `sqliteHistoryPanel.ts` で各モジュールを import して呼び出すだけにする
+
+### 落とし穴
+- `CalendarWidget` は `state.selectedDate` を直接参照している。抽出時は状態を引数で受け取るか、コールバックでパネルに通知する設計にする
+- `renderCalendarNav()` 内の `document.getElementById` 呼び出しはパネルから要素を渡す形に変更
+- `escapeHtml` と `debounce` は汎用ユーティリティなので `src/dashboard/utils/` に移動
+- テスト用の `_test` エクスポートは移行先モジュールでも維持する
+
+## Definition of Done
+- [ ] 4つの抽出モジュールが作成されている
+- [ ] sqliteHistoryPanel.ts が 400 行以下
+- [ ] 各抽出モジュールに対応する単体テストが存在しパスする
+- [ ] 既存の全テストがパスする
+- [ ] `npm run build` が成功する
+- [ ] コードレビュー完了

--- a/pbi/2026-07-13-04-fix-sqlite-client-error-propagation.md
+++ b/pbi/2026-07-13-04-fix-sqlite-client-error-propagation.md
@@ -1,0 +1,114 @@
+# PBI: sqliteClient.call() のエラー伝播改善
+
+## ユーザーストーリー
+開発者として、`SqliteClient.call()` が失敗時に `null` ではなく構造化されたエラー情報を返してほしい。
+なぜなら現在すべての障害（タイムアウト、offscreen ドキュメント喪失、ディスクI/Oエラー、クォータ超過）が `null` に潰され、ダッシュボードに「履歴の読み込みに失敗しました」という一律のメッセージしか表示できないから。
+
+## ビジネス価値
+- **UX改善**: ユーザーに具体的なエラーメッセージを表示できる（例: 「データベースの初期化中です。しばらくお待ちください」vs「ディスク容量が不足しています」）
+- **デバッグ容易性**: エラーの種類が呼び出し元で判別可能になり、問題特定が高速化
+- **回復可能性**: 一時的なエラー（offscreen 再起動中など）と永続的なエラーを区別し、自動リトライの判断が可能になる
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: 正常系は success:true を返す
+  Given SQLite データベースが正常に動作している
+  When  dashboardSqliteService.queryLogs() が呼ばれたとき
+  Then  { success: true, rows: [...], total: N } が返される
+
+Scenario: タイムアウト時に具体的なエラーを返す
+  Given Service Worker からの応答が10秒以内に返らない
+  When  dashboardSqliteService.queryLogs() が呼ばれたとき
+  Then  { success: false, error: "Dashboard SQLite request timed out" } が返される
+
+Scenario: バックエンドエラー時にエラーメッセージが伝播する
+  Given OPFS Worker がディスクI/Oエラーを返した
+  When  dashboardSqliteService.queryLogs() が呼ばれたとき
+  Then  { success: false, error: "disk I/O error" } のような具体的なエラーメッセージが返される
+
+Scenario: データベース未初期化時に初期化中であることを伝える
+  Given SQLite データベースが未初期化である
+  When  dashboardSqliteService.queryLogs() が呼ばれたとき
+  Then  { success: false, error: "Database not initialized" } が返され
+  And  エラーメッセージに初期化待機のヒントが含まれる
+```
+
+## 受け入れ基準
+- [ ] `SqliteClient.call()` の戻り値が `T | null` から `{ success: true; data: T } | { success: false; error: string }` に変更されている
+- [ ] `dashboardSqliteService.ts` の全関数が `null` チェックではなく `response.success` で分岐する
+- [ ] `sqliteHistoryPanel.ts` のエラー表示が具体的なメッセージを反映する
+- [ ] ダッシュボードのエラー表示が「読み込みに失敗しました」から具体的な理由に変わる（最低3パターン: タイムアウト / DB未初期化 / ストレージエラー）
+- [ ] 既存の全テストがパスする
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- ダッシュボードで SQLite 未初期化時に具体的なエラーメッセージが表示されること
+- ダッシュボードでタイムアウト時にリトライを示唆するメッセージが表示されること
+
+### 統合テスト
+- `SqliteClient.call()` → `dashboardSqliteService` のチェーンでエラー情報が失われず伝播すること
+- Service Worker の `DASHBOARD_SQLITE` ハンドラが `SqliteClient` のエラーを正しくシリアライズしてダッシュボードに返すこと
+
+### 単体テスト
+- `call()` が各エラーケースで正しい error 文字列を返す（offscreen 不在 / タイムアウト / オペレーションエラー）
+- `dashboardSqliteService.queryLogs()` が `{ success: false }` を受け取ったときに適切にハンドリングする
+
+## 実装アプローチ
+- **互換性維持**: 呼び出し元の全箇所を修正する（約20箇所の `null` チェック）。TypeScript の型で漏れを検出
+- **段階的**: まず `call()` の型を変更 → コンパイルエラー箇所を修正 → ダッシュボードのエラー表示を改善
+
+## 見積もり
+1 ストーリーポイント（極小変更。戻り値の型変更 + 呼び出し元修正）
+
+## 技術的考慮事項
+- **依存関係**: 独立。他のPBIと並列で着手可能
+- **テスタビリティ**: 変更は純粋に関数の戻り値型の変更。既存テストのモックが戻り値 `null` を期待している場合は修正が必要
+- **非機能要件**: パフォーマンス影響なし（オブジェクトのアロケーションが1つ増えるのみ）
+- **ADR参照**: 特になし
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+# call() の現在のシグネチャと全呼び出し箇所
+rg -n "call\(" src/background/sqliteClient.ts
+rg -n "= await.*call\(" src/background/
+# null チェックしている全箇所
+rg -n "=== null" src/dashboard/dashboardSqliteService.ts
+rg -n "!result" src/dashboard/dashboardSqliteService.ts
+```
+
+### 実装手順
+1. `src/background/sqliteClient.ts`:
+   ```ts
+   // Before
+   private async call<T>(fn: () => Promise<T>): Promise<T | null> {
+   // After
+   private async call<T>(fn: () => Promise<T>): Promise<{ success: true; data: T } | { success: false; error: string }> {
+   ```
+2. エラーメッセージの分類: タイムアウト / offscreen 不在 / 操作エラー の3種類に分類
+3. `dashboardSqliteService.ts` の全関数を修正（約20関数）:
+   ```ts
+   // Before
+   if (result === null) return null;
+   // After
+   if (!result.success) {
+     console.error('queryLogs failed:', result.error);
+     return null;
+   }
+   ```
+4. `sqliteHistoryPanel.ts` のエラー表示を改善（`state.error` に具体的なメッセージを設定）
+
+### 落とし穴
+- `dashboardSqliteProtocol.ts` のレスポンス型との整合性。`DashboardSqliteResponseFor<S>` は既に `{ success: false; error: string }` を含むため、大きな変更は不要なはず
+- Service Worker のハンドラ（`dashboardSqliteHandlers.ts`）が `SqliteClient` の新しい戻り値型を受け取って `sendResponse` に渡す際のマッピング
+
+## Definition of Done
+- [ ] `call()` が structured error を返す
+- [ ] 全呼び出し元が新しい戻り値型に対応
+- [ ] ダッシュボードのエラー表示が3パターン以上に対応
+- [ ] 既存の全テストがパスする
+- [ ] `npm run type-check` が成功する
+- [ ] コードレビュー完了

--- a/pbi/2026-07-13-05-fix-shared-migration-module.md
+++ b/pbi/2026-07-13-05-fix-shared-migration-module.md
@@ -1,0 +1,119 @@
+# PBI: マイグレーションロジックの共有モジュール化
+
+## ユーザーストーリー
+開発者として、`sqliteEngineContext.ts` と `opfsWorker.ts` に重複する ALTER TABLE マイグレーションループ（19カラム）と FTS5 スキーマ初期化を1つの共有モジュールに統合してほしい。
+なぜなら現在同一のマイグレーションが2箇所にコピーされており、PBI-11 の `gist_synced` 追加時に両方の編集漏れのリスクが顕在化したから。
+
+## ビジネス価値
+- **保守性**: スキーマ変更が1ファイルの編集で完了。両方のバックエンドが同一順序・同一内容でマイグレーションを適用することを保証
+- **バグ防止**: マイグレーション順序の不一致によるデータ不整合を防止
+- **コード量削減**: 約80行の重複マイグレーションコードが削除される
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: 両バックエンドが同一のマイグレーションを実行する
+  Given shared/migrations.ts が MIGRATION_COLUMNS と runMigrations() をエクスポートしている
+  When  IDB VFS パスと OPFS Worker パスの両方で init が呼ばれたとき
+  Then 両方とも runMigrations() を呼び出し
+  And 同じ順序で同じ ALTER TABLE 文が実行される
+
+Scenario: 新規カラム追加時に1ファイル編集で両方に反映される
+  Given 新規カラム "experimental_flag INTEGER DEFAULT 0" を追加したい
+  When  schema.ts の MIGRATION_COLUMNS 配列に1行追加したとき
+  Then sqliteEngineContext.ts も opfsWorker.ts も変更不要で
+  And 両方のバックエンドが次の init で新カラムを追加する
+
+Scenario: カラム既存時の重複エラーが抑制される
+  Given カラム "content TEXT" が既に存在する
+  When  runMigrations() が ALTER TABLE ADD COLUMN content TEXT を実行したとき
+  Then "duplicate column name" エラーは無視され
+  And その他のカラム追加は続行される
+
+Scenario: FTS5 スキーマが存在しない場合に自動作成される
+  Given browsing_logs_fts テーブルが存在しない
+  When  runMigrations() が呼ばれたとき
+  Then FTS5 virtual table とトリガーが作成され
+  And 既存の browsing_logs 行が FTS インデックスに再構築される
+```
+
+## 受け入れ基準
+- [ ] `src/offscreen/schema.ts` に `MIGRATION_COLUMNS` 定数が追加されている（19カラムの配列）
+- [ ] `src/offscreen/schema.ts` に `MIGRATION_SEQUENCE` が追加されている（obsidian_synced, gist_synced などの単発マイグレーションのリスト）
+- [ ] `src/offscreen/migrations.ts` が作成され、`runMigrations(engine: MigrationEngine)` 関数をエクスポートしている
+- [ ] `MigrationEngine` インターフェースが定義されている（`exec(sql: string)` メソッド）
+- [ ] `sqliteEngineContext.ts` の `_doInit()` から ALTER TABLE ループと FTS 再構築ロジックが削除され、`runMigrations()` 呼び出しに置き換わっている
+- [ ] `opfsWorker.ts` の `initSqliteInner()` から ALTER TABLE ループが削除され、`runMigrations()` 呼び出しに置き換わっている
+- [ ] 既存の全テストがパスする（後方互換性）
+- [ ] 既存ユーザーの古いDBが正常にマイグレーションされる
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 古いスキーマのDBを新バージョンで開いたとき、全19カラムが追加され、FTS5 が有効化されること
+
+### 統合テスト
+- `runMigrations()` が IDB VFS パスと OPFS Worker パスの両方で正しく動作すること
+- `MigrationEngine` のモック実装で全マイグレーションステップが呼ばれることを検証
+
+### 単体テスト
+- `MIGRATION_COLUMNS` が `COLUMN_NAMES` と重複なく定義されている
+- `runMigrations()` がカラム既存エラーを正しく抑制する（`duplicate column name` のみ catch、その他は rethrow）
+- `runMigrations()` が空のDBで FTS5 再構築をスキップする（無駄な処理をしない）
+- `runMigrations()` が FTS5 インデックス空 + データ有りのケースで再構築を実行する
+
+## 実装アプローチ
+- **依存**: PBI #1（StorageBackend アダプタ）の完了後に着手。アダプタの `MigrationEngine` 的なインターフェースに依存するため
+- **安全性**: マイグレーションの内容自体は変更せず、コードの移動のみ。`ALTER TABLE ... ADD COLUMN` の冪等性により安全
+
+## 見積もり
+2 ストーリーポイント（migrations.ts の新規作成 + 2箇所の呼び出し元置換 + 単体テスト）
+
+## 技術的考慮事項
+- **依存関係**: PBI #1 のアダプタインターフェースに依存。`MigrationEngine` は `StorageBackend` のサブセット
+- **テスタビリティ**: `MigrationEngine` をモックすることで、マイグレーション手順を独立してテスト可能
+- **非機能要件**: パフォーマンス影響なし。init 時のマイグレーションは既存と同じ
+- **ADR参照**: ADR 2026-06-17（OPFS+FTS5共存）の移行手順に準拠
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+# 両ファイルの重複部分を確認
+rg -n "newColumns = \[" src/offscreen/sqliteEngineContext.ts
+rg -n "newColumns = \[" src/offscreen/opfsWorker.ts
+# 両者の差分
+diff <(rg "newColumns" -A 30 src/offscreen/sqliteEngineContext.ts) \
+     <(rg "newColumns" -A 30 src/offscreen/opfsWorker.ts)
+```
+
+### 実装手順
+1. `src/offscreen/schema.ts` に以下を追加:
+   ```ts
+   export const MIGRATION_COLUMNS = [
+     'content TEXT', 'masked_count INTEGER', /* ... 全19カラム */
+   ] as const;
+   ```
+2. `src/offscreen/migrations.ts` を作成:
+   ```ts
+   export interface MigrationEngine {
+     exec(sql: string): Promise<void>;
+     queryValue(sql: string): Promise<unknown>;
+   }
+   export async function runMigrations(engine: MigrationEngine): Promise<void> { ... }
+   ```
+3. `sqliteEngineContext.ts` の `_doInit()` と `opfsWorker.ts` の `initSqliteInner()` からマイグレーションループを削除し `runMigrations()` 呼び出しに置換
+4. MigrationEngine アダプタを各コンテキストで実装（IDB VFS 用 / OPFS Worker 用）
+
+### 落とし穴
+- `opfsWorker.ts` の `sqlExec` 関数はラップ済み。`MigrationEngine.exec()` はバックエンドごとに異なる実装になる
+- FTS5 の再構築（`INSERT INTO browsing_logs_fts(browsing_logs_fts) VALUES('rebuild')`）は `opfsWorker.ts` 固有の最適化。IDB VFS パスでは異なるアプローチかも
+- `obsidian_synced` と `gist_synced` の単発マイグレーションは `MIGRATION_COLUMNS` とは別に `MIGRATION_SEQUENCE` で管理
+
+## Definition of Done
+- [ ] `migrations.ts` が作成され、両バックエンドから呼ばれている
+- [ ] 重複した ALTER TABLE ループが両ファイルから削除されている
+- [ ] 単体テストが全マイグレーションステップをカバーしている
+- [ ] 既存の全テストがパスする
+- [ ] `npm run build` が成功する
+- [ ] コードレビュー完了

--- a/src/background/__tests__/sqliteClient-keepalive.test.ts
+++ b/src/background/__tests__/sqliteClient-keepalive.test.ts
@@ -11,6 +11,8 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 vi.mock('../../utils/logger.js', () => ({
   addLog: vi.fn(),
+  logError: vi.fn(),
+  ErrorCode: { STORAGE_READ_FAILURE: 'STRG_RD_001' },
   LogType: { INFO: 'INFO', WARN: 'WARN', ERROR: 'ERROR', DEBUG: 'DEBUG' },
 }));
 

--- a/src/background/__tests__/sqliteClient-queue.test.ts
+++ b/src/background/__tests__/sqliteClient-queue.test.ts
@@ -10,6 +10,8 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 vi.mock('../../utils/logger.js', () => ({
   addLog: vi.fn(),
+  logError: vi.fn(),
+  ErrorCode: { STORAGE_READ_FAILURE: 'STRG_RD_001' },
   LogType: { INFO: 'INFO', WARN: 'WARN', ERROR: 'ERROR', DEBUG: 'DEBUG' },
 }));
 

--- a/src/background/__tests__/sqliteClient-shared-instance.test.ts
+++ b/src/background/__tests__/sqliteClient-shared-instance.test.ts
@@ -9,6 +9,8 @@ import { vi, describe, it, expect } from 'vitest';
 
 vi.mock('../../utils/logger.js', () => ({
   addLog: vi.fn(),
+  logError: vi.fn(),
+  ErrorCode: { STORAGE_READ_FAILURE: 'STRG_RD_001' },
   LogType: { INFO: 'INFO', WARN: 'WARN', ERROR: 'ERROR', DEBUG: 'DEBUG' },
 }));
 

--- a/src/background/__tests__/sqliteClient-unit.test.ts
+++ b/src/background/__tests__/sqliteClient-unit.test.ts
@@ -8,6 +8,8 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 vi.mock('../../utils/logger.js', () => ({
   addLog: vi.fn(),
+  logError: vi.fn(),
+  ErrorCode: { STORAGE_READ_FAILURE: 'STRG_RD_001' },
   LogType: { INFO: 'INFO', WARN: 'WARN', ERROR: 'ERROR', DEBUG: 'DEBUG' },
 }));
 

--- a/src/background/handlers/__tests__/dashboardSqliteHandlers-extra.test.ts
+++ b/src/background/handlers/__tests__/dashboardSqliteHandlers-extra.test.ts
@@ -109,7 +109,7 @@ describe('handleDashboardSqlite — delete', () => {
     const mock = createMockSqliteClient();
     mock.delete.mockResolvedValue(false);
     const result = await handleDashboardSqlite({ subtype: 'delete', id: 3, ...TK() }, mock as any, undefined, VALID_TOKEN);
-    expect(result).toEqual({ success: false });
+    expect(result).toEqual({ success: false, error: 'Delete failed' });
   });
 });
 
@@ -160,7 +160,7 @@ describe('handleDashboardSqlite — update', () => {
       undefined,
       VALID_TOKEN
     );
-    expect(result).toEqual({ success: false });
+    expect(result).toEqual({ success: false, error: 'Update failed' });
   });
 });
 
@@ -296,7 +296,7 @@ describe('handleDashboardSqlite — purge_now', () => {
     mock.purgeOldRecords.mockResolvedValue(null);
     vi.mocked(getSettings).mockResolvedValue({ sqlite_retention_days: 30 } as any);
     const result = await handleDashboardSqlite({ subtype: 'purge_now' }, mock as any);
-    expect(result).toEqual({ success: true, purged: 0, skipped: false });
+    expect(result).toEqual({ success: false, error: 'Purge failed' });
   });
 
   it('purges with only days configured', async () => {
@@ -341,7 +341,7 @@ describe('handleDashboardSqlite — content_purge_now', () => {
     mock.purgeContent.mockResolvedValue(null);
     vi.mocked(getSettings).mockResolvedValue({ content_retention_days: 7 } as any);
     const result = await handleDashboardSqlite({ subtype: 'content_purge_now' }, mock as any);
-    expect(result).toEqual({ success: true, purged: 0, skipped: false });
+    expect(result).toEqual({ success: false, error: 'Content purge failed' });
   });
 });
 

--- a/src/background/handlers/__tests__/dashboardSqliteHandlers-extra.test.ts
+++ b/src/background/handlers/__tests__/dashboardSqliteHandlers-extra.test.ts
@@ -176,7 +176,7 @@ describe('handleDashboardSqlite — get_count', () => {
     const mock = createMockSqliteClient();
     mock.getCount.mockResolvedValue(null);
     const result = await handleDashboardSqlite({ subtype: 'get_count' }, mock as any);
-    expect(result).toEqual({ success: true, count: 0 });
+    expect(result).toEqual({ success: false, error: 'Get count failed' });
   });
 });
 

--- a/src/background/handlers/dashboardSqliteHandlers.ts
+++ b/src/background/handlers/dashboardSqliteHandlers.ts
@@ -80,9 +80,10 @@ export async function handleDashboardSqlite(
                     orderDir: payload.orderDir || 'DESC',
                     tagFilter: payload.tagFilter,
                 });
-                return result
-                    ? { success: true, rows: result.rows, total: result.total }
-                    : { success: false, error: 'Query failed' };
+                if (result === null) {
+                    return { success: false, error: sqliteClient.lastError || 'Query failed' };
+                }
+                return { success: true, rows: result.rows, total: result.total };
             }
             case 'search': {
                 const result = await sqliteClient.search(
@@ -90,17 +91,24 @@ export async function handleDashboardSqlite(
                     payload.limit ?? 50,
                     payload.offset ?? 0
                 );
-                return result
-                    ? { success: true, rows: result.rows, total: result.total }
-                    : { success: false, error: 'Search failed' };
+                if (result === null) {
+                    return { success: false, error: sqliteClient.lastError || 'Search failed' };
+                }
+                return { success: true, rows: result.rows, total: result.total };
             }
             case 'toggle_star': {
                 const result = await sqliteClient.toggleStar(payload.id);
-                return result ?? { success: false, error: 'Toggle star failed' };
+                if (!result) {
+                    return { success: false, error: sqliteClient.lastError || 'Toggle star failed' };
+                }
+                return result;
             }
             case 'delete': {
-                const result = await sqliteClient.delete(payload.id);
-                return { success: result };
+                const ok = await sqliteClient.delete(payload.id);
+                if (!ok) {
+                    return { success: false, error: sqliteClient.lastError || 'Delete failed' };
+                }
+                return { success: true };
             }
             case 'update': {
                 const changes = payload.changes || {};
@@ -108,19 +116,28 @@ export async function handleDashboardSqlite(
                 if (invalidKeys.length > 0) {
                     return { success: false, error: `Invalid update fields: ${invalidKeys.join(', ')}` };
                 }
-                const result = await sqliteClient.update(
+                const ok = await sqliteClient.update(
                     payload.id,
                     changes
                 );
-                return { success: result };
+                if (!ok) {
+                    return { success: false, error: sqliteClient.lastError || 'Update failed' };
+                }
+                return { success: true };
             }
             case 'get_count': {
                 const count = await sqliteClient.getCount();
-                return { success: true, count: count ?? 0 };
+                if (count === null) {
+                    return { success: true, count: 0 };
+                }
+                return { success: true, count };
             }
             case 'clear_all': {
                 const ok = await sqliteClient.clearAll();
-                return { success: ok };
+                if (!ok) {
+                    return { success: false, error: sqliteClient.lastError || 'Clear all failed' };
+                }
+                return { success: true };
             }
             case 'import': {
                 const rows = payload.rows;
@@ -167,15 +184,15 @@ export async function handleDashboardSqlite(
                 const status = await sqliteClient.getStatus();
                 if (status) {
                     return { success: true, ...status };
-                } else {
-                    return { success: false, error: 'Status check failed' };
                 }
+                return { success: false, error: sqliteClient.lastError || 'Status check failed' };
             }
             case 'opfs_spike': {
                 const report = await sqliteClient.runOpfsSpike();
-                return report
-                    ? { success: true, report }
-                    : { success: false, error: 'OPFS spike failed' };
+                if (report) {
+                    return { success: true, report };
+                }
+                return { success: false, error: sqliteClient.lastError || 'OPFS spike failed' };
             }
             case 'append_to_obsidian': {
                 const ids = payload.ids;
@@ -225,11 +242,14 @@ export async function handleDashboardSqlite(
                 if (days === null && max === null) {
                     return { success: true, purged: 0, skipped: true };
                 }
-                const result = await sqliteClient.purgeOldRecords(
+                const purgedResult = await sqliteClient.purgeOldRecords(
                     days !== null ? Number(days) : undefined,
                     max  !== null ? Number(max)  : undefined,
                 );
-                return { success: true, purged: result?.purged ?? 0, skipped: false };
+                if (purgedResult === null) {
+                    return { success: false, error: sqliteClient.lastError || 'Purge failed' };
+                }
+                return { success: true, purged: purgedResult.purged, skipped: false };
             }
             case 'content_purge_now': {
                 const settings = await getSettings();
@@ -239,19 +259,22 @@ export async function handleDashboardSqlite(
                 if (contentDays === null && contentMax === null) {
                     return { success: true, purged: 0, skipped: true };
                 }
-                const result = await sqliteClient.purgeContent(
+                const contentResult = await sqliteClient.purgeContent(
                     contentDays !== null ? Number(contentDays) : undefined,
                     contentMax  !== null ? Number(contentMax)  : undefined,
                     includeStarred,
                 );
-                return { success: true, purged: result?.purged ?? 0, skipped: false };
+                if (contentResult === null) {
+                    return { success: false, error: sqliteClient.lastError || 'Content purge failed' };
+                }
+                return { success: true, purged: contentResult.purged, skipped: false };
             }
             case 'backup_db': {
                 const data = await sqliteClient.backupDb();
                 if (data) {
                     return { success: true, data: bytesToBase64(data) };
                 }
-                return { success: false, error: 'Backup failed' };
+                return { success: false, error: sqliteClient.lastError || 'Backup failed' };
             }
             case 'backfill_metadata': {
                 if (!runBackfill) {

--- a/src/background/handlers/dashboardSqliteHandlers.ts
+++ b/src/background/handlers/dashboardSqliteHandlers.ts
@@ -128,7 +128,7 @@ export async function handleDashboardSqlite(
             case 'get_count': {
                 const count = await sqliteClient.getCount();
                 if (count === null) {
-                    return { success: true, count: 0 };
+                    return { success: false, error: sqliteClient.lastError || 'Get count failed' };
                 }
                 return { success: true, count };
             }
@@ -169,6 +169,9 @@ export async function handleDashboardSqlite(
                             skipped++;
                         }
                     }
+                }
+                if (sqliteClient.lastError) {
+                    return { success: false, error: sqliteClient.lastError };
                 }
                 return { success: true, inserted, skipped, total: rows.length };
             }

--- a/src/background/handlers/dashboardSqliteHandlers.ts
+++ b/src/background/handlers/dashboardSqliteHandlers.ts
@@ -170,7 +170,7 @@ export async function handleDashboardSqlite(
                         }
                     }
                 }
-                if (sqliteClient.lastError) {
+                if (sqliteClient.lastError && inserted === 0) {
                     return { success: false, error: sqliteClient.lastError };
                 }
                 return { success: true, inserted, skipped, total: rows.length };

--- a/src/background/sqliteClient.ts
+++ b/src/background/sqliteClient.ts
@@ -180,6 +180,7 @@ export class SqliteClient {
       if (!res?.success) {
         const msg = res?.error || `${type} failed`;
         recordSqliteFailure(type, msg);
+        logError('SQLite Client: call failed', { error: msg }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
         return { success: false, error: categorizeError(msg) };
       }
       recordSqliteSuccess();

--- a/src/background/sqliteClient.ts
+++ b/src/background/sqliteClient.ts
@@ -6,7 +6,7 @@
  * Pattern: src/background/localAiClient.ts
  */
 
-import { addLog, LogType } from '../utils/logger.js';
+import { addLog, LogType, logError, ErrorCode } from '../utils/logger.js';
 import { errorMessage } from '../utils/errorUtils.js';
 import { recordSqliteFailure, recordSqliteSuccess } from './sqliteAlert.js';
 import { Mutex } from './Mutex.js';
@@ -35,6 +35,24 @@ interface OffscreenResponse {
   [key: string]: unknown;
 }
 
+type CallResult<T> = { success: true; data: T } | { success: false; error: string };
+
+function categorizeError(msg: string): string {
+  if (msg.includes('timed out') || msg.includes('Timeout')) {
+    return 'SQLite request timed out. The database may still be initializing.';
+  }
+  if (msg.includes('offscreen') || msg.includes('offscreenDocument')) {
+    return 'Database connection lost. Please reload the extension.';
+  }
+  if (msg.includes('quota') || msg.includes('QuotaExceededError')) {
+    return 'Storage quota exceeded. Some older records may have been removed.';
+  }
+  if (msg.includes('SQLITE_') || msg.includes('disk I/O')) {
+    return `Database error: ${msg}`;
+  }
+  return `Unexpected error: ${msg}`;
+}
+
 // ============================================================================
 // SqliteClient
 // ============================================================================
@@ -49,6 +67,9 @@ export class SqliteClient {
    * overlapping requests from multiple tabs would race each other.
    */
   private readonly requestQueue: Mutex;
+
+  /** Last categorized error from call(). Read by dashboard handlers. */
+  lastError: string | null = null;
 
   constructor() {
     this.creatingOffscreenPromise = null;
@@ -153,44 +174,64 @@ export class SqliteClient {
     type: string,
     payload: Record<string, unknown> = {},
     transform?: (res: OffscreenResponse) => T,
-  ): Promise<T | null> {
+  ): Promise<CallResult<T>> {
     try {
-      const response = await this.msgOffscreen(type, payload);
-      if (response?.success) {
-        recordSqliteSuccess();
-        return transform ? transform(response) : (response as unknown as T);
+      const res = await this.msgOffscreen(type, payload);
+      if (!res?.success) {
+        const msg = res?.error || `${type} failed`;
+        recordSqliteFailure(type, msg);
+        return { success: false, error: categorizeError(msg) };
       }
-      recordSqliteFailure(type, response?.error || 'unknown');
-      return null;
-    } catch (error: unknown) {
-      addLog(LogType.ERROR, `SqliteClient: ${type} failed`, { error: errorMessage(error) });
-      recordSqliteFailure(type, errorMessage(error));
-      return null;
+      recordSqliteSuccess();
+      return { success: true, data: transform ? transform(res) : (res as unknown as T) };
+    } catch (error) {
+      const msg = errorMessage(error);
+      recordSqliteFailure(type, msg);
+      logError('SQLite Client: call failed', { error: msg }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
+      return { success: false, error: categorizeError(msg) };
     }
   }
 
   async init(): Promise<boolean> {
-    return (await this.call<void>('SQLITE_INIT')) !== null;
+    const result = await this.call('SQLITE_INIT');
+    if (!result.success) {
+      this.lastError = result.error;
+      return false;
+    }
+    this.lastError = null;
+    return true;
   }
 
   async insert(record: BrowsingLogRecord): Promise<{ id: number } | null> {
-    return this.call<{ id: number }>(
+    const result = await this.call<{ id: number }>(
       'SQLITE_INSERT',
       record as unknown as Record<string, unknown>,
       (res) => ({ id: Number(res.id) }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async insertBatch(records: BrowsingLogRecord[]): Promise<{ count: number } | null> {
-    return this.call<{ count: number }>(
+    const result = await this.call<{ count: number }>(
       'SQLITE_INSERT_BATCH',
       { records: records as unknown as Record<string, unknown>[] },
       (res) => ({ count: Number(res.count) }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async query<T = BrowsingLogRecord>(options: QueryOptions = {}): Promise<{ rows: T[]; total: number } | null> {
-    return this.call<{ rows: T[]; total: number }>(
+    const result = await this.call<{ rows: T[]; total: number }>(
       'SQLITE_QUERY',
       options as unknown as Record<string, unknown>,
       (res) => ({
@@ -198,10 +239,16 @@ export class SqliteClient {
         total: Number(res.total || 0),
       }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async search(query: string, limit = 50, offset = 0): Promise<{ rows: SearchResult[]; total: number } | null> {
-    return this.call<{ rows: SearchResult[]; total: number }>(
+    const result = await this.call<{ rows: SearchResult[]; total: number }>(
       'SQLITE_SEARCH',
       { query, limit, offset },
       (res) => ({
@@ -209,42 +256,84 @@ export class SqliteClient {
         total: Number(res.total || 0),
       }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async update(id: number, changes: Partial<Record<string, unknown>>): Promise<boolean> {
-    return (await this.call<void>('SQLITE_UPDATE', { id, ...changes })) !== null;
+    const result = await this.call('SQLITE_UPDATE', { id, ...changes });
+    if (!result.success) {
+      this.lastError = result.error;
+      return false;
+    }
+    this.lastError = null;
+    return true;
   }
 
   async delete(id: number): Promise<boolean> {
-    return (await this.call<void>('SQLITE_DELETE', { id })) !== null;
+    const result = await this.call('SQLITE_DELETE', { id });
+    if (!result.success) {
+      this.lastError = result.error;
+      return false;
+    }
+    this.lastError = null;
+    return true;
   }
 
   async toggleStar(id: number): Promise<{ is_starred: number } | null> {
-    return this.call<{ is_starred: number }>(
+    const result = await this.call<{ is_starred: number }>(
       'SQLITE_TOGGLE_STAR',
       { id },
       (res) => ({ is_starred: Number(res.is_starred) }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async getCount(): Promise<number | null> {
-    return this.call<number>('SQLITE_COUNT', {}, (res) => Number(res.count));
+    const result = await this.call<number>('SQLITE_COUNT', {}, (res) => Number(res.count));
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async exportDb(): Promise<Uint8Array | null> {
-    return this.call<Uint8Array>(
+    const result = await this.call<Uint8Array>(
       'SQLITE_EXPORT',
       {},
       (res) => new Uint8Array(res.data as number[]),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async backupDb(): Promise<Uint8Array | null> {
-    return this.call<Uint8Array>(
+    const result = await this.call<Uint8Array>(
       'SQLITE_BACKUP',
       {},
       (res) => new Uint8Array(res.data as number[]),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async restoreDb(data: Uint8Array): Promise<boolean> {
@@ -258,7 +347,7 @@ export class SqliteClient {
   }
 
   async getStatus(): Promise<{ initialized: boolean; path: string; fallback: boolean; fts5?: boolean; initError?: string; compileOptions?: string[]; compileOptionsSource?: 'opfs-worker' | 'idb' | 'fallback' } | null> {
-    return this.call<{ initialized: boolean; path: string; fallback: boolean; fts5?: boolean; initError?: string; compileOptions?: string[]; compileOptionsSource?: 'opfs-worker' | 'idb' | 'fallback' }>(
+    const result = await this.call<{ initialized: boolean; path: string; fallback: boolean; fts5?: boolean; initError?: string; compileOptions?: string[]; compileOptionsSource?: 'opfs-worker' | 'idb' | 'fallback' }>(
       'SQLITE_STATUS',
       {},
       (res) => ({
@@ -271,10 +360,22 @@ export class SqliteClient {
         compileOptionsSource: res.compileOptionsSource as 'opfs-worker' | 'idb' | 'fallback' | undefined,
       }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async clearAll(): Promise<boolean> {
-    return (await this.call<void>('SQLITE_CLEAR_ALL')) !== null;
+    const result = await this.call('SQLITE_CLEAR_ALL');
+    if (!result.success) {
+      this.lastError = result.error;
+      return false;
+    }
+    this.lastError = null;
+    return true;
   }
 
   /** Run the OPFS feasibility spike (PBI-10) in the offscreen document. */
@@ -292,19 +393,31 @@ export class SqliteClient {
   }
 
   async runOpfsSpike(): Promise<OpfsSpikeReport | null> {
-    return this.call<OpfsSpikeReport>(
+    const result = await this.call<OpfsSpikeReport>(
       'SQLITE_OPFS_SPIKE',
       {},
       (res) => res.report as OpfsSpikeReport,
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async purgeOldRecords(retentionDays?: number, maxRecords?: number): Promise<{ purged: number } | null> {
-    return this.call<{ purged: number }>(
+    const result = await this.call<{ purged: number }>(
       'SQLITE_PURGE',
       { retentionDays, maxRecords },
       (res) => ({ purged: Number(res.purged || 0) }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async purgeContent(
@@ -312,23 +425,35 @@ export class SqliteClient {
     maxRecords?: number,
     includeStarred?: boolean,
   ): Promise<{ purged: number } | null> {
-    return this.call<{ purged: number }>(
+    const result = await this.call<{ purged: number }>(
       'CONTENT_PURGE',
       { retentionDays, maxRecords, includeStarred },
       (res) => ({ purged: Number(res.purged || 0) }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async insertAuditLog(record: { provider: string; url: string; created_at: number }): Promise<{ id: number } | null> {
-    return this.call<{ id: number }>(
+    const result = await this.call<{ id: number }>(
       'SQLITE_AUDIT_LOG_INSERT',
       record,
       (res) => ({ id: Number(res.id) }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 
   async queryAuditLog(options: { limit?: number; offset?: number } = {}): Promise<{ rows: Array<{ id: number; provider: string; url: string; created_at: number }>; total: number } | null> {
-    return this.call<{ rows: Array<{ id: number; provider: string; url: string; created_at: number }>; total: number }>(
+    const result = await this.call<{ rows: Array<{ id: number; provider: string; url: string; created_at: number }>; total: number }>(
       'SQLITE_AUDIT_LOG_QUERY',
       options as unknown as Record<string, unknown>,
       (res) => ({
@@ -336,6 +461,12 @@ export class SqliteClient {
         total: Number(res.total || 0),
       }),
     );
+    if (!result.success) {
+      this.lastError = result.error;
+      return null;
+    }
+    this.lastError = null;
+    return result.data;
   }
 }
 

--- a/src/dashboard/__tests__/dashboardSqliteService.test.ts
+++ b/src/dashboard/__tests__/dashboardSqliteService.test.ts
@@ -60,11 +60,11 @@ describe('dashboardSqliteService', () => {
       );
     });
 
-    it('returns null on failed response', async () => {
+    it('returns error object on failed response', async () => {
       givenResponse({ success: false, error: 'DB error' });
 
       const result = await queryLogs();
-      expect(result).toBeNull();
+      expect(result).toEqual({ error: 'DB error' });
     });
 
     it('returns null on rejection', async () => {

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -843,15 +843,17 @@ async function exportLocalMarkdownCore(options: LocalMarkdownExportOptions): Pro
         })()
       : await queryLogs({ limit: 100000, orderBy: 'created_at', orderDir: 'ASC' });
 
-    if (!result || result.rows.length === 0) {
+    if (!result || !('rows' in result) || result.rows.length === 0) {
       statusEl.textContent = options.emptyMessage;
       statusEl.className = 'error';
       return;
     }
 
+    const { rows } = result;
+
     // Group entries by local date
-    const entriesByDate = new Map<string, typeof result.rows>();
-    for (const row of result.rows) {
+    const entriesByDate = new Map<string, typeof rows>();
+    for (const row of rows) {
       const date = getLocalDateString(row.created_at);
       if (!entriesByDate.has(date)) {
         entriesByDate.set(date, []);
@@ -879,7 +881,7 @@ async function exportLocalMarkdownCore(options: LocalMarkdownExportOptions): Pro
       totalFiles++;
     }
 
-    statusEl.textContent = `${result.rows.length}件の記録を${totalFiles}ファイルにエクスポートしました。`;
+    statusEl.textContent = `${'rows' in result ? result.rows.length : 0}件の記録を${totalFiles}ファイルにエクスポートしました。`;
     statusEl.className = 'success';
   } catch (e) {
     statusEl.textContent = `エクスポートに失敗しました: ${e instanceof Error ? e.message : String(e)}`;

--- a/src/dashboard/dashboardSqliteService.ts
+++ b/src/dashboard/dashboardSqliteService.ts
@@ -84,12 +84,13 @@ export async function queryLogs(options: {
   orderBy?: string;
   orderDir?: 'ASC' | 'DESC';
   tagFilter?: string;
-} = {}): Promise<{ rows: BrowsingLogEntry[]; total: number } | null> {
+} = {}): Promise<{ rows: BrowsingLogEntry[]; total: number } | { error: string } | null> {
   try {
     const response = await sendDashboardMessage({ subtype: 'query', ...options });
     if (response.success) {
       return { rows: (response.rows || []) as BrowsingLogEntry[], total: Number(response.total || 0) };
     }
+    console.warn('queryLogs failed:', response.error);
     return null;
   } catch (error) {
     console.error('queryLogs failed:', error);
@@ -104,12 +105,13 @@ export async function searchLogs(
   query: string,
   limit = 50,
   offset = 0
-): Promise<{ rows: BrowsingLogEntry[]; total: number } | null> {
+): Promise<{ rows: BrowsingLogEntry[]; total: number } | { error: string } | null> {
   try {
     const response = await sendDashboardMessage({ subtype: 'search', query, limit, offset });
     if (response.success) {
       return { rows: (response.rows || []) as BrowsingLogEntry[], total: Number(response.total || 0) };
     }
+    console.warn('searchLogs failed:', response.error);
     return null;
   } catch (error) {
     console.error('searchLogs failed:', error);

--- a/src/dashboard/dashboardSqliteService.ts
+++ b/src/dashboard/dashboardSqliteService.ts
@@ -91,7 +91,7 @@ export async function queryLogs(options: {
       return { rows: (response.rows || []) as BrowsingLogEntry[], total: Number(response.total || 0) };
     }
     console.warn('queryLogs failed:', response.error);
-    return null;
+    return { error: String(response.error || 'Query failed') };
   } catch (error) {
     console.error('queryLogs failed:', error);
     return null;
@@ -112,7 +112,7 @@ export async function searchLogs(
       return { rows: (response.rows || []) as BrowsingLogEntry[], total: Number(response.total || 0) };
     }
     console.warn('searchLogs failed:', response.error);
-    return null;
+    return { error: String(response.error || 'Search failed') };
   } catch (error) {
     console.error('searchLogs failed:', error);
     return null;

--- a/src/dashboard/exportLogsService.ts
+++ b/src/dashboard/exportLogsService.ts
@@ -12,7 +12,7 @@ import { queryLogs, backupDb } from './dashboardSqliteService.js';
 
 async function queryAllData() {
   const result = await queryLogs({ limit: 10000, orderBy: 'created_at', orderDir: 'DESC' });
-  return result?.rows || [];
+  return (result && 'rows' in result ? result.rows : []);
 }
 
 export async function exportMarkdown(ids?: number[]): Promise<string> {

--- a/src/dashboard/sqliteHistoryPanel.ts
+++ b/src/dashboard/sqliteHistoryPanel.ts
@@ -114,7 +114,7 @@ async function loadData(options: {
     const limit = PAGE_SIZE;
     const offset = page * limit;
 
-    let result: { rows: BrowsingLogEntry[]; total: number } | null;
+    let result: { rows: BrowsingLogEntry[]; total: number } | { error: string } | null;
 
     // Use tagFilter from options or state, preferring explicit options
     const activeTagFilter = options.tagFilter !== undefined ? options.tagFilter : state.activeTagFilter;
@@ -133,7 +133,7 @@ async function loadData(options: {
       });
 
       // Filter by tag in JavaScript if tagFilter is set
-      if (result && activeTagFilter) {
+      if (result && !('error' in result) && activeTagFilter) {
         const filteredRows = result.rows.filter(row => {
           // Tags are stored as comma-separated string in SQLite
           const tagsString = row.tags || '';
@@ -147,7 +147,7 @@ async function loadData(options: {
           rows: filteredRows.slice(offset, offset + limit),
           total: filteredRows.length,
         };
-      } else if (result) {
+      } else if (result && !('error' in result)) {
         result = {
           rows: result.rows.slice(offset, offset + limit),
           total: result.total,
@@ -155,15 +155,19 @@ async function loadData(options: {
       }
     }
 
-    if (result) {
+    if (result === null) {
+      state.error = t('historyLoadError');
+      state.entries = [];
+      state.total = 0;
+    } else if ('error' in result) {
+      state.error = result.error;
+      state.entries = [];
+      state.total = 0;
+    } else {
       state.entries = result.rows;
       state.total = result.total;
       // Reset selection when entries change (search, pagination, date)
       state.selectedIds.clear();
-    } else {
-      state.error = t('historyLoadError');
-      state.entries = [];
-      state.total = 0;
     }
   } catch (err) {
     state.error = `Error: ${errorMessage(err)}`;

--- a/src/dashboard/sqliteHistoryPanel.ts
+++ b/src/dashboard/sqliteHistoryPanel.ts
@@ -199,23 +199,40 @@ function updateDynamicRegions(): void {
   }
 
   updateTagFilterBar();
-  updateBulkBar();
 
-  // Re-render calendar nav so the "clear filters" button shows/hides
-  renderCalendarNav();
+  const calContainer = document.getElementById('sqlite-calendar-nav');
+  if (calContainer) {
+    renderCalendarNav(calContainer, state.selectedDate,
+      { searchQuery: state.searchQuery, activeTagFilter: state.activeTagFilter },
+      {
+        onDateSelect: (d) => handleDateSelect(d),
+        onRangeSelect: (since, until) => { state.selectedDate = null; state.searchQuery = ''; state.currentPage = 0; loadData({ since, until }); },
+        onClearFilters: () => { state.searchQuery = ''; state.selectedDate = null; state.activeTagFilter = null; state.currentPage = 0; loadData(); },
+      }
+    );
+  }
 
-  const listEl = document.getElementById('sqlite-entry-list');
-  if (listEl) {
+  const listContainer = document.getElementById('sqlite-entry-list');
+  if (listContainer) {
     if (state.loading) {
-      listEl.innerHTML = `<div class="loading">${t('historyLoading')}</div>`;
+      listContainer.innerHTML = `<div class="loading">${t('historyLoading')}</div>`;
     } else {
-      renderEntryList();
+      renderEntryList(listContainer, state.entries, state.selectedIds, state.activeTagFilter, null, {
+        onToggleStar: (id) => handleToggleStar(id),
+        onDelete: (id) => handleDelete(id),
+        onSelectionChange: (id, selected) => { if (selected) state.selectedIds.add(id); else state.selectedIds.delete(id); updateBulkBar(state.selectedIds, state.entries, bulkCallbacks); },
+        onTagFilterClick: (tag) => { state.activeTagFilter = state.activeTagFilter === tag ? null : tag; state.currentPage = 0; loadData({ tagFilter: state.activeTagFilter || undefined, ...dateRangeFromSelected() }); },
+        onContentToggle: (controlsId) => handleContentToggle(controlsId),
+      });
     }
   }
 
   if (!state.loading) {
-    renderPagination();
+    const pagContainer = document.getElementById('sqlite-pagination');
+    if (pagContainer) renderPagination(pagContainer, state.currentPage, state.total, PAGE_SIZE, (page) => { state.currentPage = page; reloadCurrent(); });
   }
+
+  updateBulkBar(state.selectedIds, state.entries, bulkCallbacks);
 }
 
 /** Show or hide the tag filter bar in an already-mounted panel. */
@@ -315,26 +332,34 @@ function createCopyButton(entry: BrowsingLogEntry): HTMLButtonElement {
   return button;
 }
 
-function updateBulkBar(): void {
+function updateBulkBar(
+  selectedIds: Set<number>,
+  entries: BrowsingLogEntry[],
+  _callbacks: {
+    onSelectAll: (checked: boolean) => void;
+    onClear: () => void;
+    onAppend: () => void;
+  }
+): void {
   const bar = document.getElementById('sqlite-bulk-bar');
   const selectAll = document.getElementById('sqlite-select-all') as HTMLInputElement | null;
   const countEl = document.getElementById('sqlite-selection-count');
   const appendBtn = document.getElementById('sqlite-append-obsidian') as HTMLButtonElement | null;
 
   if (bar) {
-    bar.style.display = state.selectedIds.size > 0 ? '' : 'none';
+    bar.style.display = selectedIds.size > 0 ? '' : 'none';
   }
 
   if (selectAll) {
-    selectAll.checked = state.entries.length > 0 && state.selectedIds.size === state.entries.length;
+    selectAll.checked = entries.length > 0 && selectedIds.size === entries.length;
   }
 
   if (countEl) {
-    countEl.textContent = t('historySelectionCount', [String(state.selectedIds.size)]);
+    countEl.textContent = t('historySelectionCount', [String(selectedIds.size)]);
   }
 
   if (appendBtn) {
-    appendBtn.disabled = state.selectedIds.size === 0;
+    appendBtn.disabled = selectedIds.size === 0;
   }
 }
 
@@ -396,6 +421,40 @@ async function handleDateSelect(dateStr: string): Promise<void> {
   await loadData({ since, until });
 }
 
+function handleContentToggle(controlsId: string): void {
+  const area = document.getElementById(controlsId);
+  if (!area) return;
+  const isHidden = area.classList.toggle('hidden');
+  const btn = document.querySelector(`[aria-controls="${controlsId}"]`) as HTMLButtonElement | null;
+  if (!btn) return;
+  btn.setAttribute('aria-expanded', String(!isHidden));
+  if (controlsId.startsWith('content-sent-')) {
+    btn.textContent = isHidden ? (t('historyShowSentData') || 'AIへ送信したデータ') : (t('historyHideSentData') || 'データを非表示');
+  } else if (controlsId.startsWith('content-received-')) {
+    btn.textContent = isHidden ? (t('historyShowReceivedData') || 'AIから受信したデータ') : (t('historyHideReceivedData') || 'データを非表示');
+  } else {
+    btn.textContent = isHidden ? t('historyShowContent') : t('historyHideContent');
+  }
+}
+
+const bulkCallbacks = {
+  onSelectAll: (checked: boolean) => {
+    if (checked) {
+      state.entries.forEach(e => state.selectedIds.add(e.id));
+    } else {
+      state.selectedIds.clear();
+    }
+    updateBulkBar(state.selectedIds, state.entries, bulkCallbacks);
+  },
+  onClear: () => {
+    state.selectedIds.clear();
+    updateBulkBar(state.selectedIds, state.entries, bulkCallbacks);
+  },
+  onAppend: () => {
+    handleAppendToObsidian();
+  },
+};
+
 // ============================================================================
 // Rendering
 // ============================================================================
@@ -448,9 +507,31 @@ function renderState(): void {
   `;
 
   if (!state.loading) {
-    renderEntryList();
-    renderPagination();
-    renderCalendarNav();
+    const calContainer = document.getElementById('sqlite-calendar-nav');
+    if (calContainer) {
+      renderCalendarNav(calContainer, state.selectedDate,
+        { searchQuery: state.searchQuery, activeTagFilter: state.activeTagFilter },
+        {
+          onDateSelect: (d) => handleDateSelect(d),
+          onRangeSelect: (since, until) => { state.selectedDate = null; state.searchQuery = ''; state.currentPage = 0; loadData({ since, until }); },
+          onClearFilters: () => { state.searchQuery = ''; state.selectedDate = null; state.activeTagFilter = null; state.currentPage = 0; loadData(); },
+        }
+      );
+    }
+
+    const listContainer = document.getElementById('sqlite-entry-list');
+    if (listContainer) {
+      renderEntryList(listContainer, state.entries, state.selectedIds, state.activeTagFilter, null, {
+        onToggleStar: (id) => handleToggleStar(id),
+        onDelete: (id) => handleDelete(id),
+        onSelectionChange: (id, selected) => { if (selected) state.selectedIds.add(id); else state.selectedIds.delete(id); updateBulkBar(state.selectedIds, state.entries, bulkCallbacks); },
+        onTagFilterClick: (tag) => { state.activeTagFilter = state.activeTagFilter === tag ? null : tag; state.currentPage = 0; loadData({ tagFilter: state.activeTagFilter || undefined, ...dateRangeFromSelected() }); },
+        onContentToggle: (controlsId) => handleContentToggle(controlsId),
+      });
+    }
+
+    const pagContainer = document.getElementById('sqlite-pagination');
+    if (pagContainer) renderPagination(pagContainer, state.currentPage, state.total, PAGE_SIZE, (page) => { state.currentPage = page; reloadCurrent(); });
   }
 
   // Wire search input
@@ -587,33 +668,36 @@ function enrichEntryWithChromeStorage(
   };
 }
 
-async function renderEntryList(): Promise<void> {
-  const listEl = document.getElementById('sqlite-entry-list');
-  if (!listEl) return;
-
-  // Server-side tag filter: state.entries already filtered by loadData with tagFilter
-  const displayEntries = state.entries;
+function renderEntryList(
+  container: HTMLElement,
+  entries: BrowsingLogEntry[],
+  selectedIds: Set<number>,
+  activeTagFilter: string | null,
+  enrichmentMap: Map<string, SavedUrlEntry> | null,
+  callbacks: {
+    onToggleStar: (id: number) => void | Promise<void>;
+    onDelete: (id: number) => void | Promise<void>;
+    onSelectionChange: (id: number, selected: boolean) => void;
+    onTagFilterClick: (tag: string) => void;
+    onContentToggle: (controlsId: string) => void;
+  }
+): void {
+  const displayEntries = entries;
 
   if (displayEntries.length === 0) {
-    listEl.innerHTML = `<div class="empty-state">${t('historyNoRecords')}</div>`;
+    container.innerHTML = `<div class="empty-state">${t('historyNoRecords')}</div>`;
     return;
   }
 
-  // Enrich entries with chrome.storage data if they lack diagnostic metadata.
-  // This is a lazy merge: entries already in SQLite with metrics are unchanged.
-  // Entries missing metrics are enriched from the most recent chrome.storage
-  // state. This handles the case where the SQLite entry was created by an
-  // older version of the pipeline that did not save diagnostic fields.
-  const enrichmentMap = await getChromeStorageLookup();
   const enrichedEntries = enrichmentMap
     ? displayEntries.map(e => enrichEntryWithChromeStorage(e, enrichmentMap))
     : displayEntries;
 
-  listEl.innerHTML = enrichedEntries.map(entry => {
+  container.innerHTML = enrichedEntries.map(entry => {
     const entryTags = parseTagsForDisplay(entry.tags);
     const tagsHtml = entryTags.length > 0
       ? `<div class="sqlite-entry-tags">${entryTags.map(tag => {
-          const isActive = state.activeTagFilter === tag;
+          const isActive = activeTagFilter === tag;
           return `<button type="button" class="tag-badge${isActive ? ' filter-active' : ''}"
             data-tag="${escapeHtml(tag)}"
             data-action="tag-filter"
@@ -627,7 +711,7 @@ async function renderEntryList(): Promise<void> {
     <div class="sqlite-entry" data-id="${entry.id}">
       <div class="sqlite-entry-header">
         <input type="checkbox" class="sqlite-entry-checkbox" data-action="select"
-               data-id="${entry.id}" ${state.selectedIds.has(entry.id) ? 'checked' : ''}
+               data-id="${entry.id}" ${selectedIds.has(entry.id) ? 'checked' : ''}
                aria-label="${t('historySelectRecord')}">
         <button type="button" class="sqlite-entry-star ${entry.is_starred ? 'starred' : ''}"
                 data-action="star" title="${t('historyToggleStar')}"
@@ -661,109 +745,92 @@ async function renderEntryList(): Promise<void> {
   }).join('');
 
   // Wire action buttons
-  listEl.querySelectorAll('[data-action="select"]').forEach((el) => {
+  container.querySelectorAll('[data-action="select"]').forEach((el) => {
     const id = Number((el as HTMLElement).getAttribute('data-id'));
     el.addEventListener('change', () => {
       const checkbox = el as HTMLInputElement;
-      if (checkbox.checked) {
-        state.selectedIds.add(id);
-      } else {
-        state.selectedIds.delete(id);
-      }
-      updateBulkBar();
+      callbacks.onSelectionChange(id, checkbox.checked);
     });
   });
-  listEl.querySelectorAll('[data-action="star"]').forEach((el) => {
+  container.querySelectorAll('[data-action="star"]').forEach((el) => {
     const entryId = Number((el as HTMLElement).closest('.sqlite-entry')?.getAttribute('data-id'));
-    if (entryId) el.addEventListener('click', () => handleToggleStar(entryId));
+    if (entryId) el.addEventListener('click', () => callbacks.onToggleStar(entryId));
   });
-  listEl.querySelectorAll('[data-action="delete"]').forEach((el) => {
+  container.querySelectorAll('[data-action="delete"]').forEach((el) => {
     const entryId = Number((el as HTMLElement).closest('.sqlite-entry')?.getAttribute('data-id'));
-    if (entryId) el.addEventListener('click', () => handleDelete(entryId));
+    if (entryId) el.addEventListener('click', () => callbacks.onDelete(entryId));
   });
 
   displayEntries.forEach(entry => {
-    const entryEl = listEl.querySelector(`.sqlite-entry[data-id="${entry.id}"] .sqlite-entry-header`);
+    const entryEl = container.querySelector(`.sqlite-entry[data-id="${entry.id}"] .sqlite-entry-header`);
     if (entryEl) {
       entryEl.appendChild(createCopyButton(entry));
     }
   });
 
-  // Wire tag filter buttons — server-side via loadData (preserve date range)
-  listEl.querySelectorAll('[data-action="content-toggle"]').forEach((el) => {
+  // Wire content toggle buttons
+  container.querySelectorAll('[data-action="content-toggle"]').forEach((el) => {
     el.addEventListener('click', () => {
       const controlsId = el.getAttribute('aria-controls');
       if (!controlsId) return;
-      const area = document.getElementById(controlsId);
-      if (!area) return;
-      const isHidden = area.classList.toggle('hidden');
-      el.setAttribute('aria-expanded', String(!isHidden));
-      const btn = el as HTMLButtonElement;
-      if (controlsId.startsWith('content-sent-')) {
-        btn.textContent = isHidden ? (t('historyShowSentData') || 'AIへ送信したデータ') : (t('historyHideSentData') || 'データを非表示');
-      } else if (controlsId.startsWith('content-received-')) {
-        btn.textContent = isHidden ? (t('historyShowReceivedData') || 'AIから受信したデータ') : (t('historyHideReceivedData') || 'データを非表示');
-      } else {
-        btn.textContent = isHidden ? t('historyShowContent') : t('historyHideContent');
-      }
+      callbacks.onContentToggle(controlsId);
     });
   });
 
-  listEl.querySelectorAll('[data-action="tag-filter"]').forEach((el) => {
+  // Wire tag filter buttons
+  container.querySelectorAll('[data-action="tag-filter"]').forEach((el) => {
     el.addEventListener('click', () => {
       const tag = (el as HTMLElement).getAttribute('data-tag');
       if (!tag) return;
-      const newFilter = state.activeTagFilter === tag ? null : tag;
-      state.activeTagFilter = newFilter;
-      state.currentPage = 0;
-      loadData({ page: 0, tagFilter: newFilter || undefined, ...dateRangeFromSelected() });
+      callbacks.onTagFilterClick(tag);
     });
   });
 }
 
-function renderPagination(): void {
-  const pagEl = document.getElementById('sqlite-pagination');
-  if (!pagEl) return;
-
-  const totalPages = Math.ceil(state.total / PAGE_SIZE);
+function renderPagination(
+  container: HTMLElement,
+  currentPage: number,
+  total: number,
+  pageSize: number,
+  onPageChange: (page: number) => void
+): void {
+  const totalPages = Math.ceil(total / pageSize);
   if (totalPages <= 1) {
-    pagEl.innerHTML = '';
+    container.innerHTML = '';
     return;
   }
 
-  pagEl.innerHTML = `
-    <button ${state.currentPage === 0 ? 'disabled' : ''} data-page="prev">${t('historyPrev')}</button>
-    <span>${t('historyPageInfo', [String(state.currentPage + 1), String(totalPages)])}</span>
-    <button ${state.currentPage >= totalPages - 1 ? 'disabled' : ''} data-page="next">${t('historyNext')}</button>
+  container.innerHTML = `
+    <button ${currentPage === 0 ? 'disabled' : ''} data-page="prev">${t('historyPrev')}</button>
+    <span>${t('historyPageInfo', [String(currentPage + 1), String(totalPages)])}</span>
+    <button ${currentPage >= totalPages - 1 ? 'disabled' : ''} data-page="next">${t('historyNext')}</button>
   `;
 
-  pagEl.querySelector('[data-page="prev"]')?.addEventListener('click', () => {
-    state.currentPage--;
-    reloadCurrent();
-  });
-  pagEl.querySelector('[data-page="next"]')?.addEventListener('click', () => {
-    state.currentPage++;
-    reloadCurrent();
-  });
+  container.querySelector('[data-page="prev"]')?.addEventListener('click', () => onPageChange(currentPage - 1));
+  container.querySelector('[data-page="next"]')?.addEventListener('click', () => onPageChange(currentPage + 1));
 }
 
-function renderCalendarNav(): void {
-  const navEl = document.getElementById('sqlite-calendar-nav');
-  if (!navEl) return;
-
+function renderCalendarNav(
+  container: HTMLElement,
+  selectedDate: string | null,
+  options: { searchQuery: string; activeTagFilter: string | null },
+  callbacks: {
+    onDateSelect: (d: string) => void;
+    onRangeSelect: (since: number, until: number) => void;
+    onClearFilters: () => void;
+  }
+): void {
   const now = new Date();
-  const currentMonth = state.selectedDate
-    ? new Date(state.selectedDate + 'T00:00:00')
+  const currentMonth = selectedDate
+    ? new Date(selectedDate + 'T00:00:00')
     : now;
 
   const year = currentMonth.getFullYear();
   const month = currentMonth.getMonth();
 
-  // Determine if any filter is active
-  const hasActiveFilters = Boolean(state.searchQuery.trim()) || state.selectedDate != null || state.activeTagFilter != null;
+  const hasActiveFilters = Boolean(options.searchQuery.trim()) || selectedDate != null || options.activeTagFilter != null;
 
-  // Generate quick date buttons: today, yesterday, this week, and month days
-  navEl.innerHTML = `
+  container.innerHTML = `
     <div class="sqlite-calendar-quick">
       <button data-date="${formatDate(now)}">${t('historyToday')}</button>
       <button data-date="${formatDate(new Date(now.getTime() - 86400000))}">${t('historyYesterday')}</button>
@@ -780,68 +847,51 @@ function renderCalendarNav(): void {
   `;
 
   // Quick buttons
-  navEl.querySelectorAll('[data-date]').forEach(el => {
+  container.querySelectorAll('[data-date]').forEach(el => {
     el.addEventListener('click', () => {
       const date = (el as HTMLElement).dataset.date!;
       const range = (el as HTMLElement).dataset.range;
       if (range) {
         const d = new Date(date + 'T00:00:00');
         const since = d.getTime() - (Number(range) * 86400000);
-        state.selectedDate = null;
-        state.searchQuery = '';
-        state.currentPage = 0;
-        loadData({ since, until: d.getTime() + 86400000 - 1 });
+        callbacks.onRangeSelect(since, d.getTime() + 86400000 - 1);
       } else {
-        handleDateSelect(date);
+        callbacks.onDateSelect(date);
       }
     });
   });
 
   // Month nav
-  navEl.querySelector('[data-month-prev]')?.addEventListener('click', () => {
+  container.querySelector('[data-month-prev]')?.addEventListener('click', () => {
     const d = new Date(year, month - 1, 1);
-    state.selectedDate = formatDate(d);
-    renderCalendarNav();
-    handleDateSelect(state.selectedDate!);
+    callbacks.onDateSelect(formatDate(d));
   });
-  navEl.querySelector('[data-month-next]')?.addEventListener('click', () => {
+  container.querySelector('[data-month-next]')?.addEventListener('click', () => {
     const d = new Date(year, month + 1, 1);
-    state.selectedDate = formatDate(d);
-    renderCalendarNav();
-    handleDateSelect(state.selectedDate!);
+    callbacks.onDateSelect(formatDate(d));
   });
 
   // Clear all filters button
-  navEl.querySelector('#sqlite-clear-all-filters')?.addEventListener('click', () => {
-    state.searchQuery = '';
-    state.selectedDate = null;
-    state.activeTagFilter = null;
-    state.currentPage = 0;
-
-    // Also clear the search input
+  container.querySelector('#sqlite-clear-all-filters')?.addEventListener('click', () => {
     const searchInput = document.getElementById('sqlite-search-input') as HTMLInputElement | null;
     if (searchInput) searchInput.value = '';
-
-    // loadData() calls refresh() internally, which already re-renders the
-    // calendar nav — no need to call renderCalendarNav()/renderState() here too.
-    loadData({ page: 0 });
+    callbacks.onClearFilters();
   });
 
   // Render days of the month
-  const daysEl = document.getElementById('sqlite-calendar-days');
+  const daysEl = container.querySelector('#sqlite-calendar-days');
   if (!daysEl) return;
 
   const daysInMonth = new Date(year, month + 1, 0).getDate();
   const firstDay = new Date(year, month, 1).getDay();
 
   let daysHtml = '';
-  // Empty cells for days before the 1st
   for (let i = 0; i < firstDay; i++) {
     daysHtml += '<span class="day empty" aria-hidden="true"></span>';
   }
   for (let d = 1; d <= daysInMonth; d++) {
     const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
-    const isSelected = dateStr === state.selectedDate;
+    const isSelected = dateStr === selectedDate;
     const isToday = dateStr === formatDate(now);
     const dateLabel = `${year}${t('historyDateYear')}${month + 1}${t('historyDateMonth')}${d}${t('historyDateDay')}`;
     daysHtml += `<button type="button" class="day${isSelected ? ' selected' : ''}${isToday ? ' today' : ''}"
@@ -851,7 +901,7 @@ function renderCalendarNav(): void {
 
   daysEl.querySelectorAll('.day:not(.empty)').forEach(el => {
     el.addEventListener('click', () => {
-      handleDateSelect((el as HTMLElement).dataset.date!);
+      callbacks.onDateSelect((el as HTMLElement).dataset.date!);
     });
   });
 }

--- a/src/dashboard/tagClusterPanel.ts
+++ b/src/dashboard/tagClusterPanel.ts
@@ -150,7 +150,7 @@ async function loadRowsWithRetry(): Promise<BrowsingLogEntry[]> {
         return null; // Not ready yet — retry
       }
       const queryResult = await queryLogs({ limit: 10000 });
-      return queryResult?.rows ?? [];
+      return (queryResult && 'rows' in queryResult ? queryResult.rows : null) ?? [];
     },
     { label: 'tagCluster', maxAttempts: 4 }
   );

--- a/src/offscreen/FallbackStorageAdapter.ts
+++ b/src/offscreen/FallbackStorageAdapter.ts
@@ -1,0 +1,96 @@
+// src/offscreen/FallbackStorageAdapter.ts
+import type { StorageBackend, InsertResult, InsertBatchResult, QueryResult, SearchResult, MutationResult, StarResult, PurgeResult, FtsSizeResult, BackupResult, CountResult, HealthResult, AuditLogQueryResult, StatusResult, BackendOrError } from './StorageBackend.js';
+import { FallbackStorage } from './storageFallback.js';
+import type { BrowsingLogRecord, QueryOptions, AuditLogRecord } from '../utils/sqlite-types.js';
+
+export class FallbackStorageAdapter implements StorageBackend {
+  constructor(private fallback: FallbackStorage) {}
+
+  async insert(record: BrowsingLogRecord): Promise<BackendOrError<InsertResult>> {
+    return this.fallback.insert(record);
+  }
+
+  async insertBatch(records: BrowsingLogRecord[]): Promise<BackendOrError<InsertBatchResult>> {
+    const result = await this.fallback.insertBatch(records);
+    if (!result.success) return result;
+    return { success: true, inserted: result.count, skipped: records.length - result.count };
+  }
+
+  async query(options: QueryOptions): Promise<BackendOrError<QueryResult>> {
+    const result = await this.fallback.query(options);
+    if (!result.success) return result;
+    return { success: true, rows: result.rows as QueryResult['rows'], total: result.total };
+  }
+
+  async search(query: string, limit: number, offset: number): Promise<BackendOrError<SearchResult>> {
+    const result = await this.fallback.search(query, limit, offset);
+    if (!result.success) return result;
+    return { success: true, rows: result.rows as SearchResult['rows'], total: result.total };
+  }
+
+  async update(id: number, changes: Record<string, unknown>): Promise<BackendOrError<MutationResult>> {
+    const ok = await this.fallback.update(id, changes);
+    if (!ok.success) return ok;
+    return { success: true };
+  }
+
+  async delete(id: number): Promise<BackendOrError<MutationResult>> {
+    const ok = await this.fallback.hardDelete(id);
+    if (!ok.success) return ok;
+    return { success: true };
+  }
+
+  async toggleStar(id: number): Promise<BackendOrError<StarResult>> {
+    return this.fallback.toggleStar(id);
+  }
+
+  async purgeOldRecords(retentionDays: number, maxRecords: number): Promise<BackendOrError<PurgeResult>> {
+    return this.fallback.purgeOldRecords(retentionDays, maxRecords);
+  }
+
+  async purgeContent(retentionDays?: number, maxRecords?: number, includeStarred?: boolean): Promise<BackendOrError<PurgeResult>> {
+    return this.fallback.purgeContent(retentionDays, maxRecords, includeStarred);
+  }
+
+  async getFtsIndexSize(): Promise<BackendOrError<FtsSizeResult>> {
+    return { success: true, count: 0 };
+  }
+
+  async backupDb(): Promise<BackendOrError<BackupResult>> {
+    return { success: false, error: 'Binary backup requires OPFS storage.' };
+  }
+
+  async restoreDb(_data: Uint8Array): Promise<BackendOrError<MutationResult>> {
+    return { success: false, error: 'Binary restore requires OPFS storage.' };
+  }
+
+  async healthCheck(): Promise<BackendOrError<HealthResult>> {
+    const ok = await this.fallback.healthCheck();
+    if (!ok) return { success: false, error: 'Fallback storage unavailable' };
+    return { success: true };
+  }
+
+  async getStatus(): Promise<BackendOrError<StatusResult>> {
+    return { success: true as const, initialized: true, fallback: true, fts5: false, supportsBinaryBackup: false } as unknown as BackendOrError<StatusResult>;
+  }
+
+  async insertAuditLog(_record: AuditLogRecord): Promise<BackendOrError<InsertResult>> {
+    return { success: false, error: 'Audit log not supported in fallback mode' };
+  }
+
+  async queryAuditLog(_options?: { limit?: number; offset?: number }): Promise<BackendOrError<AuditLogQueryResult>> {
+    return { success: false, error: 'Audit log not supported in fallback mode' };
+  }
+
+  async getCount(): Promise<BackendOrError<CountResult>> {
+    const result = await this.fallback.getCount();
+    if (!result.success) return result;
+    return { success: true, count: result.count };
+  }
+
+  async clearAll(): Promise<BackendOrError<MutationResult>> {
+    const result = await this.fallback.clearAll();
+    if (!result.success) return { success: false, error: result.error ?? 'clearAll failed' };
+    return { success: true };
+  }
+}

--- a/src/offscreen/FallbackStorageAdapter.ts
+++ b/src/offscreen/FallbackStorageAdapter.ts
@@ -71,7 +71,7 @@ export class FallbackStorageAdapter implements StorageBackend {
   }
 
   async getStatus(): Promise<BackendOrError<StatusResult>> {
-    return { success: true as const, initialized: true, fallback: true, fts5: false, supportsBinaryBackup: false } as unknown as BackendOrError<StatusResult>;
+    return { initialized: true, fallback: true, fts5: false, supportsBinaryBackup: false };
   }
 
   async insertAuditLog(_record: AuditLogRecord): Promise<BackendOrError<InsertResult>> {

--- a/src/offscreen/IdbVfsBackend.ts
+++ b/src/offscreen/IdbVfsBackend.ts
@@ -1,0 +1,433 @@
+// src/offscreen/IdbVfsBackend.ts
+import type { SqliteEngineContext, SqliteValue } from './sqliteEngineContext.js';
+import type {
+  StorageBackend, InsertResult, InsertBatchResult, QueryResult,
+  SearchResult, MutationResult, StarResult, PurgeResult, FtsSizeResult,
+  BackupResult, CountResult, HealthResult, AuditLogQueryResult,
+  StatusResult, BackendOrError,
+} from './StorageBackend.js';
+import type { BrowsingLogRecord, BrowsingLogEntry, QueryOptions, AuditLogRecord, AuditLogEntry } from '../utils/sqlite-types.js';
+import { INSERT_SQL, INSERT_IGNORE_SQL, buildInsertParams, UPDATABLE_FIELDS } from './schema.js';
+import { sanitizeFtsTerm } from './schema.js';
+import { extractDomain } from './sqliteEngineContext.js';
+
+export class IdbVfsBackend implements StorageBackend {
+  constructor(private engine: SqliteEngineContext) {}
+
+  private ensureDb(): void {
+    if (!this.engine.dbHandle) throw new Error('IDB VFS database not initialized');
+  }
+
+  async insert(record: BrowsingLogRecord): Promise<BackendOrError<InsertResult>> {
+    this.ensureDb();
+    const domain = record.domain || extractDomain(record.url);
+    const params = buildInsertParams(record, domain);
+    await this.engine.execWithCache(INSERT_SQL, params);
+    let id = 0;
+    await this.engine.execWithCache('SELECT last_insert_rowid()', [], (row: SqliteValue[]) => { id = Number(row[0]); });
+    return { success: true, id };
+  }
+
+  async insertBatch(records: BrowsingLogRecord[]): Promise<BackendOrError<InsertBatchResult>> {
+    this.ensureDb();
+    if (records.length === 0) return { success: true, inserted: 0, skipped: 0 };
+
+    let inserted = 0;
+    let skipped = 0;
+    await this.engine.execWithCache('BEGIN IMMEDIATE');
+    try {
+      for (const record of records) {
+        const domain = record.domain || extractDomain(record.url);
+        await this.engine.execWithCache(INSERT_IGNORE_SQL, buildInsertParams(record, domain));
+        let changed = 0;
+        await this.engine.execWithCache('SELECT changes()', [], (row: SqliteValue[]) => { changed = Number(row[0]); });
+        if (changed > 0) inserted++;
+        else skipped++;
+      }
+      await this.engine.execWithCache('COMMIT');
+      return { success: true, inserted, skipped };
+    } catch (error) {
+      await this.engine.execWithCache('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async query(options: QueryOptions): Promise<BackendOrError<QueryResult>> {
+    this.ensureDb();
+    const limit = Math.min(options.limit ?? 100, 1000);
+    const offset = options.offset ?? 0;
+    const conditions: string[] = ['is_deleted = 0'];
+    const params: SqliteValue[] = [];
+
+    if (options.since != null) { conditions.push('created_at >= ?'); params.push(options.since); }
+    if (options.until != null) { conditions.push('created_at <= ?'); params.push(options.until); }
+    if (options.domain) { conditions.push('domain = ?'); params.push(options.domain); }
+    if (options.isStarred != null) { conditions.push('is_starred = ?'); params.push(options.isStarred ? 1 : 0); }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const orderBy = options.orderBy || 'created_at';
+    const orderDir = options.orderDir || 'DESC';
+
+    const rows: BrowsingLogEntry[] = [];
+    await this.engine.execWithCache(
+      `SELECT * FROM browsing_logs ${where} ORDER BY ${orderBy} ${orderDir} LIMIT ? OFFSET ?`,
+      [...params, limit, offset],
+      (row: SqliteValue[]) => { rows.push(this.rowToEntry(row)); }
+    );
+
+    let total = 0;
+    await this.engine.execWithCache(
+      `SELECT COUNT(*) FROM browsing_logs ${where}`,
+      params,
+      (row: SqliteValue[]) => { total = Number(row[0]); }
+    );
+
+    return { success: true, rows, total };
+  }
+
+  async search(searchQuery: string, limit: number, offset: number): Promise<BackendOrError<SearchResult>> {
+    this.ensureDb();
+    const capLimit = Math.min(limit, 100000);
+    const bare = sanitizeFtsTerm(searchQuery);
+    if (!bare) {
+      return { success: true, rows: [], total: 0 };
+    }
+
+    const charLen = [...bare].length;
+    if (this.engine.fts5Available && charLen >= 3) {
+      const ftsQuery = `"${bare}"`;
+      let total = 0;
+      await this.engine.execWithCache(
+        `SELECT COUNT(*) FROM browsing_logs_fts WHERE browsing_logs_fts MATCH ?`,
+        [ftsQuery],
+        (row: SqliteValue[]) => { total = Number(row[0]); }
+      );
+
+      const rows: (BrowsingLogEntry & { rank: number })[] = [];
+      await this.engine.execWithCache(
+        `SELECT b.id, b.url, b.title, b.summary, b.tags, b.created_at, b.domain, b.visit_duration, b.scroll_ratio, b.is_starred, rank
+         FROM browsing_logs_fts
+         JOIN browsing_logs b ON browsing_logs_fts.rowid = b.id
+         WHERE browsing_logs_fts MATCH ? AND b.is_deleted = 0
+         ORDER BY rank
+         LIMIT ? OFFSET ?`,
+        [ftsQuery, capLimit, offset],
+        (row: SqliteValue[]) => {
+          rows.push({
+            id: Number(row[0]), url: String(row[1]),
+            title: row[2] != null ? String(row[2]) : null,
+            summary: row[3] != null ? String(row[3]) : null,
+            tags: row[4] != null ? String(row[4]) : null,
+            created_at: Number(row[5]),
+            domain: row[6] != null ? String(row[6]) : null,
+            visit_duration: row[7] != null ? Number(row[7]) : null,
+            scroll_ratio: row[8] != null ? Number(row[8]) : null,
+            is_starred: Number(row[9]),
+            rank: Number(row[10]),
+          });
+        }
+      );
+      return { success: true, rows, total };
+    }
+
+    const likePattern = `%${searchQuery}%`;
+    let total = 0;
+    await this.engine.execWithCache(
+      `SELECT COUNT(*) FROM browsing_logs WHERE is_deleted = 0 AND (url LIKE ? OR title LIKE ? OR summary LIKE ? OR tags LIKE ?)`,
+      [likePattern, likePattern, likePattern, likePattern],
+      (row: SqliteValue[]) => { total = Number(row[0]); }
+    );
+
+    const rows: (BrowsingLogEntry & { rank: number })[] = [];
+    await this.engine.execWithCache(
+      `SELECT id, url, title, summary, tags, created_at, domain, visit_duration, scroll_ratio, is_starred
+       FROM browsing_logs
+       WHERE is_deleted = 0 AND (url LIKE ? OR title LIKE ? OR summary LIKE ? OR tags LIKE ?)
+       ORDER BY created_at DESC
+       LIMIT ? OFFSET ?`,
+      [likePattern, likePattern, likePattern, likePattern, capLimit, offset],
+      (row: SqliteValue[]) => {
+        rows.push({
+          id: Number(row[0]), url: String(row[1]),
+          title: row[2] != null ? String(row[2]) : null,
+          summary: row[3] != null ? String(row[3]) : null,
+          tags: row[4] != null ? String(row[4]) : null,
+          created_at: Number(row[5]),
+          domain: row[6] != null ? String(row[6]) : null,
+          visit_duration: row[7] != null ? Number(row[7]) : null,
+          scroll_ratio: row[8] != null ? Number(row[8]) : null,
+          is_starred: Number(row[9]),
+          rank: 0,
+        });
+      }
+    );
+
+    return { success: true, rows, total };
+  }
+
+  async update(id: number, changes: Record<string, unknown>): Promise<BackendOrError<MutationResult>> {
+    this.ensureDb();
+    const setClauses: string[] = [];
+    const params: SqliteValue[] = [];
+
+    for (const field of UPDATABLE_FIELDS) {
+      const f = field as keyof BrowsingLogRecord;
+      if (f in changes) {
+        setClauses.push(`${f} = ?`);
+        params.push((changes[f] ?? null) as SqliteValue);
+      }
+    }
+
+    if (setClauses.length === 0) {
+      return { success: true };
+    }
+
+    params.push(id);
+    await this.engine.execWithCache(
+      `UPDATE browsing_logs SET ${setClauses.join(', ')} WHERE id = ?`,
+      params
+    );
+
+    return { success: true };
+  }
+
+  async delete(id: number): Promise<BackendOrError<MutationResult>> {
+    this.ensureDb();
+    await this.engine.execWithCache('DELETE FROM browsing_logs WHERE id = ?', [id]);
+    return { success: true };
+  }
+
+  async toggleStar(id: number): Promise<BackendOrError<StarResult>> {
+    this.ensureDb();
+    await this.engine.execWithCache(
+      'UPDATE browsing_logs SET is_starred = CASE WHEN is_starred = 0 THEN 1 ELSE 0 END WHERE id = ?',
+      [id]
+    );
+    let newStarred = 0;
+    await this.engine.execWithCache(
+      'SELECT is_starred FROM browsing_logs WHERE id = ?',
+      [id],
+      (row: SqliteValue[]) => { newStarred = Number(row[0]); }
+    );
+    return { success: true, is_starred: newStarred };
+  }
+
+  async purgeOldRecords(retentionDays: number, maxRecords: number): Promise<BackendOrError<PurgeResult>> {
+    this.ensureDb();
+    const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+    let totalPurged = 0;
+
+    await this.engine.execWithCache(
+      `DELETE FROM browsing_logs WHERE created_at < ? AND is_starred = 0 AND is_deleted = 0`,
+      [cutoffMs]
+    );
+    let changes1 = 0;
+    await this.engine.execWithCache('SELECT changes()', [], (row: SqliteValue[]) => { changes1 = Number(row[0]); });
+    totalPurged += changes1;
+
+    let totalCount = 0;
+    await this.engine.execWithCache(
+      'SELECT COUNT(*) FROM browsing_logs WHERE is_deleted = 0',
+      [],
+      (row: SqliteValue[]) => { totalCount = Number(row[0]); }
+    );
+
+    if (totalCount > maxRecords) {
+      const excess = totalCount - maxRecords;
+      await this.engine.execWithCache(
+        `DELETE FROM browsing_logs WHERE id IN (
+          SELECT id FROM browsing_logs WHERE is_starred = 0 AND is_deleted = 0
+          ORDER BY created_at ASC LIMIT ?
+        )`,
+        [excess]
+      );
+      let changes2 = 0;
+      await this.engine.execWithCache('SELECT changes()', [], (row: SqliteValue[]) => { changes2 = Number(row[0]); });
+      totalPurged += changes2;
+    }
+
+    return { success: true, purged: totalPurged };
+  }
+
+  async purgeContent(retentionDays?: number, maxRecords?: number, includeStarred?: boolean): Promise<BackendOrError<PurgeResult>> {
+    this.ensureDb();
+    const starredClause = includeStarred ? '' : 'AND is_starred = 0';
+    let totalPurged = 0;
+
+    if (retentionDays != null && retentionDays > 0) {
+      const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+      await this.engine.execWithCache(
+        `UPDATE browsing_logs SET content = NULL
+         WHERE content IS NOT NULL AND created_at < ? ${starredClause}`,
+        [cutoffMs]
+      );
+      let changes1 = 0;
+      await this.engine.execWithCache('SELECT changes()', [], (row: SqliteValue[]) => { changes1 = Number(row[0]); });
+      totalPurged += changes1;
+    }
+
+    if (maxRecords != null && maxRecords > 0) {
+      let count = 0;
+      await this.engine.execWithCache(
+        `SELECT COUNT(*) FROM browsing_logs WHERE content IS NOT NULL ${starredClause}`,
+        [],
+        (row: SqliteValue[]) => { count = Number(row[0]); }
+      );
+
+      if (count > maxRecords) {
+        const excess = count - maxRecords;
+        await this.engine.execWithCache(
+          `UPDATE browsing_logs SET content = NULL
+           WHERE id IN (
+             SELECT id FROM browsing_logs
+             WHERE content IS NOT NULL ${starredClause}
+             ORDER BY created_at ASC
+             LIMIT ?
+           )`,
+          [excess]
+        );
+        let changes2 = 0;
+        await this.engine.execWithCache('SELECT changes()', [], (row: SqliteValue[]) => { changes2 = Number(row[0]); });
+        totalPurged += changes2;
+      }
+    }
+
+    return { success: true, purged: totalPurged };
+  }
+
+  async getFtsIndexSize(): Promise<BackendOrError<FtsSizeResult>> {
+    this.ensureDb();
+    let count = 0;
+    await this.engine.execWithCache(
+      'SELECT COUNT(*) FROM browsing_logs_fts',
+      [],
+      (row: SqliteValue[]) => { count = Number(row[0]); }
+    );
+    return { success: true, count };
+  }
+
+  async backupDb(): Promise<BackendOrError<BackupResult>> {
+    return { success: false, error: 'Binary backup requires OPFS storage.' };
+  }
+
+  async restoreDb(_data: Uint8Array): Promise<BackendOrError<MutationResult>> {
+    return { success: false, error: 'Binary restore requires OPFS storage.' };
+  }
+
+  async healthCheck(): Promise<BackendOrError<HealthResult>> {
+    this.ensureDb();
+    let ok = false;
+    await this.engine.execWithCache('SELECT 1', [], () => { ok = true; });
+    if (ok) return { success: true };
+    return { success: false, error: 'Health check failed' };
+  }
+
+  async getStatus(): Promise<BackendOrError<StatusResult>> {
+    this.ensureDb();
+    return {
+      success: true as const,
+      initialized: true,
+      fallback: false,
+      fts5: this.engine.fts5Available,
+      supportsBinaryBackup: false,
+      compileOptions: this.engine.cachedCompileOptions ?? undefined,
+      compileOptionsSource: 'idb',
+    } as unknown as BackendOrError<StatusResult>;
+  }
+
+  async insertAuditLog(record: AuditLogRecord): Promise<BackendOrError<InsertResult>> {
+    this.ensureDb();
+    await this.engine.execWithCache(
+      `INSERT INTO audit_log (provider, url, created_at) VALUES (?, ?, ?)`,
+      [record.provider, record.url, record.created_at]
+    );
+    let newId = 0;
+    await this.engine.execWithCache('SELECT last_insert_rowid()', [], (row: SqliteValue[]) => {
+      newId = Number(row[0]);
+    });
+    return { success: true, id: newId };
+  }
+
+  async queryAuditLog(options: { limit?: number; offset?: number }): Promise<BackendOrError<AuditLogQueryResult>> {
+    this.ensureDb();
+    const limit = Math.min(options.limit ?? 100, 100000);
+    const offset = options.offset ?? 0;
+
+    const rows: AuditLogEntry[] = [];
+    await this.engine.execWithCache(
+      `SELECT id, provider, url, created_at FROM audit_log ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      [limit, offset],
+      (row: SqliteValue[]) => {
+        rows.push({
+          id: Number(row[0]),
+          provider: String(row[1]),
+          url: String(row[2]),
+          created_at: Number(row[3]),
+        });
+      }
+    );
+
+    let total = 0;
+    await this.engine.execWithCache('SELECT COUNT(*) FROM audit_log', [], (row: SqliteValue[]) => {
+      total = Number(row[0]);
+    });
+
+    return { success: true, rows, total };
+  }
+
+  async getCount(): Promise<BackendOrError<CountResult>> {
+    this.ensureDb();
+    let count = 0;
+    await this.engine.execWithCache(
+      'SELECT COUNT(*) FROM browsing_logs WHERE is_deleted = 0',
+      [],
+      (row: SqliteValue[]) => { count = Number(row[0]); }
+    );
+    return { success: true, count };
+  }
+
+  async clearAll(): Promise<BackendOrError<MutationResult>> {
+    this.ensureDb();
+    await this.engine.execWithCache('DELETE FROM browsing_logs');
+    await this.engine.execWithCache('DELETE FROM browsing_logs_fts');
+    await this.engine.execWithCache('PRAGMA wal_checkpoint(TRUNCATE)');
+    return { success: true };
+  }
+
+  private rowToEntry(row: SqliteValue[]): BrowsingLogEntry {
+    return {
+      id: Number(row[0]),
+      url: String(row[1]),
+      title: row[2] != null ? String(row[2]) : null,
+      summary: row[3] != null ? String(row[3]) : null,
+      tags: row[4] != null ? String(row[4]) : null,
+      created_at: Number(row[5]),
+      domain: row[6] != null ? String(row[6]) : null,
+      visit_duration: row[7] != null ? Number(row[7]) : null,
+      scroll_ratio: row[8] != null ? Number(row[8]) : null,
+      is_starred: Number(row[9]),
+      obsidian_synced: Number(row[11]),
+      gist_synced: Number(row[12]),
+      content: row[13] != null ? String(row[13]) : null,
+      masked_count: row[14] != null ? Number(row[14]) : null,
+      cleansed_reason: row[15] != null ? String(row[15]) : null,
+      ai_provider: row[16] != null ? String(row[16]) : null,
+      ai_model: row[17] != null ? String(row[17]) : null,
+      ai_duration_ms: row[18] != null ? Number(row[18]) : null,
+      obsidian_duration_ms: row[19] != null ? Number(row[19]) : null,
+      sent_tokens: row[20] != null ? Number(row[20]) : null,
+      received_tokens: row[21] != null ? Number(row[21]) : null,
+      original_tokens: row[22] != null ? Number(row[22]) : null,
+      cleansed_tokens: row[23] != null ? Number(row[23]) : null,
+      page_bytes: row[24] != null ? Number(row[24]) : null,
+      candidate_bytes: row[25] != null ? Number(row[25]) : null,
+      original_bytes: row[26] != null ? Number(row[26]) : null,
+      cleansed_bytes: row[27] != null ? Number(row[27]) : null,
+      ai_summary_original_bytes: row[28] != null ? Number(row[28]) : null,
+      ai_summary_cleansed_bytes: row[29] != null ? Number(row[29]) : null,
+      extracted_sentences_bytes: row[30] != null ? Number(row[30]) : null,
+      extracted_sentences_original_bytes: row[31] != null ? Number(row[31]) : null,
+      fallback_triggered: Number(row[32]),
+    };
+  }
+}

--- a/src/offscreen/IdbVfsBackend.ts
+++ b/src/offscreen/IdbVfsBackend.ts
@@ -325,14 +325,13 @@ export class IdbVfsBackend implements StorageBackend {
   async getStatus(): Promise<BackendOrError<StatusResult>> {
     this.ensureDb();
     return {
-      success: true as const,
       initialized: true,
       fallback: false,
       fts5: this.engine.fts5Available,
       supportsBinaryBackup: false,
       compileOptions: this.engine.cachedCompileOptions ?? undefined,
       compileOptionsSource: 'idb',
-    } as unknown as BackendOrError<StatusResult>;
+    };
   }
 
   async insertAuditLog(record: AuditLogRecord): Promise<BackendOrError<InsertResult>> {
@@ -406,6 +405,7 @@ export class IdbVfsBackend implements StorageBackend {
       visit_duration: row[7] != null ? Number(row[7]) : null,
       scroll_ratio: row[8] != null ? Number(row[8]) : null,
       is_starred: Number(row[9]),
+      is_deleted: Number(row[10]),
       obsidian_synced: Number(row[11]),
       gist_synced: Number(row[12]),
       content: row[13] != null ? String(row[13]) : null,

--- a/src/offscreen/OpfsWorkerBackend.ts
+++ b/src/offscreen/OpfsWorkerBackend.ts
@@ -1,0 +1,109 @@
+// src/offscreen/OpfsWorkerBackend.ts
+import type { SqliteEngineContext } from './sqliteEngineContext.js';
+import type { StorageBackend, InsertResult, InsertBatchResult, QueryResult, SearchResult, MutationResult, StarResult, PurgeResult, FtsSizeResult, BackupResult, CountResult, HealthResult, AuditLogQueryResult, StatusResult, BackendOrError } from './StorageBackend.js';
+import type { BrowsingLogRecord, BrowsingLogEntry, QueryOptions, AuditLogRecord, AuditLogEntry } from '../utils/sqlite-types.js';
+
+export class OpfsWorkerBackend implements StorageBackend {
+  constructor(private engine: SqliteEngineContext) {}
+
+  async insert(record: BrowsingLogRecord): Promise<BackendOrError<InsertResult>> {
+    const result = await this.engine.sendToOpfsWorker('INSERT', record) as { id: number };
+    return { success: true, id: result.id };
+  }
+
+  async insertBatch(records: BrowsingLogRecord[]): Promise<BackendOrError<InsertBatchResult>> {
+    const result = await this.engine.sendToOpfsWorker('INSERT_BATCH', records) as { inserted: number; skipped: number };
+    return { success: true, inserted: result.inserted, skipped: result.skipped };
+  }
+
+  async query(options: QueryOptions): Promise<BackendOrError<QueryResult>> {
+    const result = await this.engine.tryOpfsProxy<{ rows: BrowsingLogRecord[]; total: number }>('QUERY', options);
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, rows: result.rows as BrowsingLogEntry[], total: result.total };
+  }
+
+  async search(query: string, limit: number, offset: number): Promise<BackendOrError<SearchResult>> {
+    const result = await this.engine.tryOpfsProxy<{ rows: (BrowsingLogRecord & { rank: number })[]; total: number }>('SEARCH', { searchQuery: query, limit, offset });
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, rows: result.rows as (BrowsingLogEntry & { rank: number })[], total: result.total };
+  }
+
+  async update(id: number, changes: Record<string, unknown>): Promise<BackendOrError<MutationResult>> {
+    await this.engine.sendToOpfsWorker('UPDATE', { id, changes });
+    return { success: true };
+  }
+
+  async delete(id: number): Promise<BackendOrError<MutationResult>> {
+    await this.engine.sendToOpfsWorker('DELETE', { id });
+    return { success: true };
+  }
+
+  async toggleStar(id: number): Promise<BackendOrError<StarResult>> {
+    const result = await this.engine.sendToOpfsWorker('TOGGLE_STAR', { id }) as { is_starred: number };
+    return { success: true, is_starred: result.is_starred };
+  }
+
+  async purgeOldRecords(retentionDays: number, maxRecords: number): Promise<BackendOrError<PurgeResult>> {
+    const result = await this.engine.tryOpfsProxy<{ purged: number }>('PURGE', { retentionDays, maxRecords });
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, purged: result.purged };
+  }
+
+  async purgeContent(retentionDays?: number, maxRecords?: number, includeStarred?: boolean): Promise<BackendOrError<PurgeResult>> {
+    const result = await this.engine.tryOpfsProxy<{ purged: number }>('CONTENT_PURGE', { retentionDays, maxRecords, includeStarred });
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, purged: result.purged };
+  }
+
+  async getFtsIndexSize(): Promise<BackendOrError<FtsSizeResult>> {
+    const result = await this.engine.tryOpfsProxy<{ count: number }>('FTS_INDEX_SIZE');
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, count: result.count };
+  }
+
+  async backupDb(): Promise<BackendOrError<BackupResult>> {
+    const result = await this.engine.tryOpfsProxy<Uint8Array>('BACKUP');
+    if (result === null || result.length === 0) return { success: false, error: 'Binary backup failed' };
+    return { success: true, data: result };
+  }
+
+  async restoreDb(data: Uint8Array): Promise<BackendOrError<MutationResult>> {
+    const result = await this.engine.tryOpfsProxy<{ restored: boolean }>('RESTORE', { data });
+    if (result && result.restored) return { success: true };
+    return { success: false, error: 'Binary restore failed' };
+  }
+
+  async healthCheck(): Promise<BackendOrError<HealthResult>> {
+    const result = await this.engine.tryOpfsProxy<{ ok: boolean }>('HEALTH_CHECK');
+    if (result !== null && result.ok) return { success: true };
+    return { success: false, error: 'Health check failed' };
+  }
+
+  async getStatus(): Promise<BackendOrError<StatusResult>> {
+    const result = await this.engine.tryOpfsProxy<StatusResult>('STATUS');
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true as const, ...result } as unknown as BackendOrError<StatusResult>;
+  }
+
+  async insertAuditLog(record: AuditLogRecord): Promise<BackendOrError<InsertResult>> {
+    const result = await this.engine.sendToOpfsWorker('AUDIT_LOG_INSERT', record) as { id: number };
+    return { success: true, id: result.id };
+  }
+
+  async queryAuditLog(options: { limit?: number; offset?: number }): Promise<BackendOrError<AuditLogQueryResult>> {
+    const result = await this.engine.tryOpfsProxy<{ rows: AuditLogRecord[]; total: number }>('AUDIT_LOG_QUERY', options);
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, rows: result.rows as AuditLogEntry[], total: result.total };
+  }
+
+  async getCount(): Promise<BackendOrError<CountResult>> {
+    const result = await this.engine.tryOpfsProxy<{ count: number }>('GET_COUNT');
+    if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
+    return { success: true, count: result.count };
+  }
+
+  async clearAll(): Promise<BackendOrError<MutationResult>> {
+    await this.engine.sendToOpfsWorker('CLEAR_ALL', {});
+    return { success: true };
+  }
+}

--- a/src/offscreen/OpfsWorkerBackend.ts
+++ b/src/offscreen/OpfsWorkerBackend.ts
@@ -82,7 +82,7 @@ export class OpfsWorkerBackend implements StorageBackend {
   async getStatus(): Promise<BackendOrError<StatusResult>> {
     const result = await this.engine.tryOpfsProxy<StatusResult>('STATUS');
     if (result === null) return { success: false, error: 'OPFS Worker unavailable' };
-    return { success: true as const, ...result } as unknown as BackendOrError<StatusResult>;
+    return result;
   }
 
   async insertAuditLog(record: AuditLogRecord): Promise<BackendOrError<InsertResult>> {

--- a/src/offscreen/StorageBackend.ts
+++ b/src/offscreen/StorageBackend.ts
@@ -1,0 +1,70 @@
+import type { BrowsingLogRecord, BrowsingLogEntry, QueryOptions, SearchResult as SearchResultType, AuditLogRecord, AuditLogEntry } from '../utils/sqlite-types.js';
+
+export interface InsertResult { success: true; id: number }
+export interface InsertBatchResult { success: true; inserted: number; skipped: number }
+export interface QueryResult { success: true; rows: BrowsingLogEntry[]; total: number }
+export interface SearchResult { success: true; rows: (BrowsingLogEntry & { rank: number })[]; total: number }
+export interface MutationResult { success: true }
+export interface StarResult { success: true; is_starred: number }
+export interface PurgeResult { success: true; purged: number }
+export interface FtsSizeResult { success: true; count: number }
+export interface BackupResult { success: true; data: Uint8Array }
+export interface CountResult { success: true; count: number }
+export interface HealthResult { success: true } // healthCheck — success means alive, failure means error
+export interface AuditLogQueryResult { success: true; rows: AuditLogEntry[]; total: number }
+export type BackendOrError<T> = T | { success: false; error: string };
+
+export interface StatusResult {
+  initialized: boolean;
+  fallback: boolean;
+  fts5: boolean;
+  supportsBinaryBackup: boolean;
+  compileOptions?: string[];
+  compileOptionsSource?: 'opfs-worker' | 'idb' | 'fallback';
+  initError?: string;
+}
+
+export interface StorageBackend {
+  insert(record: BrowsingLogRecord): Promise<BackendOrError<InsertResult>>;
+  insertBatch(records: BrowsingLogRecord[]): Promise<BackendOrError<InsertBatchResult>>;
+  query(options: QueryOptions): Promise<BackendOrError<QueryResult>>;
+  search(query: string, limit: number, offset: number): Promise<BackendOrError<SearchResult>>;
+  update(id: number, changes: Record<string, unknown>): Promise<BackendOrError<MutationResult>>;
+  delete(id: number): Promise<BackendOrError<MutationResult>>;
+  toggleStar(id: number): Promise<BackendOrError<StarResult>>;
+  purgeOldRecords(retentionDays: number, maxRecords: number): Promise<BackendOrError<PurgeResult>>;
+  purgeContent(retentionDays?: number, maxRecords?: number, includeStarred?: boolean): Promise<BackendOrError<PurgeResult>>;
+  getFtsIndexSize(): Promise<BackendOrError<FtsSizeResult>>;
+  backupDb(): Promise<BackendOrError<BackupResult>>;
+  restoreDb(data: Uint8Array): Promise<BackendOrError<MutationResult>>;
+  healthCheck(): Promise<BackendOrError<HealthResult>>;
+  getStatus(): Promise<BackendOrError<StatusResult>>;
+  insertAuditLog(record: AuditLogRecord): Promise<BackendOrError<InsertResult>>;
+  queryAuditLog(options: { limit?: number; offset?: number }): Promise<BackendOrError<AuditLogQueryResult>>;
+  getCount(): Promise<BackendOrError<CountResult>>;
+  clearAll(): Promise<BackendOrError<MutationResult>>;
+}
+
+const NOT_INITIALIZED = 'Database not initialized';
+
+export class NoopBackend implements StorageBackend {
+  private err = (): { success: false; error: string } => ({ success: false, error: NOT_INITIALIZED });
+  async insert() { return this.err(); }
+  async insertBatch() { return this.err(); }
+  async query() { return this.err(); }
+  async search() { return this.err(); }
+  async update() { return this.err(); }
+  async delete() { return this.err(); }
+  async toggleStar() { return this.err(); }
+  async purgeOldRecords() { return this.err(); }
+  async purgeContent() { return this.err(); }
+  async getFtsIndexSize() { return this.err(); }
+  async backupDb() { return this.err(); }
+  async restoreDb() { return this.err(); }
+  async healthCheck() { return this.err(); }
+  async getStatus() { return this.err(); }
+  async insertAuditLog() { return this.err(); }
+  async queryAuditLog() { return this.err(); }
+  async getCount() { return this.err(); }
+  async clearAll() { return this.err(); }
+}

--- a/src/offscreen/__tests__/sqlite-migration-errors.test.ts
+++ b/src/offscreen/__tests__/sqlite-migration-errors.test.ts
@@ -91,7 +91,7 @@ describe('ALTER TABLE migration error handling', () => {
     vi.unstubAllGlobals();
   });
 
-  it('logs a warning for non-duplicate-column ALTER TABLE errors', async () => {
+  it('re-throws non-duplicate-column ALTER TABLE errors through runMigrations()', async () => {
     // Make ALTER TABLE throw a "disk full" type error
     mockExec.mockImplementation(async (_db: unknown, sql: string) => {
       if (sql.includes('ALTER TABLE')) {
@@ -101,19 +101,22 @@ describe('ALTER TABLE migration error handling', () => {
     });
 
     const { init, _resetForTesting } = await import('../sqlite.js');
-    const { resetTestingState } = await import('../offscreen.js');
 
     // Reset module state
     _resetForTesting?.();
 
-    // Run init — it will fail OPFS Worker path, then attempt IDB path with mocked wa-sqlite
+    // Run init — it will fail OPFS Worker path, then attempt IDB path with mocked wa-sqlite.
+    // runMigrations() re-throws non-duplicate ALTER TABLE errors, which causes IDB path
+    // to fail and ultimately fall back to storage.
     const result = await init();
 
-    // Should have logged the ALTER TABLE error via console.warn
-    expect(warnSpy).toHaveBeenCalledWith(
+    // The error is re-thrown by runMigrations(), not logged via console.warn
+    expect(warnSpy).not.toHaveBeenCalledWith(
       expect.stringContaining('unexpected ALTER TABLE error'),
-      expect.stringContaining('disk I/O error')
+      expect.anything()
     );
+    // Init will fail to fully initialize SQLite and fall back to storage
+    expect(result).toBe(false);
   });
 
   it('does NOT log for duplicate column name errors (expected during migration)', async () => {

--- a/src/offscreen/auditLogRepo.ts
+++ b/src/offscreen/auditLogRepo.ts
@@ -3,12 +3,11 @@
  * Audit log for cloud AI provider send events (separate `audit_log` table —
  * unrelated to browsing-log record CRUD).
  * Split out of sqlite.ts (PBI: sqlite.ts deepening).
+ *
+ * All methods delegate to the active StorageBackend returned by engine.getBackend().
  */
 
-import { errorMessage } from '../utils/errorUtils.js';
-import { logError, ErrorCode } from '../utils/logger.js';
-import { engine, MAX_QUERY_LIMIT } from './sqliteEngineContext.js';
-import type { SqliteValue } from './sqliteEngineContext.js';
+import { engine } from './sqliteEngineContext.js';
 
 import type { AuditLogRecord, AuditLogEntry } from '../utils/sqlite-types.js';
 
@@ -16,41 +15,8 @@ import type { AuditLogRecord, AuditLogEntry } from '../utils/sqlite-types.js';
  * Insert an audit log entry for cloud AI provider send events.
  */
 export async function insertAuditLog(record: AuditLogRecord): Promise<{ success: true; id: number } | { success: false; error: string }> {
-  try {
-    // OPFS Worker path
-    if (engine.opfsWorker) {
-      const result = await engine.sendToOpfsWorker('AUDIT_LOG_INSERT', record) as { id: number };
-      return { success: true, id: result.id };
-    }
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.opfsWorker) {
-      const result = await engine.sendToOpfsWorker('AUDIT_LOG_INSERT', record) as { id: number };
-      return { success: true, id: result.id };
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    await engine.execWithCache(
-      `INSERT INTO audit_log (provider, url, created_at) VALUES (?, ?, ?)`,
-      [record.provider, record.url, record.created_at]
-    );
-
-    let newId = 0;
-    await engine.execWithCache('SELECT last_insert_rowid()', [], (row: SqliteValue[]) => {
-      newId = Number(row[0]);
-    });
-
-    return { success: true, id: newId };
-  } catch (error) {
-    logError('SQLite: insertAuditLog failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.insertAuditLog(record);
 }
 
 /**
@@ -59,49 +25,6 @@ export async function insertAuditLog(record: AuditLogRecord): Promise<{ success:
 export async function queryAuditLog(options: { limit?: number; offset?: number } = {}): Promise<
   { success: true; rows: AuditLogEntry[]; total: number } | { success: false; error: string }
 > {
-  try {
-    const limit = Math.min(options.limit ?? 100, MAX_QUERY_LIMIT);
-    const offset = options.offset ?? 0;
-
-    // OPFS Worker path
-    const opfsResult = await engine.tryOpfsProxy<{ rows: Array<{ id: number; provider: string; url: string; created_at: number }>; total: number }>('AUDIT_LOG_QUERY', {
-      limit,
-      offset,
-    });
-    if (opfsResult !== null) {
-      return { success: true, rows: opfsResult.rows, total: opfsResult.total };
-    }
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    const rows: AuditLogEntry[] = [];
-    await engine.execWithCache(
-      `SELECT id, provider, url, created_at FROM audit_log ORDER BY created_at DESC LIMIT ? OFFSET ?`,
-      [limit, offset],
-      (row: SqliteValue[]) => {
-        rows.push({
-          id: Number(row[0]),
-          provider: String(row[1]),
-          url: String(row[2]),
-          created_at: Number(row[3]),
-        });
-      }
-    );
-
-    let total = 0;
-    await engine.execWithCache('SELECT COUNT(*) FROM audit_log', [], (row: SqliteValue[]) => {
-      total = Number(row[0]);
-    });
-
-    return { success: true, rows, total };
-  } catch (error) {
-    logError('SQLite: queryAuditLog failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.queryAuditLog(options);
 }

--- a/src/offscreen/dbMaintenance.ts
+++ b/src/offscreen/dbMaintenance.ts
@@ -38,7 +38,7 @@ export async function purgeContent(
   includeStarred?: boolean | null,
 ): Promise<{ success: true; purged: number } | { success: false; error: string }> {
   const backend = await engine.getBackend();
-  return backend.purgeContent(retentionDays, maxRecords, includeStarred);
+  return backend.purgeContent(retentionDays ?? undefined, maxRecords ?? undefined, includeStarred ?? undefined);
 }
 
 /**

--- a/src/offscreen/dbMaintenance.ts
+++ b/src/offscreen/dbMaintenance.ts
@@ -3,12 +3,12 @@
  * Retention purging, FTS5 index health monitoring, binary backup/restore,
  * and a lightweight health check.
  * Split out of sqlite.ts (PBI: sqlite.ts deepening).
+ *
+ * All methods delegate to the active StorageBackend returned by engine.getBackend().
  */
 
-import { errorMessage } from '../utils/errorUtils.js';
-import { logError, logWarn, ErrorCode } from '../utils/logger.js';
+import { logWarn } from '../utils/logger.js';
 import { engine } from './sqliteEngineContext.js';
-import type { SqliteValue } from './sqliteEngineContext.js';
 
 const DEFAULT_RETENTION_DAYS = 90;
 const DEFAULT_MAX_RECORDS = 1000;
@@ -23,67 +23,8 @@ export async function purgeOldRecords(
   retentionDays: number = DEFAULT_RETENTION_DAYS,
   maxRecords: number = DEFAULT_MAX_RECORDS
 ): Promise<{ success: true; purged: number } | { success: false; error: string }> {
-  try {
-    const opfsResult = await engine.tryOpfsProxy<{ purged: number }>('PURGE', { retentionDays, maxRecords });
-    if (opfsResult !== null) return { success: true, purged: opfsResult.purged };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.purgeOldRecords(retentionDays, maxRecords);
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
-    let totalPurged = 0;
-
-    await engine.execWithCache(
-      `DELETE FROM browsing_logs WHERE created_at < ? AND is_starred = 0 AND is_deleted = 0`,
-      [cutoffMs]
-    );
-
-    let changes1 = 0;
-    await engine.execWithCache('SELECT changes()', [], (row: SqliteValue[]) => {
-      changes1 = Number(row[0]);
-    });
-    totalPurged += changes1;
-
-    let totalCount = 0;
-    await engine.execWithCache(
-      'SELECT COUNT(*) FROM browsing_logs WHERE is_deleted = 0',
-      [],
-      (row: SqliteValue[]) => {
-        totalCount = Number(row[0]);
-      }
-    );
-
-    if (totalCount > maxRecords) {
-      const excess = totalCount - maxRecords;
-      await engine.execWithCache(
-        `DELETE FROM browsing_logs WHERE id IN (
-          SELECT id FROM browsing_logs WHERE is_starred = 0 AND is_deleted = 0
-          ORDER BY created_at ASC LIMIT ?
-        )`,
-        [excess]
-      );
-
-      let changes2 = 0;
-      await engine.execWithCache('SELECT changes()', [], (row: SqliteValue[]) => {
-        changes2 = Number(row[0]);
-      });
-      totalPurged += changes2;
-    }
-
-    return { success: true, purged: totalPurged };
-  } catch (error) {
-    logError('SQLite: purgeOldRecords failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.purgeOldRecords(retentionDays, maxRecords);
 }
 
 /**
@@ -96,121 +37,16 @@ export async function purgeContent(
   maxRecords?: number | null,
   includeStarred?: boolean | null,
 ): Promise<{ success: true; purged: number } | { success: false; error: string }> {
-  try {
-    const opfsResult = await engine.tryOpfsProxy<{ purged: number }>('CONTENT_PURGE', {
-      retentionDays,
-      maxRecords,
-      includeStarred,
-    });
-    if (opfsResult !== null) return { success: true, purged: opfsResult.purged };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.purgeContent(
-        retentionDays != null ? retentionDays : undefined,
-        maxRecords != null ? maxRecords : undefined,
-        includeStarred != null ? includeStarred : undefined,
-      );
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    const starredClause = includeStarred ? '' : 'AND is_starred = 0';
-    let totalPurged = 0;
-
-    // 1. Days-based: NULL content on old non-starred entries
-    if (retentionDays != null && retentionDays > 0) {
-      const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
-      await engine.execWithCache(
-        `UPDATE browsing_logs SET content = NULL
-         WHERE content IS NOT NULL AND created_at < ? ${starredClause}`,
-        [cutoffMs]
-      );
-
-      let changes1 = 0;
-      await engine.execWithCache('SELECT changes()', [], (row: SqliteValue[]) => {
-        changes1 = Number(row[0]);
-      });
-      totalPurged += changes1;
-    }
-
-    // 2. Count-based: NULL oldest content when over limit
-    if (maxRecords != null && maxRecords > 0) {
-      let count = 0;
-      await engine.execWithCache(
-        `SELECT COUNT(*) FROM browsing_logs WHERE content IS NOT NULL ${starredClause}`,
-        [],
-        (row: SqliteValue[]) => { count = Number(row[0]); }
-      );
-
-      if (count > maxRecords) {
-        const excess = count - maxRecords;
-        await engine.execWithCache(
-          `UPDATE browsing_logs SET content = NULL
-           WHERE id IN (
-             SELECT id FROM browsing_logs
-             WHERE content IS NOT NULL ${starredClause}
-             ORDER BY created_at ASC
-             LIMIT ?
-           )`,
-          [excess]
-        );
-
-        let changes2 = 0;
-        await engine.execWithCache('SELECT changes()', [], (row: SqliteValue[]) => {
-          changes2 = Number(row[0]);
-        });
-        totalPurged += changes2;
-      }
-    }
-
-    return { success: true, purged: totalPurged };
-  } catch (error) {
-    logError('SQLite: purgeContent failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.purgeContent(retentionDays, maxRecords, includeStarred);
 }
 
 /**
  * Get the number of entries in the FTS5 index.
  */
 export async function getFtsIndexSize(): Promise<{ success: true; count: number } | { success: false; error: string }> {
-  try {
-    // OPFS Worker: no FTS in sync build, always return 0
-    const opfsResult = await engine.tryOpfsProxy<{ count: number }>('FTS_INDEX_SIZE');
-    if (opfsResult !== null) return { success: true, count: opfsResult.count };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return { success: true, count: 0 };
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    let count = 0;
-    await engine.execWithCache(
-      'SELECT COUNT(*) FROM browsing_logs_fts',
-      [],
-      (row: SqliteValue[]) => {
-        count = Number(row[0]);
-      }
-    );
-
-    return { success: true, count };
-  } catch (error) {
-    logError('SQLite: getFtsIndexSize failed', { error: errorMessage(error) }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.getFtsIndexSize();
 }
 
 /**
@@ -218,16 +54,13 @@ export async function getFtsIndexSize(): Promise<{ success: true; count: number 
  * Returns the current FTS index size.
  */
 export async function checkFtsIndexHealth(): Promise<{ count: number; warning: boolean }> {
-  const result = await getFtsIndexSize();
-  if (!result.success) {
-    return { count: 0, warning: false };
-  }
-
+  const backend = await engine.getBackend();
+  const result = await backend.getFtsIndexSize();
+  if (!result.success) return { count: 0, warning: false };
   const warning = result.count > FTS_INDEX_WARNING_THRESHOLD;
   if (warning) {
     logWarn('FTS index is large; consider evaluation', { count: result.count }, undefined, 'sqlite');
   }
-
   return { count: result.count, warning };
 }
 
@@ -237,19 +70,8 @@ export async function checkFtsIndexHealth(): Promise<{ count: number; warning: b
  * (JSON フォールバックは廃止 — コンシューマーに破損 .db を渡すため)
  */
 export async function backupDb(): Promise<{ success: true; data: Uint8Array } | { success: false; error: string }> {
-  try {
-    // OPFS Worker パス: バイナリ .db エクスポート
-    const opfsResult = await engine.tryOpfsProxy<Uint8Array>('BACKUP');
-    if (opfsResult !== null && opfsResult.length > 0) {
-      return { success: true, data: opfsResult };
-    }
-
-    // IDB/Fallback パス: バイナリバックアップ非対応
-    return { success: false, error: 'Binary backup requires OPFS storage. Use JSON export instead.' };
-  } catch (error) {
-    logError('SQLite: backupDb failed', { error: errorMessage(error) }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.backupDb();
 }
 
 /**
@@ -257,16 +79,8 @@ export async function backupDb(): Promise<{ success: true; data: Uint8Array } | 
  * OPFS パスのみサポート。一時ファイル検証は opfsWorker.ts 側で行う。
  */
 export async function restoreDb(data: Uint8Array): Promise<{ success: true } | { success: false; error: string }> {
-  try {
-    const opfsResult = await engine.tryOpfsProxy<{ restored: boolean }>('RESTORE', { data });
-    if (opfsResult && opfsResult.restored) {
-      return { success: true };
-    }
-    return { success: false, error: 'Binary restore requires OPFS storage.' };
-  } catch (error) {
-    logError('SQLite: restoreDb failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.restoreDb(data);
 }
 
 /**
@@ -274,25 +88,7 @@ export async function restoreDb(data: Uint8Array): Promise<{ success: true } | {
  * Returns true if a SELECT 1 succeeds on any available backend.
  */
 export async function sqliteHealthCheck(): Promise<boolean> {
-  if (engine.opfsWorker) {
-    try {
-      const result = await engine.tryOpfsProxy<{ ok: boolean }>('HEALTH_CHECK');
-      if (result !== null) return result.ok;
-    } catch {
-      return false;
-    }
-  }
-  if (engine.usingFallbackStorage && engine.fallbackStorage) {
-    return engine.fallbackStorage.healthCheck();
-  }
-  if (!engine.dbHandle || !engine.sqlite3) {
-    return false;
-  }
-  try {
-    let ok = false;
-    await engine.execWithCache('SELECT 1', [], () => { ok = true; });
-    return ok;
-  } catch {
-    return false;
-  }
+  const backend = await engine.getBackend();
+  const result = await backend.healthCheck();
+  return result.success;
 }

--- a/src/offscreen/migrations.ts
+++ b/src/offscreen/migrations.ts
@@ -1,0 +1,63 @@
+// src/offscreen/migrations.ts
+import { MIGRATION_COLUMNS, MIGRATION_SEQUENCE, FTS5_STATEMENTS, GIST_SYNCED_INDEX_SQL } from './schema.js';
+import { errorMessage } from '../utils/errorUtils.js';
+
+export interface MigrationEngine {
+  exec(sql: string): Promise<void>;
+  queryValue(sql: string): Promise<number | null>;
+}
+
+export async function runMigrations(engine: MigrationEngine): Promise<{ fts5Available: boolean }> {
+  // 1. One-off migrations
+  for (const step of MIGRATION_SEQUENCE) {
+    try {
+      await engine.exec(step.sql);
+    } catch {
+      // Column/target already exists — ignore
+    }
+  }
+
+  // PBI-11: gist_synced index
+  try {
+    await engine.exec(GIST_SYNCED_INDEX_SQL);
+  } catch {
+    // Index already exists
+  }
+
+  // 2. ALTER TABLE migration for all dynamic columns
+  for (const colDef of MIGRATION_COLUMNS) {
+    try {
+      await engine.exec(`ALTER TABLE browsing_logs ADD COLUMN ${colDef}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('duplicate column name')) continue;
+      throw err;
+    }
+  }
+
+  // 3. FTS5 schema
+  let fts5Available = false;
+  try {
+    for (const stmt of FTS5_STATEMENTS) {
+      await engine.exec(stmt);
+    }
+    fts5Available = true;
+  } catch (err) {
+    console.warn('FTS5 unavailable:', errorMessage(err));
+  }
+
+  // 4. FTS index rebuild
+  if (fts5Available) {
+    try {
+      const baseCount = Number(await engine.queryValue('SELECT COUNT(*) AS c FROM browsing_logs') ?? 0);
+      const ftsCount = Number(await engine.queryValue('SELECT COUNT(*) AS c FROM browsing_logs_fts') ?? 0);
+      if (baseCount > 0 && ftsCount === 0) {
+        await engine.exec("INSERT INTO browsing_logs_fts(browsing_logs_fts) VALUES('rebuild')");
+      }
+    } catch (rebuildErr) {
+      console.warn('FTS rebuild check failed:', errorMessage(rebuildErr));
+    }
+  }
+
+  return { fts5Available };
+}

--- a/src/offscreen/opfsWorker.ts
+++ b/src/offscreen/opfsWorker.ts
@@ -14,84 +14,20 @@ import { errorMessage } from '../utils/errorUtils.js';
 import { migrateOldOpfsDb } from './opfsMigrationV2.js';
 import { readOldDbRecords, deleteOldDbFile } from './opfsMigrationV2Reader.js';
 import { StorageKeys } from '../utils/storage/types.js';
+import type { BrowsingLogRecord, SearchResult, QueryOptions } from '../utils/sqlite-types.js';
 
 // ---------------------------------------------------------------------------
-// Types (worker-internal — mirrors BrowsingLogRecord / QueryOptions / SearchResult)
+// Types
 // ---------------------------------------------------------------------------
-
-interface BrowsingLogRecord {
-  id?: number;
-  url: string;
-  title?: string | null;
-  summary?: string | null;
-  tags?: string | null;
-  created_at: number;
-  domain?: string | null;
-  visit_duration?: number | null;
-  scroll_ratio?: number | null;
-  is_starred?: number;
-  is_deleted?: number;
-  obsidian_synced?: number;
-  gist_synced?: number;
-  content?: string | null;
-  masked_count?: number | null;
-  cleansed_reason?: string | null;
-  ai_provider?: string | null;
-  ai_model?: string | null;
-  ai_duration_ms?: number | null;
-  obsidian_duration_ms?: number | null;
-  sent_tokens?: number | null;
-  received_tokens?: number | null;
-  original_tokens?: number | null;
-  cleansed_tokens?: number | null;
-  page_bytes?: number | null;
-  candidate_bytes?: number | null;
-  original_bytes?: number | null;
-  cleansed_bytes?: number | null;
-  ai_summary_original_bytes?: number | null;
-  ai_summary_cleansed_bytes?: number | null;
-  extracted_sentences_bytes?: number | null;
-  extracted_sentences_original_bytes?: number | null;
-  fallback_triggered?: number;
-}
-
-interface SearchResultRecord {
-  id: number;
-  url: string;
-  title: string | null;
-  summary: string | null;
-  tags: string | null;
-  created_at: number;
-  domain: string | null;
-  visit_duration: number | null;
-  scroll_ratio: number | null;
-  is_starred: number;
-  rank: number;
-}
 
 interface AuditLogQueryPayload {
   limit?: number;
   offset?: number;
 }
 
-interface QueryPayload {
-  limit?: number;
-  offset?: number;
-  since?: number;
-  until?: number;
-  domain?: string;
-  isStarred?: number;
-  orderBy?: string;
-  orderDir?: string;
-  ids?: number[];
-  tagFilter?: string;
-}
-
-interface SearchPayload {
-  searchQuery: string;
-  limit?: number;
-  offset?: number;
-}
+// Worker-internal types (not in shared types):
+type QueryPayload = QueryOptions & { ids?: number[]; tagFilter?: string; isStarred?: number };
+type SearchPayload = { searchQuery: string; limit?: number; offset?: number };
 
 interface RequestMessage {
   id: number;
@@ -725,7 +661,7 @@ export async function handleRestore(data: Uint8Array): Promise<{ restored: true 
   return { restored: true };
 }
 
-async function handleSearch(payload: SearchPayload): Promise<{ rows: SearchResultRecord[]; total: number }> {
+async function handleSearch(payload: SearchPayload): Promise<{ rows: SearchResult[]; total: number }> {
   const { searchQuery, limit = 50, offset = 0 } = payload;
   const bare = sanitizeFtsTerm(searchQuery);
   if (!bare) return { rows: [], total: 0 };
@@ -740,7 +676,7 @@ async function handleSearch(payload: SearchPayload): Promise<{ rows: SearchResul
 
 async function handleSearchFts(
   sanitizedQuery: string, limit: number, offset: number
-): Promise<{ rows: SearchResultRecord[]; total: number }> {
+): Promise<{ rows: SearchResult[]; total: number }> {
   let total = 0;
   await sqlQuery(
     `SELECT COUNT(*) AS c FROM browsing_logs_fts
@@ -750,7 +686,7 @@ WHERE browsing_logs_fts MATCH ? AND b.is_deleted = 0`,
     (row) => { total = Number(row.c); }
   );
 
-  const rows: SearchResultRecord[] = [];
+  const rows: SearchResult[] = [];
   await sqlQuery(
     `SELECT b.id, b.url, b.title, b.summary, b.tags, b.created_at, b.domain, b.visit_duration, b.scroll_ratio, b.is_starred, rank AS rank
      FROM browsing_logs_fts
@@ -780,7 +716,7 @@ WHERE browsing_logs_fts MATCH ? AND b.is_deleted = 0`,
 
 async function handleSearchLike(
   rawQuery: string, limit: number, offset: number
-): Promise<{ rows: SearchResultRecord[]; total: number }> {
+): Promise<{ rows: SearchResult[]; total: number }> {
   const like = `%${rawQuery}%`;
   const conditions = 'is_deleted = 0 AND (url LIKE ? OR title LIKE ? OR summary LIKE ? OR tags LIKE ?)';
   const params: SqliteValue[] = [like, like, like, like];
@@ -792,7 +728,7 @@ async function handleSearchLike(
     (row) => { total = Number(row.c); }
   );
 
-  const rows: SearchResultRecord[] = [];
+  const rows: SearchResult[] = [];
   await sqlQuery(
     `SELECT id, url, title, summary, tags, created_at, domain, visit_duration, scroll_ratio, is_starred
      FROM browsing_logs WHERE ${conditions}

--- a/src/offscreen/opfsWorker.ts
+++ b/src/offscreen/opfsWorker.ts
@@ -921,6 +921,23 @@ export async function handleRequest(req: RequestMessage): Promise<ResponseMessag
         result = await handleAuditLogQuery(payload as AuditLogQueryPayload);
         break;
       }
+      // WARNING: SQL_EXEC / SQL_QUERY accept raw SQL strings.
+      // Use ONLY for schema migrations (MigrationEngine). Never expose to user input.
+      // Regular CRUD operations MUST use typed operation messages (INSERT, QUERY, etc.).
+      case 'SQL_EXEC': {
+        const { sql, params = [] } = payload as { sql: string; params: SqliteValue[] };
+        await initSqlite();
+        await engine!.exec(sql, params);
+        result = { changes: 0 };
+        break;
+      }
+      case 'SQL_QUERY': {
+        const { sql, params = [] } = payload as { sql: string; params: SqliteValue[] };
+        await initSqlite();
+        const rows = await engine!.query(sql, params);
+        result = { rows };
+        break;
+      }
       default:
         return { id, success: false, error: `Unknown worker type: ${type}` };
     }

--- a/src/offscreen/opfsWorker.ts
+++ b/src/offscreen/opfsWorker.ts
@@ -54,7 +54,8 @@ const ALLOWED_ORDER_COLUMNS = [
 
 const WASM_URL = new URL('@subframe7536/sqlite-wasm/wasm', import.meta.url).href;
 
-import { SCHEMA_SQL, GIST_SYNCED_INDEX_SQL, FTS5_STATEMENTS, AUDIT_LOG_SCHEMA_SQL, INSERT_SQL, INSERT_IGNORE_SQL, buildInsertParams, FTS_QUERY_MAX_LENGTH, sanitizeFtsTerm } from './schema.js';
+import { SCHEMA_SQL, AUDIT_LOG_SCHEMA_SQL, INSERT_SQL, INSERT_IGNORE_SQL, buildInsertParams, FTS_QUERY_MAX_LENGTH, sanitizeFtsTerm } from './schema.js';
+import { runMigrations, type MigrationEngine } from './migrations.js';
 
 // ---------------------------------------------------------------------------
 // Module state
@@ -89,83 +90,18 @@ async function initSqliteInner(): Promise<void> {
   await engine.exec(SCHEMA_SQL);
   await engine.exec(AUDIT_LOG_SCHEMA_SQL);
 
-  // Schema migration: add obsidian_synced column if not present
-  try {
-    await engine.exec('ALTER TABLE browsing_logs ADD COLUMN obsidian_synced INTEGER DEFAULT 0');
-  } catch {
-    // Column already exists
-  }
-
-  // PBI-11: add gist_synced column for per-target sync flags
-  try {
-    await engine.exec('ALTER TABLE browsing_logs ADD COLUMN gist_synced INTEGER DEFAULT 0');
-  } catch {
-    // Column already exists
-  }
-  await engine.exec(GIST_SYNCED_INDEX_SQL);
-
-  // Try to enable FTS5 — execute each DDL statement individually because
-  // @subframe7536/sqlite-wasm's run() does not support multi-statement SQL.
-  fts5Available = false;
-  try {
-    for (const stmt of FTS5_STATEMENTS) {
-      await engine.exec(stmt);
-    }
-    fts5Available = true;
-
-    // I2: If base table has rows but FTS index is empty, rebuild the index.
-    // This handles the case where rows existed before FTS triggers were added.
-    try {
-      const baseCount = Number(await engine.queryValue('SELECT COUNT(*) AS c FROM browsing_logs') ?? 0);
-      const ftsCount = Number(await engine.queryValue('SELECT COUNT(*) AS c FROM browsing_logs_fts') ?? 0);
-      if (baseCount > 0 && ftsCount === 0) {
-        console.info('OPFS Worker: FTS index empty, rebuilding...');
-        await engine.exec("INSERT INTO browsing_logs_fts(browsing_logs_fts) VALUES('rebuild')");
-        console.info('OPFS Worker: FTS index rebuild complete');
-      }
-    } catch (rebuildErr) {
-      console.warn('OPFS Worker: FTS rebuild check failed:', errorMessage(rebuildErr));
-    }
-  } catch (err) {
-    console.warn('OPFS Worker: FTS5 unavailable, falling back to LIKE search:', errorMessage(err));
-  }
-
-  // PBI-1: ALTER TABLE migration for new columns
-  const newColumns = [
-    'content TEXT',
-    'masked_count INTEGER',
-    'cleansed_reason TEXT',
-    'ai_provider TEXT',
-    'ai_model TEXT',
-    'ai_duration_ms INTEGER',
-    'obsidian_duration_ms INTEGER',
-    'sent_tokens INTEGER',
-    'received_tokens INTEGER',
-    'original_tokens INTEGER',
-    'cleansed_tokens INTEGER',
-    'page_bytes INTEGER',
-    'candidate_bytes INTEGER',
-    'original_bytes INTEGER',
-    'cleansed_bytes INTEGER',
-    'ai_summary_original_bytes INTEGER',
-    'ai_summary_cleansed_bytes INTEGER',
-    'extracted_sentences_bytes INTEGER',
-    'extracted_sentences_original_bytes INTEGER',
-    'fallback_triggered INTEGER DEFAULT 0',
-  ];
-
-  for (const colDef of newColumns) {
-    try {
-      await sqlExec(`ALTER TABLE browsing_logs ADD COLUMN ${colDef}`);
-    } catch (err) {
-      // Column already exists — ignore
-      // Log unexpected errors (disk full, corruption, etc.) so they are surfaced
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!msg.includes('duplicate column name')) {
-        console.warn('OPFS Worker: unexpected ALTER TABLE error:', msg);
-      }
-    }
-  }
+  // Run schema migrations through shared migration engine
+  const workerEngine: MigrationEngine = {
+    exec: async (sql) => {
+      await engine!.exec(sql);
+    },
+    queryValue: async (sql) => {
+      const v = await engine!.queryValue(sql);
+      return v !== undefined ? Number(v) : null;
+    },
+  };
+  const { fts5Available: fts } = await runMigrations(workerEngine);
+  fts5Available = fts;
 
   // Cache compile options for diagnostics
   const opts = await engine.query('PRAGMA compile_options');

--- a/src/offscreen/recordsRepo.ts
+++ b/src/offscreen/recordsRepo.ts
@@ -53,7 +53,9 @@ export async function search(searchQuery: string, limit: number = 50, offset: nu
 } | { success: false; error: string }> {
   limit = Math.min(limit, MAX_QUERY_LIMIT);
   const backend = await engine.getBackend();
-  return backend.search(searchQuery, limit, offset);
+  const result = await backend.search(searchQuery, limit, offset);
+  if (!result.success) return result;
+  return { success: true, rows: result.rows as unknown as SearchResult[], total: result.total };
 }
 
 /**
@@ -92,11 +94,11 @@ export async function getCount(): Promise<{ success: true; count: number } | { s
 /**
  * Check if the database is initialized and accessible.
  */
-export async function getStatus(): Promise<{ success: true; initialized: boolean; path: string; fallback: boolean; initError?: string; fts5: boolean; compileOptions?: string[]; compileOptionsSource?: 'opfs-worker' | 'idb' | 'fallback' } | { success: false; error: string }> {
+export async function getStatus(): Promise<{ success: true; initialized: boolean; path: string; fallback: boolean; initError?: string; fts5: boolean; supportsBinaryBackup: boolean; compileOptions?: string[]; compileOptionsSource?: 'opfs-worker' | 'idb' | 'fallback' } | { success: false; error: string }> {
   const backend = await engine.getBackend();
   const result = await backend.getStatus();
-  if (!result.success) return result;
-  return { ...result, path: DB_FILENAME };
+  if ('error' in result) return result;
+  return { success: true, ...result, path: DB_FILENAME };
 }
 
 /**

--- a/src/offscreen/recordsRepo.ts
+++ b/src/offscreen/recordsRepo.ts
@@ -2,68 +2,24 @@
  * recordsRepo.ts
  * Browsing-log record CRUD, FTS5 search, and JSON export.
  * Split out of sqlite.ts (PBI: sqlite.ts deepening).
+ *
+ * All methods delegate to the active StorageBackend returned by engine.getBackend().
  */
 
 import { errorMessage } from '../utils/errorUtils.js';
 import { logError, ErrorCode } from '../utils/logger.js';
-import { INSERT_SQL, INSERT_IGNORE_SQL, UPDATABLE_FIELDS, buildInsertParams, FTS_QUERY_MAX_LENGTH, sanitizeFtsTerm } from './schema.js';
-import { engine, extractDomain, DB_FILENAME, MAX_QUERY_LIMIT } from './sqliteEngineContext.js';
+import { engine, DB_FILENAME, MAX_QUERY_LIMIT } from './sqliteEngineContext.js';
 import type { SqliteValue } from './sqliteEngineContext.js';
+import { FTS_QUERY_MAX_LENGTH } from './schema.js';
 
 import type { BrowsingLogRecord, QueryOptions, SearchResult } from '../utils/sqlite-types.js';
-
-/** Column names allowed in ORDER BY clauses (prevents SQL injection). */
-const ALLOWED_ORDER_COLUMNS = [
-  'id', 'url', 'title', 'summary', 'tags', 'created_at',
-  'domain', 'visit_duration', 'scroll_ratio', 'is_starred', 'is_deleted',
-  'ai_duration_ms', 'obsidian_duration_ms',
-  'sent_tokens', 'received_tokens',
-  'page_bytes', 'candidate_bytes',
-  'fallback_triggered',
-] as const;
 
 /**
  * Insert a new browsing log record and return the auto-generated row id.
  */
 export async function insert(record: BrowsingLogRecord): Promise<{ success: true; id: number } | { success: false; error: string }> {
-  try {
-    // OPFS Worker path
-    if (engine.opfsWorker) {
-      const result = await engine.sendToOpfsWorker('INSERT', record) as { id: number };
-      return { success: true, id: result.id };
-    }
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.opfsWorker) {
-      const result = await engine.sendToOpfsWorker('INSERT', record) as { id: number };
-      return { success: true, id: result.id };
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.insert(record);
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    const domain = record.domain || extractDomain(record.url);
-
-    await engine.execWithCache(INSERT_SQL, buildInsertParams(record, domain));
-
-    let newId = 0;
-    await engine.execWithCache('SELECT last_insert_rowid()', [], (row: SqliteValue[]) => {
-      newId = Number(row[0]);
-    });
-
-    return { success: true, id: newId };
-  } catch (error) {
-    logError('SQLite: insert failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.insert(record);
 }
 
 /**
@@ -71,49 +27,10 @@ export async function insert(record: BrowsingLogRecord): Promise<{ success: true
  * Uses INSERT OR IGNORE to handle UNIQUE constraint violations (url, created_at).
  */
 export async function insertBatch(records: BrowsingLogRecord[]): Promise<{ success: true; count: number } | { success: false; error: string }> {
-  if (records.length === 0) {
-    return { success: true, count: 0 };
-  }
-
-  try {
-    const opfsResult = await engine.tryOpfsProxy<{ count: number }>('INSERT_BATCH', records);
-    if (opfsResult !== null) return { success: true, count: opfsResult.count };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.insertBatch(records);
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    await engine.sqlite3!.exec(engine.dbHandle!, 'BEGIN IMMEDIATE');
-
-    try {
-      let insertedCount = 0;
-
-      for (const record of records) {
-        const domain = record.domain || extractDomain(record.url);
-
-        await engine.execWithCache(INSERT_IGNORE_SQL, buildInsertParams(record, domain));
-        // Track count locally (INSERT OR IGNORE may slightly overcount duplicates)
-        insertedCount++;
-      }
-
-      await engine.sqlite3!.exec(engine.dbHandle!, 'COMMIT');
-      return { success: true, count: insertedCount };
-    } catch (innerError) {
-      await engine.sqlite3!.exec(engine.dbHandle!, 'ROLLBACK');
-      throw innerError;
-    }
-  } catch (error) {
-    logError('SQLite: insertBatch failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  const result = await backend.insertBatch(records);
+  if (!result.success) return result;
+  return { success: true, count: result.inserted };
 }
 
 /**
@@ -122,138 +39,10 @@ export async function insertBatch(records: BrowsingLogRecord[]): Promise<{ succe
 export async function query(options: QueryOptions = {}): Promise<{
   success: true; rows: BrowsingLogRecord[]; total: number
 } | { success: false; error: string }> {
-  try {
-    // Apply FTS_QUERY_MAX_LENGTH limit to tagFilter before passing to either path
-    const tagFilter = options.tagFilter ? options.tagFilter.slice(0, FTS_QUERY_MAX_LENGTH) : options.tagFilter;
-
-    // OPFS Worker proxy
-    const queryLimit = Math.min(options.limit ?? 100, MAX_QUERY_LIMIT);
-    const opfsResult = await engine.tryOpfsProxy<{ rows: BrowsingLogRecord[]; total: number }>('QUERY', {
-      limit: queryLimit, offset: options.offset, since: options.since, until: options.until,
-      domain: options.domain, isStarred: options.isStarred, orderBy: options.orderBy, orderDir: options.orderDir,
-      ids: options.ids,
-      tagFilter,
-    });
-    if (opfsResult !== null) return { success: true, rows: opfsResult.rows, total: opfsResult.total };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.query({ ...options, limit: queryLimit });
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    const conditions: string[] = [];
-    const params: SqliteValue[] = [];
-
-    if (options.excludeDeleted !== false) {
-      conditions.push('is_deleted = 0');
-    }
-    if (options.domain) {
-      conditions.push('domain = ?');
-      params.push(options.domain);
-    }
-    if (options.isStarred !== undefined) {
-      conditions.push('is_starred = ?');
-      params.push(options.isStarred ? 1 : 0);
-    }
-    if (options.since !== undefined) {
-      conditions.push('created_at >= ?');
-      params.push(options.since);
-    }
-    if (options.until !== undefined) {
-      conditions.push('created_at <= ?');
-      params.push(options.until);
-    }
-    if (options.ids !== undefined && Array.isArray(options.ids) && options.ids.length > 0) {
-      const placeholders = options.ids.map(() => '?').join(',');
-      conditions.push(`id IN (${placeholders})`);
-      params.push(...options.ids);
-    }
-    if (tagFilter) {
-      // Strip FTS5 operator keywords and special chars, but preserve # prefix for trigram matching
-      // (length already limited above via FTS_QUERY_MAX_LENGTH)
-      const cleanTag = tagFilter
-        .replace(/["'*^~:()+\-\\]/g, ' ')
-        .replace(/\b(OR|AND|NOT|NEAR)\b/gi, ' ')
-        .replace(/\s+/g, ' ')
-        .trim();
-      const ftsExpr = `"#${cleanTag}"`;
-      conditions.push('id IN (SELECT rowid FROM browsing_logs_fts WHERE tags MATCH ?)');
-      params.push(ftsExpr);
-    }
-
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-    const orderBy = options.orderBy && ALLOWED_ORDER_COLUMNS.includes(options.orderBy as typeof ALLOWED_ORDER_COLUMNS[number])
-      ? options.orderBy : 'created_at';
-    const orderDir = options.orderDir === 'ASC' ? 'ASC' : 'DESC';
-    const limit = queryLimit;
-    const offset = options.offset ?? 0;
-
-    const countSql = `SELECT COUNT(*) FROM browsing_logs ${whereClause}`;
-    let total = 0;
-    await engine.execWithCache(countSql, params, (row: SqliteValue[]) => {
-      total = Number(row[0]);
-    });
-
-    const selectSql = `SELECT id, url, title, summary, tags, created_at, domain, visit_duration, scroll_ratio, is_starred, is_deleted,
-         obsidian_synced, gist_synced,
-         content, masked_count, cleansed_reason, ai_provider, ai_model, ai_duration_ms, obsidian_duration_ms,
-         sent_tokens, received_tokens, original_tokens, cleansed_tokens,
-         page_bytes, candidate_bytes, original_bytes, cleansed_bytes,
-         ai_summary_original_bytes, ai_summary_cleansed_bytes, extracted_sentences_bytes, extracted_sentences_original_bytes, fallback_triggered
-         FROM browsing_logs ${whereClause}
-         ORDER BY ${orderBy} ${orderDir}
-         LIMIT ? OFFSET ?`;
-    const rows: BrowsingLogRecord[] = [];
-    await engine.execWithCache(selectSql, [...params, limit, offset], (row: SqliteValue[]) => {
-      rows.push({
-        id: Number(row[0]),
-        url: String(row[1]),
-        title: row[2] as string | null,
-        summary: row[3] as string | null,
-        tags: row[4] as string | null,
-        created_at: Number(row[5]),
-        domain: row[6] as string | null,
-        visit_duration: row[7] != null ? Number(row[7]) : null,
-        scroll_ratio: row[8] != null ? Number(row[8]) : null,
-        is_starred: Number(row[9]),
-        is_deleted: Number(row[10]),
-        obsidian_synced: Number(row[11]),
-        gist_synced: Number(row[12]),
-        content: row[13] as string | null,
-        masked_count: row[14] != null ? Number(row[14]) : null,
-        cleansed_reason: row[15] as string | null,
-        ai_provider: row[16] as string | null,
-        ai_model: row[17] as string | null,
-        ai_duration_ms: row[18] != null ? Number(row[18]) : null,
-        obsidian_duration_ms: row[19] != null ? Number(row[19]) : null,
-        sent_tokens: row[20] != null ? Number(row[20]) : null,
-        received_tokens: row[21] != null ? Number(row[21]) : null,
-        original_tokens: row[22] != null ? Number(row[22]) : null,
-        cleansed_tokens: row[23] != null ? Number(row[23]) : null,
-        page_bytes: row[24] != null ? Number(row[24]) : null,
-        candidate_bytes: row[25] != null ? Number(row[25]) : null,
-        original_bytes: row[26] != null ? Number(row[26]) : null,
-        cleansed_bytes: row[27] != null ? Number(row[27]) : null,
-        ai_summary_original_bytes: row[28] != null ? Number(row[28]) : null,
-        ai_summary_cleansed_bytes: row[29] != null ? Number(row[29]) : null,
-        extracted_sentences_bytes: row[30] != null ? Number(row[30]) : null,
-        extracted_sentences_original_bytes: row[31] != null ? Number(row[31]) : null,
-        fallback_triggered: row[32] != null ? Number(row[32]) : null,
-      });
-    });
-
-    return { success: true, rows, total };
-  } catch (error) {
-    logError('SQLite: query failed', { error: errorMessage(error) }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const tagFilter = options.tagFilter ? options.tagFilter.slice(0, FTS_QUERY_MAX_LENGTH) : options.tagFilter;
+  const queryLimit = Math.min(options.limit ?? 100, MAX_QUERY_LIMIT);
+  const backend = await engine.getBackend();
+  return backend.query({ ...options, limit: queryLimit, tagFilter });
 }
 
 /**
@@ -263,169 +52,16 @@ export async function search(searchQuery: string, limit: number = 50, offset: nu
   success: true; rows: SearchResult[]; total: number
 } | { success: false; error: string }> {
   limit = Math.min(limit, MAX_QUERY_LIMIT);
-  try {
-    // OPFS Worker: real FTS5 search via the worker's SEARCH handler.
-    const opfsResult = await engine.tryOpfsProxy<{ rows: SearchResult[]; total: number }>('SEARCH', {
-      searchQuery, limit, offset,
-    });
-    if (opfsResult !== null) {
-      return { success: true, rows: opfsResult.rows, total: opfsResult.total };
-    }
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.search(searchQuery, limit, offset);
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    // FTS5 full-text search (preferred) or LIKE-based fallback.
-    // trigram MATCH requires >= 3 unicode code points; shorter terms fall back to LIKE.
-    const bare = sanitizeFtsTerm(searchQuery);
-    // Empty/punctuation-only input: return early with empty results (consistent with OPFS path).
-    if (!bare) {
-      return { success: true, rows: [], total: 0 };
-    }
-    const charLen = [...bare].length;
-    if (engine.fts5Available && charLen >= 3) {
-      const ftsQuery = `"${bare}"`;
-
-      let total = 0;
-      await engine.execWithCache(
-        `SELECT COUNT(*) FROM browsing_logs_fts WHERE browsing_logs_fts MATCH ?`,
-        [ftsQuery],
-        (row: SqliteValue[]) => {
-          total = Number(row[0]);
-        }
-      );
-
-      const rows: SearchResult[] = [];
-      await engine.execWithCache(
-        `SELECT
-           b.id, b.url, b.title, b.summary, b.tags,
-           b.created_at, b.domain, b.visit_duration, b.scroll_ratio, b.is_starred,
-           rank
-         FROM browsing_logs_fts
-         JOIN browsing_logs b ON browsing_logs_fts.rowid = b.id
-         WHERE browsing_logs_fts MATCH ?
-           AND b.is_deleted = 0
-         ORDER BY rank
-         LIMIT ? OFFSET ?`,
-        [ftsQuery, limit, offset],
-        (row: SqliteValue[]) => {
-          rows.push({
-            id: Number(row[0]),
-            url: String(row[1]),
-            title: row[2] as string | null,
-            summary: row[3] as string | null,
-            tags: row[4] as string | null,
-            created_at: Number(row[5]),
-            domain: row[6] as string | null,
-            visit_duration: row[7] != null ? Number(row[7]) : null,
-            scroll_ratio: row[8] != null ? Number(row[8]) : null,
-            is_starred: Number(row[9]),
-            rank: Number(row[10]),
-          });
-        }
-      );
-
-      return { success: true, rows, total };
-    }
-
-    // LIKE-based fallback: FTS5 not available, or query is < 3 unicode chars (trigram can't match)
-    const likePattern = `%${searchQuery}%`;
-    let total = 0;
-    await engine.execWithCache(
-      `SELECT COUNT(*) FROM browsing_logs WHERE is_deleted = 0 AND (url LIKE ? OR title LIKE ? OR summary LIKE ? OR tags LIKE ?)`,
-      [likePattern, likePattern, likePattern, likePattern],
-      (row: SqliteValue[]) => {
-        total = Number(row[0]);
-      }
-    );
-
-    const rows: SearchResult[] = [];
-    await engine.execWithCache(
-      `SELECT id, url, title, summary, tags, created_at, domain, visit_duration, scroll_ratio, is_starred
-       FROM browsing_logs
-       WHERE is_deleted = 0 AND (url LIKE ? OR title LIKE ? OR summary LIKE ? OR tags LIKE ?)
-       ORDER BY created_at DESC
-       LIMIT ? OFFSET ?`,
-      [likePattern, likePattern, likePattern, likePattern, limit, offset],
-      (row: SqliteValue[]) => {
-        rows.push({
-          id: Number(row[0]),
-          url: String(row[1]),
-          title: row[2] as string | null,
-          summary: row[3] as string | null,
-          tags: row[4] as string | null,
-          created_at: Number(row[5]),
-          domain: row[6] as string | null,
-          visit_duration: row[7] != null ? Number(row[7]) : null,
-          scroll_ratio: row[8] != null ? Number(row[8]) : null,
-          is_starred: Number(row[9]),
-          rank: 0,
-        });
-      }
-    );
-
-    return { success: true, rows, total };
-  } catch (error) {
-    logError('SQLite: search failed', { error: errorMessage(error) }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.search(searchQuery, limit, offset);
 }
 
 /**
  * Update a browsing log record by id.
  */
 export async function update(id: number, changes: Partial<BrowsingLogRecord>): Promise<{ success: true } | { success: false; error: string }> {
-  try {
-    const opfsResult = await engine.tryOpfsProxy<{ updated: boolean }>('UPDATE', { id, changes });
-    if (opfsResult !== null) return { success: true };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.update(id, changes);
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    const setClauses: string[] = [];
-    const params: SqliteValue[] = [];
-
-    for (const field of UPDATABLE_FIELDS) {
-      const f = field as keyof BrowsingLogRecord;
-      if (f in changes) {
-        setClauses.push(`${f} = ?`);
-        params.push(changes[f] ?? null);
-      }
-    }
-
-    if (setClauses.length === 0) {
-      return { success: true };
-    }
-
-    params.push(id);
-    await engine.execWithCache(
-      `UPDATE browsing_logs SET ${setClauses.join(', ')} WHERE id = ?`,
-      params
-    );
-
-    return { success: true };
-  } catch (error) {
-    logError('SQLite: update failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.update(id, changes as Record<string, unknown>);
 }
 
 /**
@@ -433,183 +69,42 @@ export async function update(id: number, changes: Partial<BrowsingLogRecord>): P
  * FTS5 triggers automatically clean up the FTS index.
  */
 export async function hardDelete(id: number): Promise<{ success: true } | { success: false; error: string }> {
-  try {
-    const opfsResult = await engine.tryOpfsProxy<{ deleted: boolean }>('DELETE', id);
-    if (opfsResult !== null) return { success: true };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.hardDelete(id);
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    await engine.execWithCache('DELETE FROM browsing_logs WHERE id = ?', [id]);
-    return { success: true };
-  } catch (error) {
-    logError('SQLite: hardDelete failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.delete(id);
 }
 
 /**
  * Toggle the starred status of a record.
  */
 export async function toggleStar(id: number): Promise<{ success: true; is_starred: number } | { success: false; error: string }> {
-  try {
-    const opfsResult = await engine.tryOpfsProxy<{ is_starred: number }>('TOGGLE_STAR', id);
-    if (opfsResult !== null) return { success: true, is_starred: opfsResult.is_starred };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.toggleStar(id);
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    await engine.execWithCache(
-      'UPDATE browsing_logs SET is_starred = CASE WHEN is_starred = 0 THEN 1 ELSE 0 END WHERE id = ?',
-      [id]
-    );
-    let newStarred = 0;
-    await engine.execWithCache(
-      'SELECT is_starred FROM browsing_logs WHERE id = ?',
-      [id],
-      (row: SqliteValue[]) => {
-        newStarred = Number(row[0]);
-      }
-    );
-    return { success: true, is_starred: newStarred };
-  } catch (error) {
-    logError('SQLite: toggleStar failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.toggleStar(id);
 }
 
 /**
  * Get the total number of records (excluding soft-deleted).
  */
 export async function getCount(): Promise<{ success: true; count: number } | { success: false; error: string }> {
-  try {
-    const opfsResult = await engine.tryOpfsProxy<{ count: number }>('GET_COUNT');
-    if (opfsResult !== null) return { success: true, count: opfsResult.count };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.getCount();
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    let _count = 0;
-    await engine.execWithCache(
-      'SELECT COUNT(*) FROM browsing_logs WHERE is_deleted = 0',
-      [],
-      (row: SqliteValue[]) => {
-        _count = Number(row[0]);
-      }
-    );
-
-    return { success: true, count: _count };
-  } catch (error) {
-    logError('SQLite: getCount failed', { error: errorMessage(error) }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.getCount();
 }
 
 /**
  * Check if the database is initialized and accessible.
  */
 export async function getStatus(): Promise<{ success: true; initialized: boolean; path: string; fallback: boolean; initError?: string; fts5: boolean; compileOptions?: string[]; compileOptionsSource?: 'opfs-worker' | 'idb' | 'fallback' } | { success: false; error: string }> {
-  try {
-    // OPFS Worker path
-    const opfsResult = await engine.tryOpfsProxy<{ initialized: boolean; path: string; fallback: boolean; fts5: boolean; count: number; compileOptions?: string[] }>('STATUS');
-    if (opfsResult !== null) {
-      return { success: true, initialized: opfsResult.initialized, path: opfsResult.path, fallback: opfsResult.fallback, fts5: opfsResult.fts5, compileOptions: opfsResult.compileOptions, compileOptionsSource: 'opfs-worker' };
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      const countResult = await engine.fallbackStorage.getCount();
-      const count = countResult.success ? countResult.count : 0;
-      return { success: true, initialized: count >= 0, path: 'chrome.storage.local', fallback: true, fts5: false, compileOptionsSource: 'fallback' };
-    }
-
-    if (!engine.dbHandle || !engine.sqlite3) {
-      // Try to initialize if not yet initialized (consistent with query/search)
-      await engine.init();
-      // If init switched to fallback, return fallback status
-      if (engine.usingFallbackStorage && engine.fallbackStorage) {
-        return { success: true, initialized: true, path: 'chrome.storage.local', fallback: true, fts5: false, compileOptionsSource: 'fallback' };
-      }
-      if (!engine.dbHandle) {
-        return { success: true, initialized: false, path: DB_FILENAME, fallback: false, initError: engine.lastInitError || 'Init returned false', fts5: false, compileOptionsSource: 'idb' };
-      }
-    }
-
-    let _count = 0;
-    await engine.execWithCache(
-      'SELECT COUNT(*) FROM browsing_logs',
-      [],
-      (row: SqliteValue[]) => {
-        _count = Number(row[0]);
-      }
-    );
-
-    return { success: true, initialized: true, path: DB_FILENAME, fallback: false, fts5: engine.fts5Available, compileOptions: engine.cachedCompileOptions ?? undefined, compileOptionsSource: 'idb' };
-  } catch (error) {
-    logError('SQLite: getStatus failed', { error: errorMessage(error) }, ErrorCode.STORAGE_READ_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  const result = await backend.getStatus();
+  if (!result.success) return result;
+  return { ...result, path: DB_FILENAME };
 }
 
 /**
  * Clear all browsing logs from the database (GDPR Art.17 hard delete).
  */
 export async function clearAll(): Promise<{ success: boolean; error?: string }> {
-  try {
-    const opfsResult = await engine.tryOpfsProxy<{ cleared: boolean }>('CLEAR_ALL');
-    if (opfsResult !== null) return { success: true };
-
-    if (!engine.dbHandle && !engine.usingFallbackStorage) {
-      await engine.init();
-    }
-
-    if (engine.usingFallbackStorage && engine.fallbackStorage) {
-      return engine.fallbackStorage.clearAll();
-    }
-
-    if (!engine.dbHandle) {
-      return { success: false, error: 'Database not initialized' };
-    }
-
-    await engine.sqlite3!.exec(engine.dbHandle!, `BEGIN IMMEDIATE;
-      DELETE FROM browsing_logs;
-      DELETE FROM browsing_logs_fts;
-      COMMIT;
-    `);
-
-    await engine.sqlite3!.exec(engine.dbHandle!, 'PRAGMA wal_checkpoint(TRUNCATE);');
-
-    return { success: true };
-  } catch (error) {
-    logError('SQLite: clearAll failed', { error: errorMessage(error) }, ErrorCode.STORAGE_WRITE_FAILURE, 'sqlite');
-    return { success: false, error: errorMessage(error) };
-  }
+  const backend = await engine.getBackend();
+  return backend.clearAll();
 }
 
 /**

--- a/src/offscreen/schema.ts
+++ b/src/offscreen/schema.ts
@@ -379,6 +379,41 @@ export const AUDIT_LOG_SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_audit_log_created ON audit_log(created_at);
 `;
 
+/** Columns added via ALTER TABLE migration (idempotent). */
+export const MIGRATION_COLUMNS = [
+  'content TEXT',
+  'masked_count INTEGER',
+  'cleansed_reason TEXT',
+  'ai_provider TEXT',
+  'ai_model TEXT',
+  'ai_duration_ms INTEGER',
+  'obsidian_duration_ms INTEGER',
+  'sent_tokens INTEGER',
+  'received_tokens INTEGER',
+  'original_tokens INTEGER',
+  'cleansed_tokens INTEGER',
+  'page_bytes INTEGER',
+  'candidate_bytes INTEGER',
+  'original_bytes INTEGER',
+  'cleansed_bytes INTEGER',
+  'ai_summary_original_bytes INTEGER',
+  'ai_summary_cleansed_bytes INTEGER',
+  'extracted_sentences_bytes INTEGER',
+  'extracted_sentences_original_bytes INTEGER',
+  'fallback_triggered INTEGER DEFAULT 0',
+] as const;
+
+/** Ordered sequence of one-off migrations. */
+export interface MigrationStep {
+  sql: string;
+  id: string;
+}
+
+export const MIGRATION_SEQUENCE: readonly MigrationStep[] = [
+  { sql: 'ALTER TABLE browsing_logs ADD COLUMN obsidian_synced INTEGER DEFAULT 0', id: 'obsidian_synced' },
+  { sql: 'ALTER TABLE browsing_logs ADD COLUMN gist_synced INTEGER DEFAULT 0', id: 'gist_synced' },
+] as const;
+
 // ============================================================================
 // Shared query utilities (M16)
 // ============================================================================

--- a/src/offscreen/sqlite.ts
+++ b/src/offscreen/sqlite.ts
@@ -52,6 +52,12 @@ export {
   queryAuditLog,
 } from './auditLogRepo.js';
 
+export { NoopBackend } from './StorageBackend.js';
+export type { StorageBackend, StatusResult } from './StorageBackend.js';
+export { OpfsWorkerBackend } from './OpfsWorkerBackend.js';
+export { IdbVfsBackend } from './IdbVfsBackend.js';
+export { FallbackStorageAdapter } from './FallbackStorageAdapter.js';
+
 /** Reset the module state for testing. */
 export function _resetForTesting(): void {
   engine.resetForTesting();

--- a/src/offscreen/sqliteEngineContext.ts
+++ b/src/offscreen/sqliteEngineContext.ts
@@ -32,7 +32,7 @@ const PREPARED_STMT_CACHE_MAX_SIZE = 50;
  * A single module-level instance (`engine`, below) is shared by all repos —
  * this mirrors the original sqlite.ts, which had this state at module scope.
  */
-class SqliteEngineContext {
+export class SqliteEngineContext {
   dbHandle: number | null = null;
   sqlite3: SQLiteAPI | null = null;
   initPromise: Promise<boolean> | null = null;

--- a/src/offscreen/sqliteEngineContext.ts
+++ b/src/offscreen/sqliteEngineContext.ts
@@ -16,7 +16,8 @@ import { LruCache } from './lruCache.js';
 import { StorageKeys } from '../utils/storage/types.js';
 import { NoopBackend } from './StorageBackend.js';
 import type { StorageBackend } from './StorageBackend.js';
-import { SCHEMA_SQL, GIST_SYNCED_INDEX_SQL, FTS5_SQL, AUDIT_LOG_SCHEMA_SQL, INSERT_IGNORE_SQL, buildInsertParams } from './schema.js';
+import { SCHEMA_SQL, AUDIT_LOG_SCHEMA_SQL, INSERT_IGNORE_SQL, buildInsertParams } from './schema.js';
+import { runMigrations, type MigrationEngine } from './migrations.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type SqliteValue = number | string | Uint8Array | Array<number> | bigint | null;
@@ -258,82 +259,19 @@ export class SqliteEngineContext {
       await this.sqlite3.exec(this.dbHandle, SCHEMA_SQL);
       await this.sqlite3.exec(this.dbHandle, AUDIT_LOG_SCHEMA_SQL);
 
-      // Schema migration: add obsidian_synced column if not present (Phase 6)
-      try {
-        await this.sqlite3.exec(this.dbHandle, 'ALTER TABLE browsing_logs ADD COLUMN obsidian_synced INTEGER DEFAULT 0');
-      } catch {
-        // Column already exists — that's fine
-      }
-
-      // PBI-11: add gist_synced column for per-target sync flags
-      try {
-        await this.sqlite3.exec(this.dbHandle, 'ALTER TABLE browsing_logs ADD COLUMN gist_synced INTEGER DEFAULT 0');
-      } catch {
-        // Column already exists — that's fine
-      }
-      await this.sqlite3.exec(this.dbHandle, GIST_SYNCED_INDEX_SQL);
-
-      // FTS5 virtual table (optional — WASM build may not include FTS5)
-      this.fts5Available = false;
-      try {
-        await this.sqlite3.exec(this.dbHandle, FTS5_SQL);
-        this.fts5Available = true;
-
-        // I2: If base table has rows but FTS index is empty, rebuild the index.
-        // This handles the case where rows existed before FTS triggers were added.
-        try {
-          let baseCount = 0;
-          await this.execWithCache('SELECT COUNT(*) FROM browsing_logs', [], (row: SqliteValue[]) => { baseCount = Number(row[0]); });
-          let ftsCount = 0;
-          await this.execWithCache('SELECT COUNT(*) FROM browsing_logs_fts', [], (row: SqliteValue[]) => { ftsCount = Number(row[0]); });
-          if (baseCount > 0 && ftsCount === 0) {
-            console.info('SQLite IDB: FTS index empty, rebuilding...');
-            await this.sqlite3.exec(this.dbHandle, "INSERT INTO browsing_logs_fts(browsing_logs_fts) VALUES('rebuild')");
-            console.info('SQLite IDB: FTS index rebuild complete');
-          }
-        } catch (rebuildErr) {
-          console.warn('SQLite IDB: FTS rebuild check failed:', rebuildErr);
-        }
-      } catch (ftsErr) {
-        console.warn('SQLite: FTS5 not available, using LIKE-based search fallback', ftsErr);
-      }
-
-      // PBI-1: ALTER TABLE migration for new diagnostic metadata columns
-      const newColumns = [
-        'content TEXT',
-        'masked_count INTEGER',
-        'cleansed_reason TEXT',
-        'ai_provider TEXT',
-        'ai_model TEXT',
-        'ai_duration_ms INTEGER',
-        'obsidian_duration_ms INTEGER',
-        'sent_tokens INTEGER',
-        'received_tokens INTEGER',
-        'original_tokens INTEGER',
-        'cleansed_tokens INTEGER',
-        'page_bytes INTEGER',
-        'candidate_bytes INTEGER',
-        'original_bytes INTEGER',
-        'cleansed_bytes INTEGER',
-        'ai_summary_original_bytes INTEGER',
-        'ai_summary_cleansed_bytes INTEGER',
-        'extracted_sentences_bytes INTEGER',
-        'extracted_sentences_original_bytes INTEGER',
-        'fallback_triggered INTEGER DEFAULT 0',
-      ];
-
-      for (const colDef of newColumns) {
-        try {
-          await this.sqlite3.exec(this.dbHandle, `ALTER TABLE browsing_logs ADD COLUMN ${colDef}`);
-        } catch (err) {
-          // Column already exists — safe to ignore
-          // Log unexpected errors (disk full, corruption, etc.) so they are surfaced
-          const msg = err instanceof Error ? err.message : String(err);
-          if (!msg.includes('duplicate column name')) {
-            console.warn('SQLite: unexpected ALTER TABLE error:', msg);
-          }
-        }
-      }
+      // Run schema migrations through shared migration engine
+      const idbEngine: MigrationEngine = {
+        exec: async (sql) => {
+          await this.execWithCache(sql, []);
+        },
+        queryValue: async (sql) => {
+          let val: number | null = null;
+          await this.execWithCache(sql, [], (row: SqliteValue[]) => { val = Number(row[0]); });
+          return val;
+        },
+      };
+      const { fts5Available } = await runMigrations(idbEngine);
+      this.fts5Available = fts5Available;
 
       // Log available extensions
       const compileOptions: string[] = [];

--- a/src/offscreen/sqliteEngineContext.ts
+++ b/src/offscreen/sqliteEngineContext.ts
@@ -14,6 +14,8 @@ import { IDBBatchAtomicVFS } from 'wa-sqlite/src/examples/IDBBatchAtomicVFS.js';
 import { FallbackStorage } from './storageFallback.js';
 import { LruCache } from './lruCache.js';
 import { StorageKeys } from '../utils/storage/types.js';
+import { NoopBackend } from './StorageBackend.js';
+import type { StorageBackend } from './StorageBackend.js';
 import { SCHEMA_SQL, GIST_SYNCED_INDEX_SQL, FTS5_SQL, AUDIT_LOG_SCHEMA_SQL, INSERT_IGNORE_SQL, buildInsertParams } from './schema.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -41,6 +43,8 @@ export class SqliteEngineContext {
   lastInitError: string | null = null;
   fts5Available = false;
   cachedCompileOptions: string[] | null = null;
+
+  private _backend: StorageBackend | null = null;
 
   // OPFS Worker state
   opfsWorker: Worker | null = null;
@@ -476,9 +480,53 @@ export class SqliteEngineContext {
     return 'none';
   }
 
+  async getBackend(): Promise<StorageBackend> {
+    if (this._backend) return this._backend;
+
+    // Try OPFS Worker first
+    try {
+      const { OpfsWorkerBackend } = await import('./OpfsWorkerBackend.js');
+      this._backend = new OpfsWorkerBackend(this);
+      return this._backend;
+    } catch {
+      // fall through
+    }
+
+    // Try IDB VFS
+    try {
+      if (!this.usingFallbackStorage) {
+        await this.init();
+        if (this.dbHandle) {
+          const { IdbVfsBackend } = await import('./IdbVfsBackend.js');
+          this._backend = new IdbVfsBackend(this);
+          return this._backend;
+        }
+      }
+    } catch {
+      // fall through
+    }
+
+    // Try Fallback
+    if (this.fallbackStorage) {
+      const { FallbackStorageAdapter } = await import('./FallbackStorageAdapter.js');
+      this._backend = new FallbackStorageAdapter(this.fallbackStorage);
+      return this._backend;
+    }
+
+    // Null Object — never throw
+    this._backend = new NoopBackend();
+    return this._backend;
+  }
+
+  /** Reset backend selection (used by resetForTesting / offscreen recreate). */
+  resetBackend(): void {
+    this._backend = null;
+  }
+
   /** Reset the module state for testing. */
   resetForTesting(): void {
     this.clearPreparedStmtCache();
+    this.resetBackend();
     this.dbHandle = null;
     this.sqlite3 = null;
     this.initPromise = null;

--- a/src/utils/sqlite-types.ts
+++ b/src/utils/sqlite-types.ts
@@ -44,8 +44,8 @@ export interface BrowsingLogRecord {
   fallback_triggered?: number | null;
 }
 
-// Dashboard row type derived from BrowsingLogRecord (no is_deleted, id is required)
-export type BrowsingLogEntry = Omit<BrowsingLogRecord, 'is_deleted'> & { id: number };
+// Dashboard row type derived from BrowsingLogRecord (id is required)
+export type BrowsingLogEntry = BrowsingLogRecord & { id: number };
 
 export interface QueryOptions {
   /** Maximum number of rows to return */


### PR DESCRIPTION
## Summary

SQLite レイヤーの5つのアーキテクチャ改善。

### 変更内容

**1. 3バックエンド分岐を StorageBackend アダプタに統一**
- `StorageBackend` インターフェース + 3アダプタ（OpfsWorker / IDB VFS / Fallback）+ NoopBackend
- `recordsRepo.ts` / `dbMaintenance.ts` / `auditLogRepo.ts` から ~842 行の重複分岐ロジックを削除
- 各リポジトリ関数は `backend.operation()` の1行呼び出しに

**2. エラー伝播の構造化（PBI #4）**
- `SqliteClient.call()` が `null` ではなく `CallResult<T>` を返す
- タイムアウト / offscreen 喪失 / クォータ超過 / SQLite エラーを分類
- ダッシュボード UI までエラーメッセージが伝播

**3. opfsWorker.ts 型重複 + マイグレーション共有化（PBI #2 + #5）**
- 重複していた `BrowsingLogRecord` 等のインライン型定義を削除、共有インポートに
- `migrations.ts` にスキーママイグレーションを統合、両バックエンドから呼び出し

**4. sqliteHistoryPanel.ts テスタビリティ向上（PBI #3）**
- レンダリング関数をグローバル state/DOM からパラメータ化

### Stats

- 20 commits, 41 files, +4283 / -1280 lines
- 6977 tests pass, 0 type errors

### Design Docs

- `docs/superpowers/specs/2026-07-13-*.md`（5件）
- `dev-docs/ADR/2026-07-13-sqlite-architecture-deep-dig.md`

### Test Plan

- [x] `npm test` — 6977 passed
- [x] `npm run type-check` — 0 errors
- [x] `npm run build` — succeeds