### PR TITLE
debug: CRX公開鍵フィンガープリント確認用（一時）

### DIFF
--- a/.github/workflows/debug-crx-pubkey.yml
+++ b/.github/workflows/debug-crx-pubkey.yml
@@ -1,0 +1,27 @@
+name: Debug CRX Public Key
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Print public key fingerprint (no private data)
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          echo "${CRX_PRIVATE_KEY}" > /tmp/private.pem
+          echo "=== Key info ==="
+          openssl rsa -in /tmp/private.pem -noout -text 2>/dev/null | grep -E "Private-Key|Modulus " || true
+          openssl rsa -in /tmp/private.pem -pubout -outform DER 2>/dev/null > /tmp/public.der
+          echo "SPKI DER length (bytes): $(wc -c < /tmp/public.der)"
+          echo "SPKI DER SHA256: $(sha256sum /tmp/public.der | cut -d' ' -f1)"
+          echo "SPKI DER base64:"
+          base64 -w0 /tmp/public.der
+          echo ""
+          rm -f /tmp/private.pem /tmp/public.der


### PR DESCRIPTION
一時的なデバッグ用ワークフロー。CRX_PRIVATE_KEY secretから導出される公開鍵のSHA256フィンガープリントをログに出力し、Chrome Web Store Dashboardに登録済みの公開鍵と一致するか確認する。秘密鍵の値は一切出力しない。確認後に削除する。