### PR TITLE
refactor(i18n): PBI 3 Phase 1-2 - Add new privacy mode keys

### DIFF
--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -1329,18 +1329,18 @@
             </div>
 
             <div class="mt-10">
-              <input type="radio" id="modeC" name="privacyMode" value="masked_cloud" aria-describedby="modeCDesc">
-              <label for="modeC"><strong data-i18n="modeC">Mode C: Masked Cloud</strong> <span
-                  data-i18n="modeCRecommended">(Recommended)</span></label>
-              <div class="help-text ml-24" id="modeCDesc" data-i18n="modeCDesc">
+              <input type="radio" id="privacyModeMaskedCloud" name="privacyMode" value="masked_cloud" aria-describedby="privacyModeMaskedCloudDesc">
+              <label for="privacyModeMaskedCloud"><strong data-i18n="privacyModeMaskedCloud">Masked Cloud</strong> <span
+                  data-i18n="privacyModeMaskedCloudRecommended">(Recommended)</span></label>
+              <div class="help-text ml-24" id="privacyModeMaskedCloudDesc" data-i18n="privacyModeMaskedCloudDesc">
                 Send only masked data to cloud AI.
               </div>
             </div>
 
             <div class="mt-10">
-              <input type="radio" id="modeD" name="privacyMode" value="cloud_only" aria-describedby="modeDDesc">
-              <label for="modeD"><strong data-i18n="modeD">Mode D: Cloud Only</strong></label>
-              <div class="help-text ml-24" id="modeDDesc" data-i18n="modeDDesc">
+              <input type="radio" id="privacyModeCloudOnly" name="privacyMode" value="cloud_only" aria-describedby="privacyModeCloudOnlyDesc">
+              <label for="privacyModeCloudOnly"><strong data-i18n="privacyModeCloudOnly">Cloud Only</strong></label>
+              <div class="help-text ml-24" id="privacyModeCloudOnlyDesc" data-i18n="privacyModeCloudOnlyDesc">
                 Send raw text directly to cloud AI.
               </div>
             </div>

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -577,19 +577,19 @@
           </div>
 
           <div class="mt-10">
-            <input type="radio" id="modeC" name="privacyMode" value="masked_cloud" aria-describedby="modeCDesc">
-            <label for="modeC"><strong data-i18n="modeC">Mode C: Masked Cloud</strong> <span
-                data-i18n="modeCRecommended">(Recommended)</span></label>
-            <div class="help-text ml-24" id="modeCDesc" data-i18n="modeCDesc">
+            <input type="radio" id="privacyModeMaskedCloud" name="privacyMode" value="masked_cloud" aria-describedby="privacyModeMaskedCloudDesc">
+            <label for="privacyModeMaskedCloud"><strong data-i18n="privacyModeMaskedCloud">Masked Cloud</strong> <span
+                data-i18n="privacyModeMaskedCloudRecommended">(Recommended)</span></label>
+            <div class="help-text ml-24" id="privacyModeMaskedCloudDesc" data-i18n="privacyModeMaskedCloudDesc">
               Send only masked data to cloud AI.<br>
               For environments where local AI is not available.
             </div>
           </div>
 
           <div class="mt-10">
