### PR TITLE
fix(ci): CRX3ヘッダーにsigned_header_dataフィールドを追加

### DIFF
--- a/.github/workflows/build-crx3.mjs
+++ b/.github/workflows/build-crx3.mjs
@@ -34,9 +34,15 @@ function encodeAsymmetricKeyProof(publicKeyDer, signature) {
   ]);
 }
 
-function encodeCrxFileHeader(proofBuf) {
-  // message CrxFileHeader { repeated AsymmetricKeyProof sha256_with_rsa = 2; ... }
-  return encodeLengthDelimitedField(2, proofBuf);
+function encodeCrxFileHeader(proofBuf, signedDataBuf) {
+  // message CrxFileHeader {
+  //   repeated AsymmetricKeyProof sha256_with_rsa = 2;
+  //   optional bytes signed_header_data = 10000;
+  // }
+  return Buffer.concat([
+    encodeLengthDelimitedField(2, proofBuf),
+    encodeLengthDelimitedField(10000, signedDataBuf),
+  ]);
 }
 
 function buildCrx3(zipPath, keyPath, outputPath) {
@@ -64,7 +70,7 @@ function buildCrx3(zipPath, keyPath, outputPath) {
   const signature = sign.sign(privateKey);
 
   const proof = encodeAsymmetricKeyProof(publicKeyDer, signature);
-  const header = encodeCrxFileHeader(proof);
+  const header = encodeCrxFileHeader(proof, signedData);
 
   const magic = Buffer.from('Cr24', 'utf8');
   const version = Buffer.alloc(4);


### PR DESCRIPTION
## Summary
- v6.6.4のChrome Web Store公開が `PKG_CANNOT_VERIFY_CRX_SIGNATURE` で失敗
- 原因: Chromiumの CRX3 実装は `CrxFileHeader` protobuf に `signed_header_data`（field 10000、署名対象の SignedData のシリアライズ済みバイト列）を含める必要があるが、`build-crx3.mjs` はこのフィールドを省略していたため、Chrome Web Store 側で署名検証ができなかった
- `signed_header_data` フィールドを追加

## Test plan
- [x] ローカルでCRX3を生成し、手動でprotobufをパースして signed_header_data フィールドの存在と署名検証成功を確認済み
- [ ] マージ後、新しいバージョンタグでリリースしChrome Web Store公開が成功することを確認