-            <input type="radio" id="modeD" name="privacyMode" value="cloud_only" aria-describedby="modeDDesc">
-            <label for="modeD"><strong data-i18n="modeD">Mode D: Cloud Only</strong></label>
-            <div class="help-text ml-24" id="modeDDesc" data-i18n="modeDDesc">
+            <input type="radio" id="privacyModeCloudOnly" name="privacyMode" value="cloud_only" aria-describedby="privacyModeCloudOnlyDesc">
+            <label for="privacyModeCloudOnly"><strong data-i18n="privacyModeCloudOnly">Cloud Only</strong></label>
+            <div class="help-text ml-24" id="privacyModeCloudOnlyDesc" data-i18n="privacyModeCloudOnlyDesc">
               Send raw text directly to cloud AI.<br>
               Prioritize speed.
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yasumaro",
-  "version": "6.5.49",
+  "version": "6.5.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yasumaro",
-      "version": "6.5.47",
+      "version": "6.5.50",
       "license": "MIT",
       "dependencies": {
         "@subframe7536/sqlite-wasm": "~1.3.1",

--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -14,7 +14,7 @@
 |-----|--------|--------|------|
 | [2026-07-22-01-doc-response-size-limit-adr.md](2026-07-22-01-doc-response-size-limit-adr.md) | 🟡中 | 🟢なし | ✅ |
 | [2026-07-22-02-refactor-response-size-limit-detection.md](2026-07-22-02-refactor-response-size-limit-detection.md) | 🔴高 | 🟡軽微 | 🔶 |
-| [2026-07-22-03-refactor-i18n-mode-key-names.md](2026-07-22-03-refactor-i18n-mode-key-names.md) | 🟡中 | 🔴あり | ⬜ |
+| [2026-07-22-03-refactor-i18n-mode-key-names.md](2026-07-22-03-refactor-i18n-mode-key-names.md) | 🟡中 | 🔴あり | 🔶 |
 
 新規PBIは `pbi/YYYY-MM-DD-NN-type-slug.md` として作成してください。
 

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -380,6 +380,27 @@
   "modeDDesc": {
     "message": "Send raw text directly to cloud AI.\nPrioritize speed."
   },
+  "privacyModeMaskedCloud": {
+    "message": "Masked Cloud"
+  },
+  "privacyModeMaskedCloudShort": {
+    "message": "Masked Cloud"
+  },
+  "privacyModeMaskedCloudDesc": {
+    "message": "Send only masked data to cloud AI (including LM Studio and Ollama).\nFor environments where browser built-in AI is not available."
+  },
+  "privacyModeMaskedCloudRecommended": {
+    "message": "(Recommended)"
+  },
+  "privacyModeCloudOnly": {
+    "message": "Cloud Only"
+  },
+  "privacyModeCloudOnlyShort": {
+    "message": "Cloud Only"
+  },
+  "privacyModeCloudOnlyDesc": {
+    "message": "Send raw text directly to cloud AI.\nPrioritize speed."
+  },
   "confirmSettings": {
     "message": "Confirmation Settings"
   },

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -362,6 +362,27 @@
   "modeDDesc": {
     "message": "生のテキストをそのままクラウドAIへ送信。\n速度優先。"
   },
+  "privacyModeMaskedCloud": {
+    "message": "Masked Cloud"
+  },
+  "privacyModeMaskedCloudShort": {
+    "message": "Masked Cloud"
+  },
+  "privacyModeMaskedCloudDesc": {
+    "message": "PIIのみマスクしてクラウドAI（LM StudioやOllamaも含む）へ送信。\nブラウザ内蔵AIが使えない環境向け。"
+  },
+  "privacyModeMaskedCloudRecommended": {
+    "message": "（推奨）"
+  },
+  "privacyModeCloudOnly": {
+    "message": "Cloud Only"
+  },
+  "privacyModeCloudOnlyShort": {
+    "message": "Cloud Only"
+  },
+  "privacyModeCloudOnlyDesc": {
+    "message": "生のテキストをそのままクラウドAIへ送信。\n速度優先。"
+  },
   "confirmSettings": {
     "message": "確認設定"
   },

--- a/src/popup/__tests__/statusPanel-extra.test.ts
+++ b/src/popup/__tests__/statusPanel-extra.test.ts
@@ -113,6 +113,8 @@ const defaultMessages: Record<string, string> = {
   modeBShort: 'Full',
   modeCShort: 'Masked',
   modeDShort: 'Cloud',
+  privacyModeMaskedCloudShort: 'Masked',
+  privacyModeCloudOnlyShort: 'Cloud',
   domainAddedToWhitelist: 'Domain added',
   pathAddedToWhitelist: 'Path added',
   saveDomain: 'Save domain',


### PR DESCRIPTION
## Summary

This PR implements Phase 1 and Phase 2 of PBI 3 (i18n key renaming for privacy modes).

### Changes

- **Added new i18n keys** to  (both English and Japanese):
  -  (replaces )
  -  (replaces )
  -  (replaces )
  -  (replaces )
  -  (replaces )
  -  (replaces )
  -  (replaces )

- **Updated HTML files** to use new keys:
  - 
  - 

- **Kept old keys** for backward compatibility (Phase 3 will remove them later)

- **Updated test mock** in  to include new keys

- **Updated package-lock.json** version to match package.json (6.5.50)

### Testing

- Type check: ✅ Passed
- Build: ✅ Passed
- Related tests: ✅ Passed (38/38 in statusPanel-extra.test.ts)

### Notes

- Old keys (, , etc.) are still present in  for backward compatibility
- Phase 3 (removing old keys) will be done in a future PR after confirming no issues
- This is part of the Checking Team review findings (2026-07-22)