### PR TITLE
chore(audit): Add VulnHunter PBIs and branch coverage tests

### DIFF
--- a/dev-docs/archived/pbi/2026-08-29-01-fix-release-check-blockers.md
+++ b/dev-docs/archived/pbi/2026-08-29-01-fix-release-check-blockers.md
@@ -46,8 +46,8 @@ Then 全カテゴリが PASS になる
 
 - [x] `public/_locales/en/messages.json` に `modelsDevDialogTitle`, `tabAll`, `tabAggregator`, `tabOthers` が追加されている
 - [x] `public/_locales/ja/messages.json` に上記4キーの日本語訳が追加されている
-- [ ] `npm run test:coverage` で `branches >= 90.0%` かつ `lines >= 90.0%`（2026-08-29 時点 88.94%まで改善、残り ~130 branches。以下14ファイルで branches カバレッジテストを追加済み、マージ済み: masterPassword.ts(69→97.5%), stripExtended.ts(69→86%), historyPendingPanel.ts(74→100%), migration.ts(59→98%), promptSanitizer.ts(67→96%), historyEntryRow.ts(84→100%), OpenAIProvider.ts(76→95%), createBackgroundServices.ts(49→100%), tagClusterPanZoom.ts(67→92%), storageFallback.ts(85→99%), legacyMigration.ts(85→99%), domainFilterTagUI.ts(75→98%), privacy.ts(76→84%), sessionStore.ts(80→92%)。再開手順: `npm run test:coverage` で最新の未達ファイル一覧を取得し、branches 不足の多いファイル順に同様のテスト追加を継続。直近のフルカバレッジ実行が vitest-pool の worker timeout で不安定だったため、再開時はまず `npm run test:coverage` を単独実行してインフラ起因の flake でないか確認すること）
-- [ ] `npm run release:check:fast` が全カテゴリ PASS（tests カテゴリのみ coverage 未達で FAIL）
+- [x] `npm run test:coverage` で `branches >= 90.0%` かつ `lines >= 90.0%`（2026-08-29 完了時点: branches 90.41% / lines 96.42%。経緯: 14ファイルへのテスト追加で 88.94% まで改善後、環境要因で `eslint` が node_modules から欠落し `eslint/__tests__` の2スイートが失敗していた状態を解消（`npm install` 実行）すると、クリーンなフル実行で 90.02% まで回復。ゲート余裕 (~2 branches) が薄かったためバッファとして5ファイル（permissionManager / onboardingWizard / privacySettings / manualContentFetcher / sourceManager）に branches カバレッジテストを追加し +47 branches）
+- [x] `npm run release:check:fast` が全カテゴリ PASS（7/7 PASS。ローカル生成物 `sbom.json` が欠落していたため `npm run generate-sbom` で再生成）
 - [x] `npm run validate` が PASS
 - [x] 追加・変更した i18n キー/テストがレビュー不要の範囲を超える場合、コードレビュー済み
 
@@ -77,7 +77,7 @@ Then 全カテゴリが PASS になる
 
 ## Definition of Done
 
-- [ ] 全 BDD シナリオが自動テスト/チェックスクリプトでパスする
-- [ ] コードレビュー完了
-- [ ] ドキュメント更新不要（PBI 作成時点で README/コメントに変更なし）
-- [ ] `pbi/00-INDEX.md` の進行中表に本 PBI が記載され、完了時にアーカイブ履歴へ移動
+- [x] 全 BDD シナリオが自動テスト/チェックスクリプトでパスする
+- [x] コードレビュー完了
+- [x] ドキュメント更新不要（PBI 作成時点で README/コメントに変更なし）
+- [x] `pbi/00-INDEX.md` の進行中表に本 PBI が記載され、完了時にアーカイブ履歴へ移動

--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -18,7 +18,7 @@
 
 | ファイル | タイトル | 状態 | 種別 | 難易度 | 副作用 | RICE |
 |---|---|---|---|---|---|---|
-| [2026-08-29-01-fix-release-check-blockers.md](./2026-08-29-01-fix-release-check-blockers.md) | リリース前チェックのブロッカー2件を解消する | ⬜ 未着手 | 🔧 | 🟡中 | 🟢なし | 4800 |
+| （なし — 未完了PBIなし） | | | | | | |
 
 ---
 
@@ -41,6 +41,10 @@
 
 完了済みPBIは [dev-docs/archived/pbi/](../dev-docs/archived/pbi/)、
 その実装計画は [dev-docs/archived/plans/](../dev-docs/archived/plans/) にある。
+
+### 2026-08-29 リリース前チェックのブロッカー解消 完了
+
+- 2026-08-29-01-fix-release-check-blockers.md（RICE 4800 — i18n 未翻訳4キー（`modelsDevDialogTitle`/`tabAll`/`tabAggregator`/`tabOthers`）を en/ja に追加し check-i18n を PASS に。branches カバレッジは14ファイルへのテスト追加（88.94%）に加え、node_modules の `eslint` 欠落で失敗していた `eslint/__tests__` 2スイートを `npm install` で解消して 90.02% に回復させ、ゲート余裕確保のため permissionManager / onboardingWizard / privacySettings / manualContentFetcher / sourceManager の5ファイルにテストを追加し 90.41%（+47 branches）。欠落していたローカル生成物 `sbom.json` を `npm run generate-sbom` で再生成。`release:check:fast` 7/7 PASS / `validate` PASS / 10580 tests PASS）
 
 ### 2026-08-28 RateLimiter/SessionAlarms Service化 完了
 

--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -18,7 +18,21 @@
 
 | ファイル | タイトル | 状態 | 種別 | 難易度 | 副作用 | RICE |
 |---|---|---|---|---|---|---|
-| （なし — 未完了PBIなし） | | | | | | |
+| [2026-08-29-00-backlog-vulnhunt-audit.md](2026-08-29-00-backlog-vulnhunt-audit.md) | VulnHunter監査48件のバックログ（RICE＋なぜなぜ分析＋トレーサビリティ） | ⬜ | 🔧 | - | - | 索引 |
+| [2026-08-29-01-fix-regex-safety.md](2026-08-29-01-fix-regex-safety.md) | 正規表現安全性 — ReDoS封鎖（VULN-025/026） | ⬜ | 🔧 | 🟢 | 🟡 | 4750 |
+| [2026-08-29-02-fix-markdown-sanitizer-boundary.md](2026-08-29-02-fix-markdown-sanitizer-boundary.md) | Markdown/Obsidian出力サニタイズ境界確立（VULN-001/008/047） | ⬜ | 🔧 | 🟡 | 🟡 | 2375 |
+| [2026-08-29-03-fix-response-body-caps.md](2026-08-29-03-fix-response-body-caps.md) | レスポンス読み込みバイト上限ユーティリティ（VULN-013/015/027/054/055） | ⬜ | 🔧 | 🟡 | 🟡 | 1663 |
+| [2026-08-29-04-fix-storage-rmw-serialization.md](2026-08-29-04-fix-storage-rmw-serialization.md) | chrome.storage読み書きの直列化（VULN-003/005/009/012/050/056） | ⬜ | 🔧 | 🟡 | 🟡 | 1440 |
+| [2026-08-29-05-fix-query-limit-clamp.md](2026-08-29-05-fix-query-limit-clamp.md) | SQLiteクエリlimit両側クランプ統一（VULN-017/021/048/049） | ⬜ | 🔧 | 🟢 | 🟢 | 1330 |
+| [2026-08-29-06-fix-trust-boundary-consistency.md](2026-08-29-06-fix-trust-boundary-consistency.md) | 信頼境界一貫性 — ゲート迂回解消（VULN-002/011/018/042） | ⬜ | 🔧 | 🟡 | 🔴 | 1260 |
+| [2026-08-29-07-fix-lock-cas-correctness.md](2026-08-29-07-fix-lock-cas-correctness.md) | ロック/CAS運用の正しさ（VULN-028/029） | ⬜ | 🔧 | 🟢 | 🟢 | 1125 |
+| [2026-08-29-08-fix-resource-boundary-caps.md](2026-08-29-08-fix-resource-boundary-caps.md) | リソース上限とライフサイクル境界強制（VULN-004/006/007/024/041/051/053） | ⬜ | 🔧 | 🟡 | 🟡 | 1080 |
+| [2026-08-29-09-fix-fetch-redirect-ssrf.md](2026-08-29-09-fix-fetch-redirect-ssrf.md) | FETCH_URLリダイレクト再検証（VULN-016） | ⬜ | 🔧 | 🟢 | 🟡 | 1000 |
+| [2026-08-29-10-fix-log-integrity.md](2026-08-29-10-fix-log-integrity.md) | ログ完全性 — attributionと制御文字無害化（VULN-019/044） | ⬜ | 🔧 | 🟢 | 🟢 | 713 |
+| [2026-08-29-11-fix-storagefallback-mutate.md](2026-08-29-11-fix-storagefallback-mutate.md) | storageFallbackミューテータ統一（VULN-022） | ⬜ | 🔧 | 🟢 | 🟢 | 475 |
+| [2026-08-29-12-fix-crypto-policy-ssot.md](2026-08-29-12-fix-crypto-policy-ssot.md) | 暗号・認証ポリシーSSOT化（VULN-010/037/038/039/040/052） | ⬜ | 🔧 | 🔴 | 🔴 | 453 |
+| [2026-08-29-13-fix-import-pipeline-safety.md](2026-08-29-13-fix-import-pipeline-safety.md) | インポート経路安全化 — 認証→上限→パース→検証（VULN-023/030/034/035/036） | ⬜ | 🔧 | 🟡 | 🟡 | 405 |
+| [2026-08-29-14-fix-security-hardening-code-quality.md](2026-08-29-14-fix-security-hardening-code-quality.md) | Code Qualityハードニング一括＋orphan-key機能バグ | ⬜ | 🔧 | 🟢 | 🟡 | 255 |
 
 ---
 

--- a/pbi/2026-08-29-00-backlog-vulnhunt-audit.md
+++ b/pbi/2026-08-29-00-backlog-vulnhunt-audit.md
@@ -1,0 +1,326 @@
+# バックログ優先度一覧 — 2026-08-29 VulnHunter 監査対応
+
+## 候補の列挙（フェーズ0）
+
+VulnHunter 2026-08-29 スキャン（Run ID: `obsidian-smart-history_VULNHUNT_RESULTS_2026-08-29-165536`、
+ブランチ `fix/test-updates-and-cleanup [5d3005a6]`）で確認された **48件の脆弱性（Medium 3 / Low 45）**
+と **Code Quality 9件** を、修正戦略が共通するルート原因ごとにクラスタリングし、14候補に整理した。
+
+| # | 候補（クラスタ） | 含まれる指摘 | 種別 |
+|---|---|---|---|
+| C1 | 正規表現安全性（線形検証・ワイルドカード上限・保存時バリデーション） | VULN-025(M), 026 | fix |
+| C2 | Markdown/Obsidian 出力サニタイズ境界の確立 | VULN-001(M), 008, 047 ＋ VULN-045/046 相当のハードニング | fix |
+| C3 | レスポンスボディ読み込みのバイト上限ユーティリティ | VULN-013, 015, 027, 054, 055 | fix |
+| C4 | chrome.storage 読み書きの直列化（RMW・単一実行・CAS） | VULN-003, 005, 009, 012, 050, 056 | fix |
+| C5 | SQLite クエリ limit の両側クランプ統一 | VULN-017, 021, 048, 049 | fix |
+| C6 | 信頼境界の一貫性（ゲート迂回経路の解消） | VULN-002, 011, 018, 042 | fix |
+| C7 | ロック/CAS 運用の正しさ（try/finally・current マージ） | VULN-028, 029 | fix |
+| C8 | リソース上限とライフサイクルの境界強制 | VULN-004, 006, 007, 024, 041, 051, 053 | fix |
+| C9 | FETCH_URL リダイレクト再検証（SSRF） | VULN-016 | fix |
+| C10 | ログ完全性（attribution・制御文字無害化） | VULN-019, 044 | fix |
+| C11 | storageFallback ミューテータ統一 | VULN-022(M) | fix |
+| C12 | 暗号・認証ポリシーの単一情報源化 | VULN-010, 037, 038, 039, 040, 052 | fix |
+| C13 | インポート経路の安全化（認証→上限→パース→検証） | VULN-023, 030, 034, 035, 036 | fix |
+| C14 | Code Quality ハードニング一括（機能バグ1件含む） | orphan-key bug, CSPValidator 自己許可, urlWhitelist 自己許可, Gemini path, TSV 数式無害化, models-dev スキーマ検証, 旧a.hrefパネル | fix |
+
+- 全 48 指摘 + Code Quality 9件が過不足なく C1–C14 に割り当て済み（トレーサビリティ表は下記）
+- 誤検知6件（VULN-014/020/031/032/033/043）とスイープ除去2件（VULN-045/046）は PBI 化対象外
+  （045/046 のシンクは C2 にハードニングとして吸収）
+
+---
+
+## 各候補の理解（フェーズ1）
+
+| 候補 | 何を作るか | 誰のため | なぜ必要 | 制約 |
+|---|---|---|---|---|
+| C1 | `DOMAIN_VALIDATION` を線形 label-wise 検証に置換、`matchesPattern` を `wildcardToRegex`（上限付き）に統一、フィルタ保存時バリデーション | 全利用者（第三者配信フィルタリストを購読する人） | 実測 8.3秒の指数 ReDoS が Service Worker を停止。1 regex 置換で消える最安の Medium | 正当なドメイン（`*.example.com` 等）を拒否しないこと、既存テスト 47件の互換維持 |
+| C2 | `sanitizeForObsidian` の HTML エンティティ化、結合安全なフラグメントエスケープヘルパー、4 消費者への適用 | Obsidian 連携利用者全員 | ページ由来 HTML が日次ノートにそのまま書かれ、レンダラ次第で実行されうる（実証済み） | ノートの可読性を損なわないエンティティ化、既存 3+1 消費者の出力互換 |
+| C3 | `readBodyCapped(response, maxBytes)` を新設し 8 シンク（Obsidian/FETCH_URL/Tranco/AI×4/Gist）を置換 | 全利用者 | Content-Length 省略（chunked）で上限が無効化され SW メモリ枯渇（実証: 64–200MB 確保） | タイムアウト維持、post-read チェックは防御深度として残す |
+| C4 | 6 サイト（MarkdownBufferManager/pendingStorage/logger storageAdapter/PersistentRetryQueue/notificationHandlers/optimisticLock）に CAS/Mutex/単一実行を適用 | 全利用者（通常運用でデータ消失が起きうる） | MV3 のマルチコンテキスト並行性でエントリ消失・重複記録・ジョブロストが実証済み | 既存 `withOptimisticLock`/`Mutex` パターンの再利用、`aiUsageTracker` を正解パターンとする |
+| C5 | `queryPlan` と handler で `Math.max(1, Math.min(...))` に統一（4 シンク） | ダッシュボード利用者 | `LIMIT -1` が SQLite で無制限を意味し、監査ログ全件materialization が可能 | 読み取り系の既定値（100/50/1000）維持 |
+| C6 | loader 両ブランチで SW CHECK_DOMAIN 待ち、オフラインリプレイの force 解除、`confirm_token` サブタイプ廃止＋パーアクション発行、権限レベルラダー | 全利用者 | ページ属性・リプレイ・同一チャネル・権限要求の 4 経路が trust シームを迂回する | e2e テスト互換、破壊的操作 UX 維持、既存 PermissionManager 再利用 |
+| C7 | trancoUpdater を try/finally 化、trustDb updateFn を current マージ型に修正 | 全利用者 | 1 回の失敗で Tranco 更新が恒久ロックアウト、同時書き込みの差分が静黙に失われる | ロック API 契約の型表現 |
+| C8 | schema 駆動 payloadGuard、書き込み境界での truncate/cap（header value・tags・文数・ノード数）、`local_export_*` retention、`clearExpiredPages` 配線 | 全利用者 | 無限成長（8.9GB/5年モデル）と二次計算の O(n²) 爆発が実証済み | 上限値は既存 precedent（1024文字/50タグ等）に合わせる |
+| C9 | FETCH_URL に `redirect: 'error'`（または manual + ホップ毎再検証）を適用 | フィルタリスト import 利用者 | 許可 URL → private IP へのリダイレクトで SW が内部応答を取得・返却（実証済み） | 正常なリダイレクト（同一オリジン http→https 等）の扱いを決める |
+| C10 | LOG_FORWARD の `_source` を sender 由来に、logger 境界で制御文字/ANSI 無害化 | 全利用者 | ログの偽装・多行注入が永続化される（実証済み）。障害解析の一次証跡が信頼できない | PII マスク維持、性能影響なし |
+| C11 | storageFallback に `mutate(fn)` ヘルパーを新設し 8 ミューテータ全てを経由させる | OPFS 不使用環境の利用者 | 6/8 ミューテータがロックなしで RMW → purge が取り消される等（実証済み） | OPFS 正常環境への影響ゼロ（フォールバック専用） |
+| C12 | 暗号パラメータ SSOT（iterations・ポリシー・KDF ラッパー）、KEK session-only 化＋`deriveHmacWrappingKey` 配線、RateLimit の local 永続化、init mutex、弱い平行実装削除 | マスターパスワード設定者 | 硬化版が実装済みでも死蔵コードのため弱い経路が本番に残る（5 指摘の共通根） | アンロック UX・既存暗号データの移行互換 |
+| C13 | 共通インポートプリミティブ（認証→サイズ上限→パース→行検証）を 3 系統に適用、YAML フロントマター エスケープ、validateRow 全フィールド化 | ファイル import 利用者 | 復号・パースが署名検証より先に走り、署名なし履歴偽造が可能（実証済み） | 既存エクスポートファイルの後方互換（iterations フィールド追加は任意読み込み） |
+| C14 | orphan-key ホワイトリストバグ修正（`StorageKeys.DOMAIN_WHITELIST` 経由）、CSPValidator/urlWhitelist 自己許可の締め直し、Gemini path エンコード、TSV 数式無害化、models-dev スキーマ検証、旧a.hrefパネルに isSecureUrl | 全利用者 | 機能が沈黙して効かないバグ1件＋将来の攻撃面になるハードニング6件 | 既存 UI 動作の非破壊 |
+
+不足情報なし。監査レポート（README.md / phase2b / phase3 / phase3d）と全 PoC から復元可能。
+
+---
+
+## 優先度付け（フェーズ2） — RICE
+
+### スコアリング
+
+**計算式**: `RICE = (Reach × Impact × Confidence) / Effort`（Effort 単位: 人月。1pt ≈ 0.1人月）
+
+| 順位 | 候補 | Reach | Impact | Confidence | Effort | RICE | 根拠 |
+|---|---|---|---|---|---|---|---|
+| 1 | C1 regex 安全性 | 1000 | 0.5 | 0.95 | 0.1 | **4750** | 第三者配信フィルタリストで全利用者が攻撃対象（unauth-web 相当）。実測 8.3秒の指数 ReDoS。修正は 1 regex 置換＋ヘルパー再利用で最安 |
+| 2 | C2 Markdown サニタイズ境界 | 1000 | 0.5 | 0.95 | 0.2 | **2375** | Medium の HTML 注入。ページ→ノート経路は全 Obsidian 連携ユーザーに到達。消費者 4 箇所の統一で 2pt |
+| 3 | C3 レスポンス読み込み上限 | 1000 | 0.35 | 0.95 | 0.2 | **1663** | 5 指摘・8 シンクを 1 ユーティリティで解消。攻撃者は任意サイトの応答ヘッダ/ボディ（chunked）で到達可能 |
+| 4 | C4 storage RMW 直列化 | 800 | 0.4 | 0.9 | 0.2 | **1440** | 通常の MV3 並行動作で記録・ログ・リトライジョブが静黙消失（攻撃不要）。データ完全性 Impact |
+| 5 | C5 limit 両側クランプ | 400 | 0.35 | 0.95 | 0.1 | **1330** | DASHBOARD_SQLITE は extension-only（Reach 抑制）だが監査ログ全件流出・無制限 materialization。修正は clamp 1 行系 |
+| 6 | C6 信頼境界一貫性 | 700 | 0.4 | 0.9 | 0.2 | **1260** | 002（任意ページがゲート迂回）を含む 4 指摘。セマンティクス変更（リプレイ force 解除等）で Confidence 0.9 |
+| 7 | C7 ロック/CAS 運用 | 500 | 0.25 | 0.9 | 0.1 | **1125** | 恒久ロックアウト＋CAS LWW。発生頻度は低いが復旧に手動介入が必要 |
+| 8 | C8 リソース上限・ライフサイクル | 800 | 0.3 | 0.9 | 0.2 | **1080** | 長期利用での無限成長（実測モデル 8.9GB/5年）＋O(n²) 爆発。全利用者の長期健全性 |
+| 9 | C9 リダイレクト SSRF | 300 | 0.35 | 0.95 | 0.1 | **1000** | FETCH_URL 経由（extension-only＋import ユーザー）だが private IP 到達は実証済み。fetch.ts 1 箇所修正 |
+| 10 | C10 ログ完全性 | 300 | 0.25 | 0.95 | 0.1 | **713** | ログ偽造は診断信頼性の問題（情報影響）。logger 1 境界＋handler 1 箇所 |
+| 11 | C11 storageFallback 統一 | 100 | 0.5 | 0.95 | 0.1 | **475** | Medium だがフォールバックモード（OPFS 不使用環境）限定で Reach 低。修正はヘルパー抽出 1 件 |
+| 12 | C12 暗号 SSOT | 400 | 0.4 | 0.85 | 0.3 | **453** | KEK 平文・100k KDF・レート制限迂回等の実質。ただし暗号変更は回帰リスクが高く Confidence/Effort を penalize |
+| 13 | C13 インポート安全化 | 300 | 0.3 | 0.9 | 0.2 | **405** | 署名なし履歴偽造（035）を含む。ファイル import ユーザー限定 |
+| 14 | C14 Code Quality 一括 | 300 | 0.15 | 0.85 | 0.15 | **255** | 機能バグ 1＋ハードニング 6。個々は小さいが束ねて 1 PBI |
+
+### 依存関係と並列性（Wave 提案）
+
+- **Wave 1（全並列・ファイル触接なし）**: 01 regex / 02 markdown / 03 body-caps / 05 limit-clamp / 09 redirect-ssrf
+- **Wave 2（並列可）**: 04 storage-RMW / 07 lock-CAS / 08 resource-caps / 10 log-integrity / 11 fallback / 13 import
+  - 注意: 03（systemHandlers.ts:98-108）と 10（systemHandlers.ts:258-264）は同一ファイル → マージ時に要コンフリクト確認
+  - 04（optimisticLock.ts）と 07（trustDb/trancoUpdater）は理論上 04 のロック強化が 07 の CAS 修正と相互作用 → 04 先着手を推奨
+- **Wave 3（高リスク・単独）**: 06 trust-boundary / 12 crypto-SSOT — 既存動作のセマンティクス変更を含むためレビュー強化
+- **任意タイミング**: 14 code-quality
+
+### 最終順位
+
+1. `2026-08-29-01-fix-regex-safety.md`（RICE 4750）
+2. `2026-08-29-02-fix-markdown-sanitizer-boundary.md`（2375）
+3. `2026-08-29-03-fix-response-body-caps.md`（1663）
+4. `2026-08-29-04-fix-storage-rmw-serialization.md`（1440）
+5. `2026-08-29-05-fix-query-limit-clamp.md`（1330）
+6. `2026-08-29-06-fix-trust-boundary-consistency.md`（1260）
+7. `2026-08-29-07-fix-lock-cas-correctness.md`（1125）
+8. `2026-08-29-08-fix-resource-boundary-caps.md`（1080）
+9. `2026-08-29-09-fix-fetch-redirect-ssrf.md`（1000）
+10. `2026-08-29-10-fix-log-integrity.md`（713）
+11. `2026-08-29-11-fix-storagefallback-mutate.md`（475）
+12. `2026-08-29-12-fix-crypto-policy-ssot.md`（453）
+13. `2026-08-29-13-fix-import-pipeline-safety.md`（405）
+14. `2026-08-29-14-fix-security-hardening-code-quality.md`（255）
+
+---
+
+## 疑問の解決 — なぜなぜ分析（フェーズ3）
+
+各クラスタの「なぜその問題が存在するのか」を 5 Whys で根源まで掘り下げ、
+**原因 → 示唆 → 解** を導出した。PBI の修正方針はすべてこの解に基づく。
+
+### C1: なぜ Service Worker が 8 秒固まるのか？
+
+1. **なぜ固まる？** → 検証 regex が入力長に対し指数的にバックトラックする（実測: 22ドット→253ms、30ドット→8265ms）。
+2. **なぜ指数的？** → 文字クラス内のドットが partition ambiguity を生む nested-quantifier 構造のため、1 文字が多数の解析経路を持つ。
+3. **なぜそのような regex が許される？** → `wildcardToRegex` には `MAX_WILDCARDS_PER_PATTERN=5` の上限があるのに、検証用 regex は別実装で複雑度のレビューを受けていない。
+4. **なぜレビューされない？** → ReDoS を検出するテスト規約（状態数増加の計数・タイミングテスト）が codebase に存在しない。
+5. **なぜ規約がない？** → 「ユーザー/第三者由来の文字列から regex を作るな。作るなら線形であることを証明せよ」という設計原則が文書化されていない。
+
+**原因 → 示唆 → 解**:
+- 原因: `ublockParser/constants.ts:43` の構造（singular choke point）と `urlSkipper.ts:52-58` の無上限展開。
+- 示唆: 15 regex サイトのうち 13 は境界付きで安全（スイープ済み）。問題は「パターン→regex 変換の複雑度保証がない」ことのみ。
+- 解: 検証を label-wise 線形処理に置換、matchesPattern を上限付き wildcardToRegex に統一、保存時バリデーションで未検証保存（domainFilter.ts:319-337）を封鎖、タイミング/状態数テストを規約化。
+
+### C2: なぜ HTML が Obsidian ノートに書かれるのか？
+
+1. **なぜ HTML が乗る？** → `sanitizeForObsidian` が markdown リンク/wikiリンク構文のみをエスケープし、HTML タグは素通し（実証済み）。
+2. **なぜリンク構文だけ？** → 当初の脅威モデルが「リンク経由フィッシング」に限定され、HTML は Obsidian 側のレンダラが無害化するという楽観があった。
+3. **なぜ楽観が放置される？** → 関数名が「サニタイズ済み」を宣言しているのに、実際は部分変換であることが型やテストで表現されていない。
+4. **なぜ表現されない？** → 「Obsidian に書き出してよい文字列」の不変条件（出力境界の契約）が設計文書に存在しない。
+5. **なぜ存在しない？** → sink 側で保証する設計（boundary guarantee）が codebase の原則として確立されておらず、各消費者が場当たり的に防御してきた。
+
+**原因 → 示唆 → 解**:
+- 原因: 境界関数の契約が曖昧＋4 消費者が同一の join パターンを複製（formatMarkdownStep/markdownExport/saveLocalMarkdownStep/markdownFormatter）。
+- 示唆: 16 呼び出しサイトはすべて単一 choke point を通るため、境界関数を正せば全消費者が治る（スイープ: 16/8 ファイル、Remaining 0）。
+- 解: `sanitizeForObsidian` に HTML エンティティ化を追加（完全境界化）、結合安全なフラグメントエスケープヘルパーを新設して join 前に各断片へ適用、境界契約を DESIGN_SPECIFICATIONS に明記。死蔵 sync-target（045/046）にも同一ヘルパーを事前適用。
+
+### C3: なぜメモリが攻撃者の支配下にあるのか？
+
+1. **なぜメモリが尽きる？** → `response.text()/json()` が応答全体を SW メモリにバッファする（実証: 64–200MB 確保）。
+2. **なぜ全体をバッファ？** → 上限チェックが Content-Length ヘッダの存在を前提とし、chunked（ヘッダ省略）で素通しする。
+3. **なぜヘッダ依存？** → サイズ上限が「検証」ではなく「読み取り後/読み取り前の条件分岐」として各所に手書きされている。
+4. **なぜ手書き？** → fetch ヘルパー層（`fetchWithTimeout`）が時間だけを抽象し、サイズの抽象を持たない。
+5. **なぜサイズを抽象しない？** → 「ネットワーク入力はバイト上限内でのみ読む」という取得規約が存在しない。
+
+**原因 → 示唆 → 解**:
+- 原因: `response.text()` の素使用が 12 本番シンクに散在（うち 8 が攻撃到達可能）。
+- 示唆: 1 つのユーティリティ（バイトカウント付きストリーミング読み取り）で全シンクを置換でき、将来の fetch 追加も規約で防げる。
+- 解: `readBodyCapped(response, maxBytes)` を新設、8 シンクを置換、既存 post-read チェックは防御深度として維持。
+
+### C4: なぜ通常運用でデータが消えるのか？
+
+1. **なぜデータが消える？** → get→mutate→set の RMW が他コンテキストの書き込みを stale スナップショットで上書きする。
+2. **なぜ上書きされる？** → 52 ファイル中 20 の RMW 形状サイトのうち、ロック適用は 4 サイトのみ（スイープ済み）。
+3. **なぜ適用されない？** → ロック（`withOptimisticLock`/`Mutex`）はオプトイン API で、使わなくても型・lint で検出されない。
+4. **なぜ検出されない？** → `StoragePort` に「共有キーへの RMW は CAS 経由のみ」という API 規約・強制がなく、生 `chrome.storage` 直参照が許容されている。
+5. **なぜ許容される？** → MV3 の SW/popup/dashboard/offscreen 並行性が設計原則として明文化されず、単一コンテキスト前提の実装が混在してきた。
+
+**原因 → 示唆 → 解**:
+- 原因: 6 確認サイト（buffer/pending/logger/queue/notification/optimisticLock 内部）の個別事情ではなく、規約の欠如。
+- 示唆: 正解パターン（`aiUsageTracker` の `withCounterLock`、`contextMenuHandlers` の single-flight、`savedUrlRepository` の CAS）は codebase 内に既存。
+- 解: 6 サイトに既存パターンを適用、`optimisticLock` の verify→set を Mutex で直列化、「RMW は CAS 経由」を DESIGN_SPECIFICATIONS に明記し Coverage/レビュー観点に追加。
+
+### C5: なぜ `LIMIT -1` が全件返すのか？
+
+1. **なぜ全件？** → SQLite は負の LIMIT を「無制限」と解釈する。
+2. **なぜ素通し？** → 4 シンクの clamp が `Math.min`（上側）のみ。
+3. **なぜ上側だけ？** → limit を「大きすぎる値の問題」としてのみ捉え、符号を問題視していなかった。
+4. **なぜ視野が狭い？** → limit 検証の共通関数がなく、handler/engine/mapper の各層で重複実装されている。
+5. **なぜ重複する？** → `queryPlan.ts`（ADR 2026-08-27-limit-policy）に集約しきれておらず、層ごとの手当てが残存している。
+
+**原因 → 示唆 → 解**:
+- 原因: `Math.max(1, …)` の欠落（queryPlan.ts:78-80、readOnlyHandler、auditHandlers、IdbVfsBackend、recordsRepo）。
+- 示唆: queryPlan が共有経路のため engine 側 1 箇所＋handler ミラーで網羅できる。
+- 解: 両側クランプを queryPlan と handler に統一実装し、4 シンクを境界値テスト（-1/0/0.5/1e9）で固定。
+
+### C6: なぜ信頼ゲートを迂回できるのか？
+
+1. **なぜ迂回できる？** → ドメイン検証（002）、パイプラインゲート（011）、confirm トークン（018）、権限要求（042）に SW トラストシームを通らない経路が存在する。
+2. **なぜ経路が増えた？** → e2e テスト、オフライン再送、UX 便宜（同一チャネルでのトークン取得、1 クリックの広い権限）のために個別にショートカットが追加された。
+3. **なぜショートカットが許された？** → 「特権操作は必ず MessageRouter の sender 検証を通る」という不変条件がメッセージ型にしか適用されていない。
+4. **なぜメッセージ型だけ？** → 網羅性テスト（senderTrustCoverage）の対象がメッセージ経路のみ。
+5. **なぜ限定される？** → 動的 import・リプレイ・権限要求といった非メッセージ経路を「信頼境界」として認識していなかった。
+
+**原因 → 示唆 → 解**:
+- 原因: trust シームの適用範囲定義の欠如（テストはメッセージ網羅のみ）。
+- 示唆: 各迂回経路には正解経路が既存（SW CHECK_DOMAIN、パイプラインゲート、パーアクショントークン、PermissionManager）。
+- 解: loader 両ブランチで SW 検証を await、リプレイを force:false 化、`confirm_token` 読み取りサブタイプ廃止＋ジェスチャ時発行、`activeTab`→per-origin→明示オプトインのレベルラダー、網羅性テストを非メッセージ経路へ拡張。
+
+### C7: なぜロックと CAS が誤用されるのか？
+
+1. **なぜ恒久ロックする？** → `updateInProgress` の解除がループ脱出経路にのみ存在し、例外で到達不能。
+2. **なぜ到達不能？** → try/finally を使っていない（制御フローで保証していない）。
+3. **なぜ CAS が効かない？** → `updateFn` が `_currentDb` を無視して stale スナップショットを返す。
+4. **なぜ無視する？** → コールバック契約（current を受け取りマージ結果を返す）が型で表現されていない。
+5. **なぜ表現されない？** → ロック API の誤用パターン（finally 忘れ・current 無視）を検出する lint 規則/契約テストがない。
+
+**原因 → 示唆 → 解**:
+- 原因: 手続き的なロック運用（API が強制しない）。
+- 示唆: 8 CAS 呼び出しサイトのうち 7 は正しく current を消費（スイープ済み）— 誤用は 1 箇所のみ。
+- 解: try/finally 化、updateFn のマージ実装、ロック API 契約テスト（finally カバレッジ・current 消費検証）を追加。
+
+### C8: なぜリソースが無限に育つのか？
+
+1. **なぜ育つ？** → 書き込み経路に上限がなく、クリーンアップ（purge）が呼ばれていない。
+2. **なぜ上限がない？** → 上限が読み取り/表示側に置かれ、書き込み境界で強制していない。
+3. **なぜ書き込み側がない？** → `payloadGuard` の対象列がハードコードで、schema から導出していない。
+4. **なぜ導出しない？** → schema を単一情報源とする規約が guard 実装時に適用されなかった。
+5. **なぜ適用されなかった？** → 「後で列を追加する」負債がトラッキングされず、guard と schema の乖離が検出されない。
+
+**原因 → 示唆 → 解**:
+- 原因: schema（TEXT 列 7 個）と guard（3 列）の乖離、purge 制御のデッドコード化、境界での truncate 欠落。
+- 示唆: 既存 precedent（1024 文字 truncate、50 タグ cap、日次 purge alarm）が存在し、配線/適用だけで解決する。
+- 解: schema 駆動 guard 化、privacyChecker/pipeline 境界での truncate、`clearExpiredPages` を日次 purge alarm に配線、`local_export_*` の retention、TextRank/tagCooccurrence/tagCluster への入力 cap。
+
+### C9: なぜリダイレクト先が検証されないのか？
+
+1. **なぜ private IP に届く？** → `validateUrlForFilterImport` は初期 URL のみ検証し、`fetch` がリダイレクトを黙って追跡する。
+2. **なぜ追跡する？** → `fetchWithTimeout` が `redirect` モードを指定せず、ブラウザ既定（follow）に委ねている。
+3. **なぜ指定しない？** → リダイレクトを脅威として扱う規約が fetch ヘルパーにない。
+4. **なぜ規約がない？** → 17 fetch サイトのうち攻撃者影響 URL は FETCH_URL 1 箇所のみで、汎用化する動機がなかった。
+5. **なぜ動機がない？** → 「検証はホップ毎に有効」という原則が文書化されていない（初期 URL 検証で足りるという誤解）。
+
+**原因 → 示唆 → 解**:
+- 原因: `systemHandlers.ts:87` で検証済み URL の応答を無検証で追跡。
+- 示唆: `redirect: 'error'` 1 行で塞げる。正規の http→https リダイレクトが壊れる場合は manual＋ホップ毎再検証に拡張。
+- 解: FETCH_URL の fetch にリダイレクト方針を実装し、fetch.ts に hop-level 再検証ヘルパーを追加（将来の攻撃者影響 URL fetch 向け規約化）。
+
+### C10: なぜログが偽造できるのか？
+
+1. **なぜ偽造できる？** → attribution が payload の `source`、本文が外部応答（エラー body）からそのまま永続化される。
+2. **なぜそのまま？** → logger のサニタイズが PII マスクのみで、制御文字/ANSI/行構造を扱わない。
+3. **なぜ PII のみ？** → logger の要件定義がプライバシーに限定され、完全性（改ざん耐性・構造保全）を要件に含めていない。
+4. **なぜ含めない？** → ログの消費者が dashboard ビューアで「人が読む表示」と扱われてきた。
+5. **なぜそう扱う？** → ログが障害解析・監査の一次証跡であるという位置づけが明文化されていない。
+
+**原因 → 示唆 → 解**:
+- 原因: logger 境界の無害化欠落＋LOG_FORWARD の attribution 混線。
+- 示唆: logger の永続化経路は単一 choke point（VULN-044 の Obsidian 2 シンクも経由）。
+- 解: `_source` を sender.url 由来に、logger 境界で `\n\r`/制御文字/ANSI を無害化（LOG_FORWARD の message/details 同時カバー）。
+
+### C11: なぜフォールバックエンジンだけ壊れているのか？
+
+1. **なぜ更新が消える？** → update/hardDelete/toggleStar/clearAll/purge 系 6 メソッドがロックなし RMW。
+2. **なぜロックなし？** → insert/insertBatch を直した際に同一パターンを他へ展開しなかった。
+3. **なぜ展開しない？** → 共有ヘルパーがなく、各メソッドが load→mutate→save を手続き複製している。
+4. **なぜ複製する？** → 「8 ミューテータは同一の安全性要件を持つ」という認識がコードに表現されていない。
+5. **なぜ表現されない？** → フォールバックエンジンが第二級実装とみなされ、OPFS 側に比べて監査・テストが薄い。
+
+**原因 → 示唆 → 解**:
+- 原因: `storageFallback.ts` のミューテータ複製（2/8 のみ mutex 済み）。
+- 示唆: `mutate(fn)` ヘルパー 1 本で 8 メソッドを直列化でき、insert 系の手書きロックも統一できる。
+- 解: ヘルパー新設＋全ミューテータ経由化＋レーステスト（purge×toggleStar の実証シナリオ）。
+
+### C12: なぜ弱い暗号経路が本番に残るのか？
+
+1. **なぜ残る？** → 硬化版（600k iterations、strict policy、deriveHmacWrappingKey）が実装済みでも呼び出しが 0 の死蔵コード。
+2. **なぜ死蔵？** → 呼び出し側が平行実装の弱い方（`utils/masterPassword`、`settingsExportImport` 独自 KDF）に配線されたまま。
+3. **なぜ弱い方に配線？** → 2 実装のどちらが「正」かを示す SSOT・ドキュメントが存在しない。
+4. **なぜ SSOT がない？** → iterations・ポリシー・KEK ストレージモードが各所にハードコードされている。
+5. **なぜハードコード？** → 暗号定数の一元化リファクタが優先化されず、平行実装の追加がレビューで止められてこなかった。
+
+**原因 → 示唆 → 解**:
+- 原因: crypto パラメータの散在（primitives.ts:16 vs :28、2 つの masterPassword 実装、2 つの KDF 経路）。
+- 示唆: 硬化版は既存・テスト済み。配線の付け替え＋弱い方の削除が本体。
+- 解: `ENVELOPE_ITERATIONS` を SSOT 化して 3 経路（export/password-change/settings）に適用、KEK を session-only＋deriveHmacWrappingKey 配線、RateLimit カウンタを storage.local 永続化、get-or-create 3 流路に `encryptionKeyMutex` パターン適用、password policy を strict 版に一本化し弱い実装を削除。
+
+### C13: なぜインポートが検証より先にリソースを使うのか？
+
+1. **なぜ先に使う？** → パース・復号・KDF が署名検証より前に走る（settings/logs/backup の 3 系統全てで順序不統一）。
+2. **なぜ不統一？** → インポート機能が別々の時期・作者で独立実装され、共通プリミティブがない。
+3. **なぜプリミティブがない？** → 「ファイル取り込みは認証→上限→パース→検証の順」という規約が存在しない。
+4. **なぜ規約がない？** → インポート経路の security review が機能単位でしか行われず、横断比較がされてこなかった。
+5. **なぜ横断しない？** → 3 系統の差異（署名の有無、上限の有無、検証フィールド数）が一覧化されていなかった。
+
+**原因 → 示唆 → 解**:
+- 原因: `importLogsService`（署名なし・2/9 フィールド検証）、`settingsExportImport`（HMAC 後置・atob 増幅）、`encryptedBackupPanel`（上限前パース）。
+- 示唆: settings 側の HMAC ゲートは正解実装として存在（fail-closed 実証済み）。
+- 解: 共通インポートプリミティブ（authenticate→size-cap→parse→validate）を確立し 3 系統に適用、`validateRow` 全 9 フィールド化、YAML フロントマター エスケープ、エクスポート側署名付与。
+
+### C14: なぜ「効かない機能」と「自己許可」が残るのか？
+
+1. **なぜホワイトリスト追加が効かない？** → popup が orphan キー `'domainWhitelist'` に書き、正キー `domain_whitelist` の読み手がいない。
+2. **なぜ誤る？** → キー名を literal で書き `StorageKeys` 定数を経由していない。
+3. **なぜ literal が通る？** → キー名が string 型で、型システムが誤りを検出できない。
+4. **なぜ検出できない？** → StorageKeys の union 型化（typo 不可能化）が未実施。
+5. **なぜ未実施？** → キー追加時の規約（必ず StorageKeys 経由）が lint/レビューで強制されていない。
+
+**原因 → 示唆 → 解**:
+- 原因: orphan キー書き込み（機能バグ）＋CSPValidator/urlWhitelist の自己許可構造など 6 ハードニング。
+- 示唆: いずれも小修正。束ねて 1 PBI とし、個々に受け入れ基準を持たせる。
+- 解: orphan キー修正（StorageKeys 経由）、CSP ドメイン追加の厳格化、allowedUrls の自己許可封鎖、Gemini path エンコード、TSV 数式無害化、models-dev スキーマ検証、旧 href パネルの isSecureUrl 適用。
+
+---
+
+## トレーサビリティ（VULN-NNN → PBI）
+
+| VULN | PBI | VULN | PBI | VULN | PBI | VULN | PBI |
+|---|---|---|---|---|---|---|---|
+| 001 | 02 | 015 | 03 | 029 | 07 | 044 | 10 |
+| 002 | 06 | 016 | 09 | 030 | 13 | 047 | 02 |
+| 003 | 04 | 017 | 05 | 034 | 13 | 048 | 05 |
+| 004 | 08 | 018 | 06 | 035 | 13 | 049 | 05 |
+| 005 | 04 | 019 | 10 | 036 | 13 | 050 | 04 |
+| 006 | 08 | 021 | 05 | 037 | 12 | 051 | 08 |
+| 007 | 08 | 022 | 11 | 038 | 12 | 052 | 12 |
+| 008 | 02 | 023 | 13 | 039 | 12 | 053 | 08 |
+| 009 | 04 | 024 | 08 | 040 | 12 | 054 | 03 |
+| 010 | 12 | 025 | 01 | 041 | 08 | 055 | 03 |
+| 011 | 06 | 026 | 01 | 042 | 06 | 056 | 04 |
+| 012 | 04 | 027 | 03 | 043 | （誤検知） | | |
+| 013 | 03 | 028 | 07 | | | | |
+
+Code Quality 9件 → PBI 02（sync-target サニタイザ）、10（LOG_FORWARD 制御文字）、14（残り 7件）。
+誤検知 6件（014/020/031/032/033/043）とスイープ除去 2件（045/046）は対象外。
+
+---
+
+## PBI作成（フェーズ4）・ファイル出力（フェーズ5）
+
+上記順位で 14 PBI を `pbi/` に作成した。各 PBI は `pbi-create-bdd` 準拠
+（ユーザーストーリー / ビジネス価値 / 優先度RICE / BDD 4シナリオ / 受け入れ基準 / テスト戦略 / 実装アプローチ / 見積もり / 技術的考慮事項 / 実装者向け注記 / DoD）。
+
+- `pbi/2026-08-29-00-backlog-vulnhunt-audit.md` — 本ファイル（候補列挙・RICE・なぜなぜ分析・トレーサビリティ）
+- `pbi/2026-08-29-01-fix-regex-safety.md` ほか 14 件（ファイル名の `NN` が着手順を示す）
+
+**出典**: `obsidian-smart-history_VULNHUNT_RESULTS_2026-08-29-165536/`（README.md, phase2_merged_candidates.md, phase2b_output.md, phase3_output.md, phase3d_output.md, poc/, exploit_tests/）

--- a/pbi/2026-08-29-01-fix-regex-safety.md
+++ b/pbi/2026-08-29-01-fix-regex-safety.md
@@ -1,0 +1,109 @@
+# PBI: 正規表現安全性の確立 — ReDoS 封鎖（VULN-025/026, CWE-1333）
+
+## ユーザーストーリー
+利用者として、uBlock フィルタリストの読み込みや URL スキップ判定で Service Worker が固まらないようにしたい、なぜなら悪意ある/破損したフィルタ行や過剰なワイルドカードパターンによる指数バックトラック（実測 8.3秒）で記録機能全体が停止するから
+
+## ビジネス価値
+- Medium 脆弱性（VULN-025）の解消: 第三者配信のフィルタリスト 1 行で SW が停止し、録画・保存・すべての機能が stall する
+- Low（VULN-026）の解消: 保存済みパターン 1 件のマッチングで 3.2–8.8 秒/チェック（実証済み）
+- 測定方法: 30 ドット入力で `DOMAIN_VALIDATION` が O(n) になること（状態数増加の計数テスト＋タイミングテスト）、`urlSkipper` のワイルドカード数が 5 に cap されること
+
+## 優先度
+- 順位: 1 / 14
+- RICEスコア: 4750（Reach=1000 / Impact=0.5 / Confidence=95% / Effort=0.1人月）
+  - Reach 1000: フィルタリスト URL import は third-party 供給経路であり、全利用者が攻撃対象になりうる
+  - Impact 0.5: Medium（拡張全体の DoS。VulnHunter 3件の Medium のうち最も到達が容易）
+  - Confidence 95%: シンクと修正箇所が単一 choke point（constants.ts:43）に特定済み。実証 PoC/テスト済み
+  - Effort 0.1: regex 置換＋既存ヘルパー再利用＋テスト 1 ファイル
+- 根拠: 最安 Effort で最大 Impact を消す。スイープで「15 regex サイト中 13 は安全」が確認済みのため波及なし
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: 指数入力でも検証が線形時間で完了する
+  Given 30 個のドットを含むフィルタ行が与えられる
+  When DOMAIN_VALIDATION 検証を実行する
+  Then 検証は指数的な状態増加なく完了し
+  And 状態数の増加が入力長に対し線形であることが計数テストで確認される
+
+Scenario: 正当なワイルドカードドメインは引き続き受理される（回帰防止）
+  Given "*.example.com" と "example.com" のパターンが与えられる
+  When 検証とマッチングを実行する
+  Then いずれも受理され、マッチ判定は現行と同じ結果を返す
+
+Scenario: ワイルドカード過多のパターンは保存時に拒否される
+  Given 12 個のアンカー（ワイルドカード）を含むパターンが与えられる
+  When domainFilter の保存検証を実行する
+  Then パターンは拒否され storage に保存されない（現行モード以外のリストも含む）
+
+Scenario: urlSkipper のマッチは wildcardToRegex の上限を経由する
+  Given ワイルドカード 12 個の保存済みパターンが与えられる
+  When isDomainInList が URL マッチングを実行する
+  Then 展開は MAX_WILDCARDS_PER_PATTERN=5 の cap を経由し、16 アンカー入力でも多項式時間を超えない
+```
+
+## 受け入れ基準
+- [ ] `src/utils/ublockParser/constants.ts:43` の `DOMAIN_VALIDATION` が、split-on-dot＋label 検証（`^[a-z0-9_-]+$` 相当）による線形実装に置換されている
+- [ ] `src/content/urlSkipper.ts:52-58` の `matchesPattern` が `wildcardToRegex()`（`MAX_WILDCARDS_PER_PATTERN=5` cap 付き）を再利用している
+- [ ] `src/dashboard/settings/domainFilter.ts:319-337` の保存経路で、現行モード以外のリストもワイルドカード数・パターン妥当性の検証対象になっている
+- [ ] 状態数計数テスト（バックトラック状態の増加が線形）とタイミングテストが追加されている
+- [ ] 既存 `ublockParser` 47 件・`urlSkipper` 系テストが全てグリーン（正当パターンの挙動不変）
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: 30 ドット入力の実測時間が 100ms 未満、12 アンカーのマッチングが 100ms 未満
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（regex 単体で完全検証可能）
+
+### 統合テスト
+- `ublockParser` の import パイプライン経由: 悪意あるフィルタ行（30 ドット）を含むリストの import がタイムアウト内で完了し、正当行のみ反映されること
+
+### 単体テスト
+- 新規: `src/utils/ublockParser/__tests__/domainValidationLinear.test.ts`
+  - ビジネスロジック: 正当ドメイン/ワイルドカードの受理、不正文字の拒否
+  - 境界値: 63 文字ラベル、連続ドット、先頭 `*.`、空ラベル
+  - 例外/性能: 30 ドット入力の状態数計数（線形性）とタイミング上限
+- 新規: `src/content/__tests__/urlSkipperWildcardCap.test.ts`
+  - 12/16 アンカー入力での cap 動作、cap 違反パターンの拒否挙動
+
+## 実装アプローチ
+- **Outside-In**: まず `ublockParser` 統合テストを Red（現行 regex ではタイミング上限を主張できない）にし、線形実装で Green。次に urlSkipper をヘルパー統一で Green
+- **Red-Green-Refactor**: 検証関数の API（`validateDomain` 等）は維持し実装のみ置換
+
+## 見積もり
+1pt（要チームでの見積もり — regex 置換＋ヘルパー再利用＋テスト 2 ファイル）
+
+## 技術的考慮事項
+- 依存関係: なし（単独着手可。Wave 1 推奨）
+- テスタビリティ: 状態数計数は Python 実証テスト（`exploit_tests/test_vuln_025_redos_domain_validation.py`）の手法を Jest に移植
+- 非機能要件: 正当パターンの挙動を一切変えない（既存 47 テストが回帰ゲート）
+- 注意: `domainValidation.ts:7` / `trancoUpdater.ts:167` 等の既存境界付き regex には触れない（スイープで安全確認済み）
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '40,50p' src/utils/ublockParser/constants.ts
+sed -n '48,62p' src/content/urlSkipper.ts
+sed -n '315,340p' src/dashboard/settings/domainFilter.ts
+sed -n '14,24p' src/utils/wildcardToRegex.ts
+```
+
+### 実装手順
+1. `constants.ts` の `DOMAIN_VALIDATION` を「`*.` プレフィックス分離 → `split('.')` → 各ラベルを線形検証」に置換
+2. `urlSkipper.matchesPattern` を `wildcardToRegex` 経由に変更（5 wildcards 超は false 扱い＋保存時に拒否）
+3. 保存時バリデーションを `domainFilter` の全モード経路に適用
+4. テスト 2 ファイル追加、`npm run validate`
+
+### 落とし穴
+- `*.` プレフィックスや `-`/`_` を拒否すると既存プリセットが壊れる — 既存テストの期待値を先に読むこと
+- `matchesPattern` を直接 regex 構築に戻さないこと（cap の意味がなくなる）
+- タイミングテストは環境差が大きい — 状態数計数を主観拠点にし、タイミングは緩い上限で
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-025/026 が解消されること

--- a/pbi/2026-08-29-02-fix-markdown-sanitizer-boundary.md
+++ b/pbi/2026-08-29-02-fix-markdown-sanitizer-boundary.md
@@ -1,0 +1,108 @@
+# PBI: Markdown/Obsidian 出力サニタイズ境界の確立（VULN-001/008/047, CWE-79）
+
+## ユーザーストーリー
+利用者として、訪問したページの内容が Obsidian 日次ノートやローカル markdown エクスポートに安全に書かれるようにしたい、なぜならページ由来の生 HTML（`<img onerror>` 等）や AI タグの断片が「サニタイズ済み」を名乗る境界を素通りし、ノート内で実行・偽装リンクになるから
+
+## ビジネス価値
+- Medium 脆弱性（VULN-001）の解消: `sanitizeForObsidian` が HTML を通すことが実証済み（payload が verbatim でノートに到達）
+- VULN-008/047 の解消: per-field サニタイズが join 境界で `[ #bar](https://evil.com)` に再構成される（実証済み）
+- 測定方法: `sanitizeForObsidian('<img src=x onerror=alert(1)>')` が HTML をエンティティ化すること、4 消費者の join 出力に生リンク構文が形成されないこと
+
+## 優先度
+- 順位: 2 / 14
+- RICEスコア: 2375（Reach=1000 / Impact=0.5 / Confidence=95% / Effort=0.2人月）
+  - Reach 1000: ページ→ノート経路は全 Obsidian 連携ユーザーに到達（録画は既定動作）
+  - Impact 0.5: Medium。ノート内 HTML 実行は Obsidian レンダラ次第だが、偽装リンク・構造汚染は確実
+  - Confidence 95%: 16 呼び出しサイトが単一 choke point を経由（スイープ確認済み）。修正は境界関数 1 箇所＋ヘルパー 1 本
+  - Effort 0.2: 境界強化＋4 消費者のヘルパー適用＋テスト
+- 根拠: スイープで「1 choke point 修正で 15 サイトが恩恵」が確認済み。境界を正すことが全消費者の根cause解消になる
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: 生 HTML はエンティティ化されてノートに書かれる
+  Given ページ要約に "<img src=x onerror=alert(1)>" が含まれる
+  When formatMarkdownStep がノート本文を生成する
+  Then HTML は <img ...> 形式でエンティティ化され、タグとして解釈可能な文字列は存在しない
+
+Scenario: タグ断片の結合でリンク構文は再構成されない
+  Given タグ "foo [" と "bar](https://evil.example)" が与えられる
+  When タグ行を結合する
+  Then 各断片が結合安全にエスケープされ、バランスした markdown リンクが形成されない
+
+Scenario: 正当な markdown 出力は現行と同じ見た目を保つ（回帰防止）
+  Given 通常のタイトル・URL・要約・タグが与えられる
+  When ノート本文を生成する
+  Then 既存テストの期待出力と一致する（エスケープは記号にのみ影響）
+
+Scenario: クリップボード出力も同一境界を通る
+  Given 同一の悪意あるタグ断片が与えられる
+  When formatEntryToMarkdown（clipboard）が実行される
+  Then 共有ヘルパーを経由し、ノート出力と同一のエスケープ結果になる
+```
+
+## 受け入れ基準
+- [ ] `src/utils/markdownSanitizer.ts:110-122` の `sanitizeForObsidian` が、既存のリンク/wikiリンク エスケープに加え `<`/`>`/`&`（属性文脈の `"` を含む）をエンティティ化する
+- [ ] 結合安全なフラグメントエスケープヘルパー（`[ ] ( )` を無効化する link-text エスケープ）が新設され、`formatMarkdownStep.ts:53-56`、`markdownExport.ts:78-83`、`saveLocalMarkdownStep.ts:80-85`、`markdownFormatter.ts:8-10` の 4 消費者で適用されている
+- [ ] ヘルパーは死蔵 sync-target（`obsidianSyncService.ts:62`、`gistSyncTarget.ts:49`）にも事前適用されている（将来配線時の再発防止）
+- [ ] 新規テストで「HTML エンティティ化」「join 再構成の不可能性」「正当出力の回帰」が検証されている
+- [ ] 既存 markdown 出力系テストが全てグリーン
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: `sanitizeForObsidian('<img ...>')` の生 HTML 通過が 0 件、join 再構成 PoC が失敗する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（Obsidian 実体は外部。単体＋境界テストで検証し、ノート内容は PoC で確認）
+
+### 統合テスト
+- `RecordingPipeline` → `formatMarkdownStep` 経由: 悪意ある要約/タグを持つ録画がノート本文生成時に無害化されること（steps 統合テストに 1 シナリオ追加）
+
+### 単体テスト
+- 新規: `src/utils/__tests__/markdownSanitizerBoundary.test.ts`
+  - ビジネスロジック: HTML/リンク/wikiリンクのエスケープ結果
+  - 境界値: 空文字、記号のみ、`&amp;` 二重エンコード、unicode
+  - 例外: 非文字列入力のガード
+- 新規: `src/background/__tests__/markdownJoinSafety.test.ts`（4 消費者×join 再構成 PoC の否定）
+
+## 実装アプローチ
+- **Outside-In**: まず境界テストを Red（現行は生 HTML 通過）にし、`sanitizeForObsidian` 強化で Green。次に 4 消費者の join をヘルパーに置換して Green
+- **Red-Green-Refactor**: エンティティ化は既存エスケープの後段に追加し、出力差分を既存テストで固定
+
+## 見積もり
+2pt（要チームでの見積もり — 境界強化＋ヘルパー新設＋4 消費者適用＋テスト 2 ファイル）
+
+## 技術的考慮事項
+- 依存関係: なし（Wave 1 推奨）
+- テスタビリティ: PoC `poc/VULN-001_html_injection_obsidian_notes.md` / `VULN-008_tag_summary_join_link_reformation.md` の入力をそのまま回帰テストに転用
+- 非機能要件: エンティティ化によるノート可読性の劣化を最小化（`<`/`>`/`&` のみ。markdown 記法文字は触れない）
+- 注意: 4 消費者は同一パターンの複製 — 1 ヘルパーに集約し、重複を増やさない
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '105,125p' src/utils/markdownSanitizer.ts
+sed -n '48,60p' src/background/pipeline/steps/formatMarkdownStep.ts
+sed -n '5,20p' src/utils/markdownFormatter.ts
+sed -n '75,88p' src/background/markdownExport.ts
+```
+
+### 実装手順
+1. `sanitizeForObsidian` に HTML エンティティ化を追加（既存エスケープ後の最終段）
+2. `sanitizeLinkTextFragment`（仮称）ヘルパーを `markdownSanitizer.ts` に新設（`[ ] ( )` エスケープ）
+3. 4 消費者の tag/summary 断片にヘルパーを適用
+4. 死蔵 sync-target 2 箇所にヘルパーを事前適用（コメントで将来配線時の契約を明記）
+5. テスト追加、`npm run validate`
+
+### 落とし穴
+- エンティティ化を join の前にかけると再構成は防げるが `[` が残る — フラグメントエスケープは「構造文字の無効化」であり、エンティティ化とは役割が違う。両方やること
+- Obsidian の wikilink `[[...]]` を壊さないこと（既存テストで固定）
+- `markdownExport.ts` は summary に別サニタイザを使う（VULN-030 とは別経路）— 本 PBI では summary 経路に触れない
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-001/008/047 が解消されること

--- a/pbi/2026-08-29-03-fix-response-body-caps.md
+++ b/pbi/2026-08-29-03-fix-response-body-caps.md
@@ -1,0 +1,107 @@
+# PBI: レスポンスボディ読み込みのバイト上限ユーティリティ（VULN-013/015/027/054/055, CWE-400）
+
+## ユーザーストーリー
+利用者として、悪意ある/侵害されたリモート（Obsidian・AI プロバイダ・Tranco・GitHub・フィルタ URL）が巨大な chunked 応答を返しても拡張が停止しないようにしたい、なぜなら現在のサイズ上限が Content-Length ヘッダ（攻撃者が省略可能）に依存し、`response.text()/json()` が SW メモリを無制限に消費するから
+
+## ビジネス価値
+- 5 指摘・8 シンクを 1 ユーティリティで解消（実証: 64–200MB の確保、chunked で上限無効化）
+- MV3 Service Worker のメモリ枯渇による拡張全体 DoS（録画状態の喪失）を封鎖
+- 測定方法: 全 8 シンクが `readBodyCapped` を経由すること、Content-Length なしで cap が強制されること
+
+## 優先度
+- 順位: 3 / 14
+- RICEスコア: 1663（Reach=1000 / Impact=0.35 / Confidence=95% / Effort=0.2人月）
+  - Reach 1000: 任意サイトの応答ヘッダ（VULN-013 の Obsidian 経路、Tranco 経路）・configured endpoint で到達
+  - Impact 0.35: 拡張全体 DoS（データ消失ではなく可用性）
+  - Confidence 95%: スイープで 12 本番シンク中 8 シンクが攻撃到達可能と特定済み。ユーティリティ 1 本で完結
+  - Effort 0.2: ユーティリティ新設＋8 シンク置換＋テスト
+- 根拠: 根本原因（RC-3: ヘッダ条件付き上限＋素の body 読み取り）が全 5 指摘で同一のため、1 ユーティリティが正攻法
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: Content-Length なしの chunked 応答はバイト上限で打ち切られる
+  Given リモートが cap を超える chunked 応答を返す
+  When readBodyCapped で本文を読む
+  Then 読み取りは maxBytes で中断され、エラー（または打ち切り結果）が返り SW メモリは上限内に保たれる
+
+Scenario: Content-Length が嘘/省略でも cap は守られる
+  Given Content-Length: 100 を申告しつつ 1GB を返す応答が与えられる
+  When 読み取りを実行する
+  Then ヘッダに依存せず実バイト数で cap される
+
+Scenario: 通常サイズの応答は現行どおり動作する（回帰防止）
+  Given cap 内の正当な応答が与えられる
+  When 各シンク（Obsidian/FETCH_URL/Tranco/AI/Gist）が読む
+  Then 現行と同一のパース結果が返る
+
+Scenario: 上限超過はログに記録され処理が継続する
+  Given cap を超える応答が与えられる
+  When 呼び出し元（例: saveToObsidianStep）が失敗を処理する
+  Then 既存のエラー分類に沿って記録され、パイプライン全体は停止しない
+```
+
+## 受け入れ基準
+- [ ] `src/utils/readBodyCapped.ts`（仮称）が新設され、バイトカウント付きストリーミング読み取り＋cap 超過中断を実装している
+- [ ] 以下 8 シンクが `readBodyCapped` に置換されている: `obsidianConfigValidator.ts:143-151`、`obsidianClient.ts:166,193-199`、`systemHandlers.ts:98-108`（FETCH_URL）、`trancoUpdater.ts:147-155`、`GeminiProvider.ts:134,232`、`OpenAIProvider.ts:183,251`、`gistSyncTarget.ts:170`
+- [ ] 既存の post-read チェック（systemHandlers.ts:107 等）は防御深度として維持されている
+- [ ] Gist の素 fetch（`gistSyncTarget.ts:120,147,175`）も `fetchWithTimeout` 経由に統一されている
+- [ ] 新規テストで「chunked 超過」「嘘ヘッダ」「cap 内正常系」「各シンク経由」が検証されている
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: `response.text()/json()` の素使用が上記シンクで 0 件
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（ローカル HTTP モックで十分。実環境計測は PoC に委譲）
+
+### 統合テスト
+- `ObsidianClient.appendToDailyNote` 経由: 巨大 chunked 応答で cap エラーが既存エラー分類に乗ること
+- `FETCH_URL` handler 経由: 超過応答が拒否され、保存済み cap エラーメッセージが維持されること
+
+### 単体テスト
+- 新規: `src/utils/__tests__/readBodyCapped.test.ts`
+  - ビジネスロジック: cap 内/超過の読み取り結果
+  - 境界値: cap ちょうど、cap+1、空 body、1 バイト chunk
+  - 例外: reader 異常終了、content-length 不一致
+- 更新: 各シンクの既存テストに cap 経由の呼び出し検証を追加
+
+## 実装アプローチ
+- **Outside-In**: まず `readBodyCapped` の単体テストを Red にし、実装で Green。次に 8 シンクを 1 つずつ置換し、各置換後に既存テストを実行
+- **Red-Green-Refactor**: cap 値は現行値（Obsidian 10MB/1MB、FETCH_URL 10MB、Tranco 50MB、AI/Gist は既定 10MB）を踏襲
+
+## 見積もり
+2pt（要チームでの見積もり — ユーティリティ＋8 シンク置換＋テスト）
+
+## 技術的考慮事項
+- 依存関係: なし（Wave 1 推奨）。ただし PBI 10（log-integrity）と `systemHandlers.ts` を共有 → マージ順に注意
+- テスタビリティ: `Response` をモックし `body.getReader()` でチャンク制御
+- 非機能要件: 正常系の性能劣化なし（ストリーミングは現行と同 O(n)）
+- 注意: `response.json()` 依存の Gemini/OpenAI/Gist は、cap 後に `JSON.parse` する形へ変更（意味不変）
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+rg -n "response\.(text|json)\(\)" src --type ts -g '!**/__tests__/**'
+sed -n '140,155p' src/utils/obsidianConfigValidator.ts
+sed -n '95,110p' src/background/handlers/systemHandlers.ts
+```
+
+### 実装手順
+1. `readBodyCapped(response, maxBytes): Promise<string>` を新設（`response.body.getReader()` ループ＋カウンタ）
+2. Obsidian 2 シンク → FETCH_URL → Tranco → AI 4 シンク → Gist の順に置換
+3. Gist を `fetchWithTimeout` 経由に統一
+4. テスト追加、`npm run validate`
+
+### 落とし穴
+- `response.json()` を `readBodyCapped` 後の `JSON.parse` に置き換える際、型アサーションを維持すること
+- cap 超過のエラーを無視して null を返すと呼び出し元が TypeError で落ちる — 既存エラー分類（`errorUtils`）に乗せること
+- Obsidian の 1MB バリアント（`obsidianClient.ts:193-199`）と 10MB の両方の cap 値を維持すること
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-013/015/027/054/055 が解消されること

--- a/pbi/2026-08-29-04-fix-storage-rmw-serialization.md
+++ b/pbi/2026-08-29-04-fix-storage-rmw-serialization.md
@@ -1,0 +1,108 @@
+# PBI: chrome.storage 読み書きの直列化 — RMW・単一実行・CAS（VULN-003/005/009/012/050/056, CWE-362/367）
+
+## ユーザーストーリー
+利用者として、複数の拡張コンテキスト（SW/popup/dashboard）が同時に動いても録画バッファ・保留ページ・ログ・リトライジョブが失われないようにしたい、なぜなら get→mutate→set の RMW がロックなしで並行実行され、stale スナップショットで他方の書き込みが消えるから
+
+## ビジネス価値
+- 6 指摘の解消: バッファエントリ消失（003 実証: final=['E2']）、保留ページ消失/重複（005）、通知の二重記録（009）、optimisticLock の TOCTOU 残窓（012）、ログ消失（050）、リトライジョブロスト（056 実証: ['A','B']→['A']）
+- 攻撃不要の通常 MV3 運用で発生するデータ完全性問題を構造的に封鎖
+- 測定方法: 6 サイトの変異テスト（インターリーブ再現）が全て lock 付きで防がれること
+
+## 優先度
+- 順位: 4 / 14
+- RICEスコア: 1440（Reach=800 / Impact=0.4 / Confidence=90% / Effort=0.2人月）
+  - Reach 800: 攻撃不要の通常並行動作で発火しうる全利用者のデータ完全性
+  - Impact 0.4: Medium 級のデータ消失（ただし揮発性バッファ・ログ・ジョブが中心）
+  - Confidence 90%: 正解パターン（withCounterLock/single-flight/CAS）が codebase 内に実証済みで存在
+  - Effort 0.2: 6 サイトへの既存パターン適用＋optimisticLock の Mutex 直列化
+- 根拠: スイープで「52 ファイル中 RMW 形状 20 サイト、うち 16 は正当理由付きで緩和済み」が確認済み。残る 4 確認＋1 新規＋lock 内部の 1 件に絞って適用する
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: 並行 flush でバッファエントリが消えない
+  Given SW と dashboard がそれぞれエントリ E1/E2 をバッファしている
+  When 2 つの flush がインターリーブする
+  Then CAS/lock 経由で最終状態が [E1, E2] になり、消失しない
+
+Scenario: 通知の二重クリックで重複記録が生まれない
+  Given 同一 URL の保留通知が 2 回高速にクリックされる
+  When onClicked ハンドラが並行実行される
+  Then 単一実行（single-flight）ガードにより録画は 1 件のみ
+
+Scenario: optimisticLock の verify→set 間で他書き込みが割り込まない
+  Given 同一 base version を持つ 2 writer が同一キーに書く
+  When 両者が withOptimisticLock を実行する
+  Then lock 内部の Mutex により verify→set が不可視化され、後続 writer がリトライで反映される
+
+Scenario: enqueue と flush が重なってもジョブが失われない
+  Given flush 中に新規ジョブ B が enqueue される
+  When persistState が走る
+  Then enqueue が lock を経由し、最終キューが ['A','B'] になる
+```
+
+## 受け入れ基準
+- [ ] `src/background/pipeline/buffers/MarkdownBufferManager.ts:35-39` の flush() が `withAtomicKeys`（または Mutex）を経由する
+- [ ] `src/utils/pendingStorage.ts:127-154` の add/removePendingPages が `withOptimisticLock(PENDING_PAGES_KEY, …)` を経由する
+- [ ] `src/utils/logger/storageAdapter.ts:20-27` の append が CAS/Mutex を経由する（`withAtomicKeys` ロガー版を検討）
+- [ ] `src/background/persistentRetryQueue.ts`（enqueue/flush/flushBatch）が lock 経由に統一され、3 本番キューが網羅される
+- [ ] `src/background/handlers/notificationHandlers.ts:64-78` に `contextMenuHandlers.ts:38-100` 型の single-flight ガードが追加されている
+- [ ] `src/utils/optimisticLock.ts:240-266` の verify→write 区間が `Mutex` で直列化され、二重読みは防御深度として維持される
+- [ ] 変異テスト（インターリーブ再現）6 件が追加され、全て lock なしでは RED / lock 付きで GREEN
+- [ ] `npm run type-check` と `npm run validate` が成功する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（マルチコンテキスト並行は InMemoryStorage＋インターリーブで検証）
+
+### 統合テスト
+- `PersistentRetryQueue` × `stepExecutor` × alarm モック: flush 中 enqueue のジョブ保全
+- `notificationHandlers` × pending store: 二重クリックでの単一記録
+
+### 単体テスト
+- 更新: 既存 `exploit_tests/test_vuln_003/005/012/050/056` のシナリオを Jest 化（RED→GREEN 検証用に「lock を外せる注入ポイント」を持たせる）
+- 新規: `src/background/handlers/__tests__/notificationSingleFlight.test.ts`
+
+## 実装アプローチ
+- **Outside-In**: 各サイトの変異テスト（RED）→ 既存パターン適用（GREEN）→ 重複整理
+- **Red-Green-Refactor**: `optimisticLock` の Mutex 直列化は最後に実施（全呼び出しサイトが受益し、回帰は既存 34 テスト）
+
+## 見積もり
+2pt（要チームでの見積もり — 6 サイト＋lock 内部強化＋変異テスト）
+
+## 技術的考慮事項
+- 依存関係: PBI 07（lock-cas-correctness）と理論上相互作用 — 本 PBI 先着手推奨（Wave 2）
+- テスタビリティ: インターリーブは `Mutex`/`withOptimisticLock` の注入モックで決定的に再現（PoC の Python シナリオを移植）
+- 非機能要件: lock 待ちによる UI 遅延は Mutex timeout（既存）で_bound_。queue-full は既存の throw 挙動を維持
+- 注意: `storageFallback.ts` は PBI 11 のスコープ（触れない）。スイープで「緩和済み16サイト」に触れない
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '30,45p' src/background/pipeline/buffers/MarkdownBufferManager.ts
+sed -n '120,160p' src/utils/pendingStorage.ts
+sed -n '15,30p' src/utils/logger/storageAdapter.ts
+sed -n '78,120p' src/background/persistentRetryQueue.ts
+sed -n '235,270p' src/utils/optimisticLock.ts
+sed -n '38,100p' src/background/handlers/contextMenuHandlers.ts   # single-flight の正解パターン
+```
+
+### 実装手順
+1. `MarkdownBufferManager` → `pendingStorage` → `storageAdapter` → `persistentRetryQueue` の順に CAS/lock 適用
+2. `notificationHandlers` に single-flight（URL キーの in-flight promise）
+3. `optimisticLock` に Mutex 直列化（PBI 07 の trustDb 修正と競合しないよう先に完了）
+4. 変異テスト 6 件、`npm run validate`
+
+### 落とし穴
+- `withOptimisticLock` の Mutex をグローバル単一にすると無関係キーまで直列化される — lock 内部でのみ共有する Mutex インスタンスにすること（キー粒度は以後の改善）
+- `persistentRetryQueue` は per-item `persistPerItem:true` の経路も stale snapshot を書く — flush 全体の persist も lock 経由に
+- ロガーは全コンテキスト共有キーのため、コンテキスト内 `isFlushing` ガードだけでは不十分（VULN-050 の根拠）— storage CAS 必須
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-003/005/009/012/050/056 が解消されること

--- a/pbi/2026-08-29-05-fix-query-limit-clamp.md
+++ b/pbi/2026-08-29-05-fix-query-limit-clamp.md
@@ -1,0 +1,101 @@
+# PBI: SQLite クエリ limit の両側クランプ統一（VULN-017/021/048/049, CWE-400）
+
+## ユーザーストーリー
+開発者として、DASHBOARD_SQLITE の読み取り系で負の limit や非有限値が LIMIT 句に届かないようにしたい、なぜなら SQLite は負の LIMIT を「無制限」と解釈し、`Math.min` のみの clamp を素通しして監査ログ・閲覧履歴全件が materialization されるから
+
+## ビジネス価値
+- 4 シンクの解消: handler（query/search/audit_log_query）、queryPlan、recordsRepo、IdbVfsBackend
+- 実証: `LIMIT -1` で 50 万行 materialization、`audit_log` 全件流出
+- 測定方法: `limit: -1 / 0 / 0.5 / 1e9` の 4 値が全シンクで [1, cap] にクランプされること
+
+## 優先度
+- 順位: 5 / 14
+- RICEスコア: 1330（Reach=400 / Impact=0.35 / Confidence=95% / Effort=0.1人月）
+  - Reach 400: DASHBOARD_SQLITE は extension-only（dashboard XSS やローカル操作者）に限定
+  - Impact 0.35: 無制限 materialization による情報一括露出＋SW 負荷
+  - Confidence 95%: clamp 1 行系の修正。境界値テストで完全固定可能
+  - Effort 0.1: queryPlan＋handler の統一 clamp＋4 シンクのテスト
+- 根拠: ADR 2026-08-27-limit-policy の QuerySpec 集約に下限追加を足すだけで完結。スイープで 8 サイト中 6 が候補、2 は正当緩和済み
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: 負の limit は既定値にクランプされる
+  Given ダッシュボードが payload { limit: -1 } を送る
+  When query / search / audit_log_query のいずれかを実行する
+  Then LIMIT は cap 内の正値になり、無制限 materialization は発生しない
+
+Scenario: 非有限値は既定値にフォールバックする
+  Given payload { limit: 0.5 } または { limit: 1e9 } が送られる
+  When 読み取りを実行する
+  Then limit は Number 変換＋clamp により [1, cap] に収まる
+
+Scenario: 通常の limit は現行どおり動作する（回帰防止）
+  Given payload { limit: 50 } が送られる
+  When query を実行する
+  Then 現行と同一の 50 行が返る
+
+Scenario: engine 直呼び（recordsRepo）でも下限が強制される
+  Given recordsRepo に limit: -1 が渡る
+  When クエリが組まれる
+  Then queryPlan レベルの clamp により正値に正規化される
+```
+
+## 受け入れ基準
+- [ ] `src/offscreen/queryPlan.ts:78-80` が `Math.max(1, Math.min(...))` の両側クランプになる
+- [ ] `src/background/handlers/dashboardSqlite/readOnlyHandler.ts:27,45,80` が信頼境界で両側クランプ（非有限は既定 100/50/1000 にフォールバック）する
+- [ ] `src/offscreen/opfsWorker/auditHandlers.ts:27` と `src/offscreen/IdbVfsBackend.ts:371` が同様の下限を持つ
+- [ ] `src/offscreen/recordsRepo.ts:44` が下限強制される
+- [ ] 境界値テスト（-1/0/0.5/1e9/正常値）が 4 シンクで追加される
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: `Math.min(…limit` のみのパターンが読み取り系で 0 件
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（handler＋engine の単体/統合で十分）
+
+### 統合テスト
+- `createDashboardSqliteHandler` 経由: 4 種の異常 limit で読み取りが既定値クランプされ成功すること（エラーではなく正常系）
+
+### 単体テスト
+- 新規: `src/offscreen/__tests__/queryPlanClamp.test.ts`（queryPlan の境界値）
+- 更新: `auditHandlers`/`IdbVfsBackend`/`recordsRepo` の既存テストに負値ケース追加
+
+## 実装アプローチ
+- **Outside-In**: handler 統合テストを Red（-1 が素通し）→ clamp 実装で Green → engine 側も同様
+- **Red-Green-Refactor**: clamp ヘルパーを queryPlan に 1 本置き、各所から呼ぶ（重複実装を増やさない）
+
+## 見積もり
+1pt（要チームでの見積もり — clamp ヘルパー＋4 シンク＋テスト）
+
+## 技術的考慮事項
+- 依存関係: なし（Wave 1 推奨）
+- テスタビリティ: 純粋関数化されているため境界値テストが容易
+- 非機能要件: 既定値（100/50/1000/10000）と cap 値の変更なし
+- 注意: `FallbackStorage.ts:256` の `slice(offset, offset+limit)` は JS slice セマンティクスで負値が安全（スイープ済み）— 触れない
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+rg -n "Math\.min\(.*limit" src --type ts -g '!**/__tests__/**'
+sed -n '74,84p' src/offscreen/queryPlan.ts
+sed -n '24,30p' src/background/handlers/dashboardSqlite/readOnlyHandler.ts
+```
+
+### 実装手順
+1. queryPlan に `clampLimit(raw, cap, fallback)` を新設
+2. handler 3 箇所・auditHandlers・IdbVfsBackend・recordsRepo から呼ぶ
+3. 境界値テスト追加、`npm run validate`
+
+### 落とし穴
+- `Math.floor(Number(payload.limit)) || fallback` を忘れると `0.5` が `0` → `Math.max(1,…)` で 1 になるが、既定値意図（100）とズレる。仕様は「非有限/非正は既定値」として handler で先に正規化すること
+- audit 系の cap（1000）と records 系（MAX_QUERY_LIMIT）は別 cap — 統一しないこと（既存 ADR の LIMIT 2 種温存方針）
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-017/021/048/049 が解消されること

--- a/pbi/2026-08-29-06-fix-trust-boundary-consistency.md
+++ b/pbi/2026-08-29-06-fix-trust-boundary-consistency.md
@@ -1,0 +1,110 @@
+# PBI: 信頼境界の一貫性 — ゲート迂回経路の解消（VULN-002/011/018/042）
+
+## ユーザーストーリー
+利用者として、任意のウェブページがドメインフィルタを迂回して録画を実行させたり、オフライン再送がプライバシー設定を無視したり、確認トークンが事前流出したりしないようにしたい、なぜなら「特権操作は必ず SW トラストシームを通る」という不変条件が非メッセージ経路で破れているから
+
+## ビジネス価値
+- VULN-002: ページが `data-ow-e2e-test` 属性＋コールドキャッシュで content script 注入時にドメイン検証をスキップ（実証済み）
+- VULN-011: オフライン再送が `force:true` でドメインフィルタ/プライバシーゲートを素通し（実証: blocked.example が記録される）
+- VULN-018: `confirm_token` サブタイプが同一チャネルで破壊的操作のトークンを先読み可能（実証済み）
+- VULN-042: コンテンツスクリプト失敗時の 1 クリックで `<all_urls>` を要求（narrow-first を skipped）
+- 測定方法: 4 経路すべてが正解経路（SW 検証・パイプラインゲート・ジェスチャ時発行・PermissionManager）を通ること
+
+## 優先度
+- 順位: 6 / 14
+- RICEスコア: 1260（Reach=700 / Impact=0.4 / Confidence=90% / Effort=0.2人月）
+  - Reach 700: 002 は任意ページ（unauth-web）、011/018/042 はリプレイ・ext-page・popup 経路
+  - Impact 0.4: ゲート迂回の複合（録画の偽装・プライバシー無視・破壊操作・過剰権限）
+  - Confidence 90%: 正解経路が全て既存。ただしリプレイ/トークンのセマンティクス変更を含む
+  - Effort 0.2: 4 箇所の修正＋網羅性テスト拡張
+- 根拠: 4 迂回の根本原因が共通（RC: trust シームの適用範囲がメッセージ型に限定）。網羅性テストの拡張まで含めて 1 PBI
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: e2e 属性があってもコールドキャッシュでは SW 検証を待つ
+  Given ページに data-ow-e2e-test 属性が設定され、ドメインフィルタキャッシュが無効である
+  When content script が注入判定を行う
+  Then 両ブランチとも SW CHECK_DOMAIN の応答を await してから import する
+
+Scenario: オフライン再送は現行ゲートを通る
+  Given ドメインフィルタで拒否された URL の記録がオフラインキューに存在する
+  When リトライ alarm が再送を実行する
+  Then checkDomainFilterStep と checkPrivacyHeadersStep が再評価され、拒否済み URL は記録されない
+
+Scenario: 破壊的操作のトークンは事前取得できない
+  Given 拡張ページが confirm_token サブタイプを呼ぶ
+  When トークン発行を要求する
+  Then 読み取り用サブタイプは存在せず、トークンは破壊的操作のジェスチャ応答でのみ発行される
+
+Scenario: 権限要求は最小スコープから始まる
+  Given レコード現在ページでコンテンツスクリプト取得に失敗する
+  When 権限フォールバックが走る
+  Then activeTab → 現在タブの per-origin の順に試行し、<all_urls> は明示的な設定オプトインでのみ要求される
+```
+
+## 受け入れ基準
+- [ ] `src/content/loader.ts:41-48`（e2e）と `:52-60`（通常）の両ブランチで、`useCache === false` 時に SW CHECK_DOMAIN を await してから動的 import する
+- [ ] `src/background/offlineQueueProcessor.ts:54-62` のリプレイが `force: false`（または明示的な 2 ゲート再評価）になる
+- [ ] `src/background/handlers/dashboardSqlite/readOnlyHandler.ts:18-24` の `confirm_token` 読み取りケースが削除され、`confirmTokenManager` がパーアクション・単回使用・短 TTL 発行になる（`dashboardSqliteService.ts:54-80` の消費者を更新）
+- [ ] `src/popup/recordCurrentPage/tabContentFetcher.ts:35-38` が activeTab → `PermissionManager.requestPermission`（per-origin）→ 設定オプトインのレベルラダーになる
+- [ ] senderTrust 網羅性テストを非メッセージ経路（動的 import・リプレイ・権限）に拡張する
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: 4 経路の PoC（e2e 属性注入・リプレイ・token 読み取り・all_urls 要求）が全て失敗する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- `data-ow-e2e-test` の e2e スイートが引き続き成功すること（キャッシュ事前投入または await 完了で互換維持）
+
+### 統合テスト
+- `loader` × domainPolicyPort × SW CHECK_DOMAIN モック: コールドキャッシュでの注入判定
+- `offlineQueueProcessor` × 2 ゲート: 拒否 URL の再評価
+- `dashboardSqliteService` × confirmTokenManager: ジェスチャ時発行→単回使用
+
+### 単体テスト
+- 更新: `tabContentFetcher` の権限ラダー（activeTab→per-origin→opt-in の順序固定）
+- 新規: `senderTrustCoverage` の非メッセージ経路ケース
+
+## 実装アプローチ
+- **Outside-In**: 4 経路の PoC テスト（RED）→ 正解経路への配線（GREEN）→ 網羅性テスト拡張
+- **Red-Green-Refactor**: トークン発行のセマンティクス変更は最後に実施（消費者の UI フロー確認を含む）
+
+## 見積もり
+2pt（要チームでの見積もり — 4 経路修正＋テスト拡張。e2e 互換調整を含む）
+
+## 技術的考慮事項
+- 依存関係: Wave 3 推奨（既存動作のセマンティクス変更を含むためレビュー強化）
+- テスタビリティ: loader は domainPolicyPort のモックで await 待ちを検証可能
+- 非機能要件: e2e テストの実行時間が大幅に増えないこと（SW round-trip 1 回分）
+- 注意: confirmToken の UX（確認ダイアログ）を壊さないこと。発行タイミングの変更を UI 側と合わせて検証
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '35,65p' src/content/loader.ts
+sed -n '50,65p' src/background/offlineQueueProcessor.ts
+sed -n '14,28p' src/background/handlers/dashboardSqlite/readOnlyHandler.ts
+sed -n '30,45p' src/popup/recordCurrentPage/tabContentFetcher.ts
+sed -n '54,82p' src/dashboard/dashboardSqliteService.ts
+```
+
+### 実装手順
+1. loader の両ブランチを await 化（e2e テストのキャッシュ投入を確認）
+2. リプレイの force 解除＋明示ゲート再評価
+3. confirm_token サブタイプ削除＋パーアクション発行（消費者更新）
+4. 権限ラダー実装
+5. 網羅性テスト拡張、`npm run validate`
+
+### 落とし穴
+- loader の await 化で注入タイミングが遅れ、抽出が空になるページが出る可能性 — visitGate のタイミング要件を確認すること
+- リプレイの force:false 化で、正規の「再送」も duplicate チェックに引っかかる可能性がある — `skipDuplicateCheck` は force と独立して扱うか、明示ゲート再評価に置換するかをテストで決める
+- トークンの単回使用化で、既存の 2 段階 UI（一覧→確認→実行）が壊れないか `dashboardSqliteHandlers` のテストで確認
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-002/011/018/042 が解消されること

--- a/pbi/2026-08-29-07-fix-lock-cas-correctness.md
+++ b/pbi/2026-08-29-07-fix-lock-cas-correctness.md
@@ -1,0 +1,104 @@
+# PBI: ロック/CAS 運用の正しさ — try/finally と current マージ（VULN-028/029, CWE-667/362）
+
+## ユーザーストーリー
+開発者として、Tranco 更新の失敗が後続の更新を永久にブロックせず、trust DB への同時書き込みが片方の差分を静かに捨てないようにしたい、なぜならロック解除が例外経路で到達不能（try/finally 未使用）で、CAS コールバックが現在状態を無視して stale スナップショットを返しているから
+
+## ビジネス価値
+- VULN-028: 1 回の更新失敗で `updateInProgress` が true のまま残り、コンテキスト再読込まで Tranco 更新が恒久ロックアウト（実証: 2 回目以降 "already in progress"）
+- VULN-029: 同時書き込みで片方の差分が静黙に失われる（CAS が LWW に退化、実証済み）
+- 測定方法: 更新を例外で中断してもフラグが false に戻ること、2 writer の差分が共に反映されること
+
+## 優先度
+- 順位: 7 / 14
+- RICEスコア: 1125（Reach=500 / Impact=0.25 / Confidence=90% / Effort=0.1人月）
+  - Reach 500: Tranco 更新（全利用者の trust DB 品質）＋trust DB 同時書き込み（設定 UI・更新・migration）
+  - Impact 0.25: 恒久ロックアウトは手動復旧が必要、LWW は信頼データの静黙欠落
+  - Confidence 90%: スイープで 8 CAS サイト中 7 が正しい current 消費と確認済み — 誤用は 1 箇所のみ
+  - Effort 0.1: finally 追加＋updateFn 修正＋契約テスト
+- 根拠: ロック API の誤用パターンに対する契約テストを追加することで、将来の誤用も検出可能にする
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: 更新の例外でもロックフラグは解除される
+  Given Tranco 更新中にネットワーク例外が発生する
+  When updateTrancoList が完了する
+  Then updateInProgress は false に戻り、次回の更新が実行できる
+
+Scenario: 同時書き込みでも双方の差分が残る
+  Given trust DB に 2 つの writer が同時に delta を適用する
+  When 両方が withOptimisticLock を完了する
+  Then updateFn が current を受け取りマージし、両差分が反映される
+
+Scenario: コンフリクト時はリトライで解決する
+  Given writer B が writer A の読み取り後に書き込む
+  When B の updateFn が実行される
+  Then コンフリクト検出後、B は current を再取得してリトライする
+
+Scenario: ロック契約の誤用はテストで検出される
+  Given 新規の lock 呼び出しが current を無視して stale 値を返す
+  When 契約テスト（current 消費検証）を実行する
+  Then テストが失敗し、誤用が CI で捕捉される
+```
+
+## 受け入れ基準
+- [ ] `src/utils/trustDb/trancoUpdater.ts:50-119` の更新ループが try/finally で `this.updateInProgress = false` を保証し、到達不能な post-loop reset を削除している
+- [ ] `src/utils/trustDb/trustDb.ts:316-319` の `updateFn` が `_currentDb` を受け取り、意図した差分を current 上にマージして返す（コンフリクト時リトライ）
+- [ ] ロック API 契約テスト（finally カバレッジ・current 消費検証）が追加されている
+- [ ] 既存 trustDb 系 221 テストが全てグリーン
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: lockout PoC・LWW PoC が失敗する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし
+
+### 統合テスト
+- `trancoUpdater` × fetch モック: 成功/失敗/例外の 3 経路でフラグ解除を検証
+- `trustDb` × 2 writer モック: 同時適用の merge 結果
+
+### 単体テスト
+- 新規: `src/utils/trustDb/__tests__/lockContract.test.ts`
+  - ビジネスロジック: updateFn の merge 動作
+  - 境界値: 空差分、同一キー同時適用、コンフリクト連鎖
+  - 例外: updateFn throw 時のロック解放
+
+## 実装アプローチ
+- **Outside-In**: lockout PoC を RED → try/finally で GREEN → LWW PoC を RED → merge 実装で GREEN
+- **Red-Green-Refactor**: 契約テストは既存 7 正解サイトに対しても実行し、回帰がないことを確認
+
+## 見積もり
+1pt（要チームでの見積もり — finally 1 箇所＋merge 1 箇所＋契約テスト）
+
+## 技術的考慮事項
+- 依存関係: PBI 04（optimisticLock の Mutex 直列化）と相互作用 — 04 先着手を推奨（Wave 2）
+- テスタビリティ: `_currentDb` はテスト注入可能
+- 非機能要件: リトライ上限は既存 `withOptimisticLock` の挙動を踏襲
+- 注意: `contextMenuHandlers.ts:38-100` は正解実装（スイープ済み）— 触れない
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '45,120p' src/utils/trustDb/trancoUpdater.ts
+sed -n '310,325p' src/utils/trustDb/trustDb.ts
+rg -n "withOptimisticLock" src/utils/trustDb --type ts
+```
+
+### 実装手順
+1. trancoUpdater のループを try/finally 化
+2. trustDb.updateFn を `(current) => merged` 型に書き換え
+3. 契約テスト追加、`npm run validate`
+
+### 落とし穴
+- finally 内でさらに例外を投げないこと（元の例外を握り潰す）
+- merge 実装で `_currentDb` をミューテートしないこと（新オブジェクトを返す — CAS の前提）
+- 例外経路のフラグ解除は既存 `Mutex.ts` の正解パターン（release が常に走る）と揃える
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-028/029 が解消されること

--- a/pbi/2026-08-29-08-fix-resource-boundary-caps.md
+++ b/pbi/2026-08-29-08-fix-resource-boundary-caps.md
@@ -1,0 +1,116 @@
+# PBI: リソース上限とライフサイクルの境界強制（VULN-004/006/007/024/041/051/053, CWE-400/459）
+
+## ユーザーストーリー
+利用者として、拡張のストレージとメモリが長期利用で際限なく膨らんだり、悪意あるページ内容が二次計算を爆発させたりしないようにしたい、なぜなら自動エクスポートが削除されず、purge が死蔵コードで、書き込み境界に上限がなく、AI タグ・文リストが O(n²) 計算に無制限に入るから
+
+## ビジネス価値
+- VULN-004: 自動 `local_export_*` ダウンロードが削除されず 8.9GB/5年モデル（実証）
+- VULN-006: `clearExpiredPages` が 0 呼び出しで期限切れ pending が永久滞留（実証: 1000 件滞留）
+- VULN-007: 攻撃者 Cache-Control 値が無 cap で storage.session に永続化（実証: 6 応答で quota 超過）
+- VULN-024: payloadGuard が 3/7 TEXT 列のみ cap（実証: 1000MB tags 通過）
+- VULN-041/051/053: 無 cap タグ/文が O(n²) 計算に流入（実証: x4 n で x29 時間、116GB edge model）
+- 測定方法: 書き込み境界での cap 強制、purge 配線、schema 駆動 guard の 3 点
+
+## 優先度
+- 順位: 8 / 14
+- RICEスコア: 1080（Reach=800 / Impact=0.3 / Confidence=90% / Effort=0.2人月）
+  - Reach 800: 長期利用の全利用者（無限成長は時間依存で必ず顕在化）
+  - Impact 0.3: 可用性・ストレージ健全性（データ消失ではない）
+  - Confidence 90%: 既存 precedent（1024 文字 truncate、50 タグ cap、日次 purge alarm、schema SSOT）が存在し配線/適用が本体
+  - Effort 0.2: 7 指摘だが各々が小修正（配線 2、truncate 1、guard 1、cap 3）
+- 根拠: 根本原因が共通（RC: 上限が表示/読み取り側に置かれ書き込み境界で強制されない）
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: 自動エクスポートは retention 内で削除される
+  Given 30 日より古い local_export_* ファイルが存在する
+  When 日次 purge alarm が走る
+  Then 古いエクスポートが削除され、総バイト数が cap 内に収まる
+
+Scenario: 期限切れ pending ページは日次 purge で消える
+  Given 期限切れの pending ページが 1000 件ある
+  When 日次 purge alarm が走る
+  Then clearExpiredPages が実行され、リストが縮む
+
+Scenario: 攻撃者の巨大ヘッダ値は書き込み境界で truncate される
+  Given 10KB の Cache-Control 値を含む応答が来る
+  When privacyChecker が PrivacyInfo を構築する
+  Then 値は 1024 文字で truncate され storage に収まる
+
+Scenario: payloadGuard は schema の全 TEXT 列を cap する
+  Given 1000MB の tags を含む SQLITE_INSERT が来る
+  When payloadGuard が検証する
+  Then tags も schema 由来の cap で拒否/切断される
+
+Scenario: 無制限タグ/文は二次計算に入る前に cap される
+  Given SQLite 経路に 500 タグ/レコードが保存されている
+  When tagCooccurrence / TextRank / tagClusterLayout が実行される
+  Then 入力が cap（50 タグ/文数上限/ノード top-N）され、計算時間が有界になる
+```
+
+## 受け入れ基準
+- [ ] `src/background/localMarkdownExportCore.ts:38-69` が download ID を記録し、日次 purge alarm で retention（30 日想定）＋総量 cap を適用する
+- [ ] `src/utils/pendingStorage.ts:199-212` の `clearExpiredPages` が日次 purge alarm から呼ばれ、addPendingPage のしきい値経由でも実行される
+- [ ] `src/utils/privacyChecker.ts:47-62` が `cacheControl.value` を 1024 文字で truncate する
+- [ ] `src/offscreen/payloadGuard.ts:68-125` が schema（`src/offscreen/schema.ts:69-102` の全 TEXT 列）駆動で各列＋合計を cap し、未知フィールドを fail-closed にする
+- [ ] `src/offscreen/sqliteMessageHandlers.ts:122-164`（SQLite 経路のタグ cap 50）と `tagCooccurrence.ts:36-41` / `sentenceExtractor.ts:91-101` / `tagClusterLayout.ts:69-90` の入力 cap が実装されている
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: 7 指摘の PoC が全て失敗する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（alarm/purge はモックで検証）
+
+### 統合テスト
+- dailyPurgeHandler × downloads モック: retention 削除の統合
+- SQLITE_INSERT × payloadGuard: schema 駆動 cap の統合
+
+### 単体テスト
+- 新規: `payloadGuardSchemaDriven.test.ts`（列追加が自動で cap 対象になること）
+- 新規: 各 cap の境界値テスト（1024 文字ちょうど、50 タグちょうど、top-N 末端）
+- 更新: TextRank/cooccurrence/layout の性能テスト（n 倍→時間の次数が落ちること）
+
+## 実装アプローチ
+- **Outside-In**: purge 配線（004/006）を先に（既存 alarm 経路への hook のみ）→ truncate（007）→ guard（024）→ cap 3 件
+- **Red-Green-Refactor**: cap 値は既存 precedent に合わせ、新規判断を持ち込まない
+
+## 見積もり
+2pt（要チームでの見積もり — 配線 2、truncate 1、guard 再構築 1、cap 3）
+
+## 技術的考慮事項
+- 依存関係: Wave 2。PBI 05（limit clamp）とは別ファイル（conflict なし）
+- テスタビリティ: purge alarm は FakeAlarmPort（既存 PBI 2026-08-27-24 のパターン）で検証可能
+- 非機能要件: truncate/cap による正規データの欠損は既存表示挙動と同等以内
+- 注意: tagClusterLayout の top-N は計算頻度の高い panel なので UX 劣化を計測すること
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '35,70p' src/background/localMarkdownExportCore.ts
+sed -n '195,215p' src/utils/pendingStorage.ts
+sed -n '44,64p' src/utils/privacyChecker.ts
+sed -n '65,128p' src/offscreen/payloadGuard.ts
+sed -n '118,168p' src/offscreen/sqliteMessageHandlers.ts
+```
+
+### 実装手順
+1. dailyPurgeHandler に export retention と clearExpiredPages を配線
+2. privacyChecker truncate
+3. payloadGuard の schema 駆動化（未知フィールド拒否）
+4. sqlite タグ cap＋3 二次計算の入力 cap
+5. テスト追加、`npm run validate`
+
+### 落とし穴
+- payloadGuard の schema 駆動化で `changes`（update 用）経路もカバーすること（既存は INSERT 系のみ）
+- retention の削除は chrome.downloads.removeFile + removeDownload の API 制約を確認（ID の記録形式）
+- 文数 cap は 64KB truncation 後に効く（sentence 数は budget 依存）— cap は minLength 越え文に限定すること
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-004/006/007/024/041/051/053 が解消されること

--- a/pbi/2026-08-29-09-fix-fetch-redirect-ssrf.md
+++ b/pbi/2026-08-29-09-fix-fetch-redirect-ssrf.md
@@ -1,0 +1,104 @@
+# PBI: FETCH_URL リダイレクト再検証 — SW 経由 SSRF 封鎖（VULN-016, CWE-918）
+
+## ユーザーストーリー
+利用者として、フィルタリスト import の URL が検証後に private IP へリダイレクトしても、Service Worker が内部ネットワークの応答を取得・返却しないようにしたい、なぜなら SSRF ガードは初期 URL のみを検証し、fetch がリダイレクトを黙って追跡するから
+
+## ビジネス価値
+- 実証済み攻撃の封鎖: 許可 URL → 30x リダイレクト → `http://127.0.0.1:9222` の body が返却される（拡張ページからは直接到達できない private IP への SW 仲介アクセス — 明確な新 capability）
+- fetch.ts に hop-level 検証規約を作り、将来の攻撃者影響 URL fetch にも適用可能にする
+- 測定方法: FETCH_URL のリダイレクト PoC が失敗すること、17 fetch サイトのうち攻撃者影響 URL を持つFETCH_URL が全ホップ検証を通ること
+
+## 優先度
+- 順位: 9 / 14
+- RICEスコア: 1000（Reach=300 / Impact=0.35 / Confidence=95% / Effort=0.1人月）
+  - Reach 300: FETCH_URL は extension-only。ただし悪意あるフィルタ URL の import（ユーザーが張り替えた供給元）で発火
+  - Impact 0.35: private IP 応答の取得（SW 経由でのみ可能な新 capability）
+  - Confidence 95%: `redirect: 'error'` 1 行で塞げる。スイープで 17 fetch サイト中攻撃者影響 URL は 1 箇所のみと確認済み
+  - Effort 0.1: fetch 方針設定＋ホップ検証ヘルパー＋テスト
+- 根拠: 最小修正で新 capability を消す。将来の fetch 追加に対する規約化を含む
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: リダイレクトは FETCH_URL で拒否される
+  Given 許可された URL が 30x で private IP へリダイレクトする
+  When FETCH_URL が fetch を実行する
+  Then リダイレクトは失敗（error または manual+拒否）し、private 応答は返らない
+
+Scenario: 正当な同一オリジン/https 昇格リダイレクトの扱いが明確である
+  Given 許可 URL が同一ホストの https へリダイレクトする
+  When FETCH_URL が fetch を実行する
+  Then 設計した方針（許可またはホップ毎再検証の通過）に従い取得される
+
+Scenario: ホップ毎検証ヘルパーは private IP を拒否する
+  Given リダイレクト先が 127.0.0.1/10.x/192.168.x/169.254.x である
+  When hop 再検証ヘルパーが評価する
+  Then 拒否される
+
+Scenario: 他の fetch サイトは現行どおり動作する（回帰防止）
+  Given tranco/gist/obsidian/AI が固定ホストで fetch する
+  When 通常の応答が返る
+  Then 既存テストが全てグリーン（リダイレクト方針の変更は FETCH_URL 系のみ）
+```
+
+## 受け入れ基準
+- [ ] `src/background/handlers/systemHandlers.ts:87` の FETCH_URL fetch に `redirect: 'error'`（または `manual`＋ホップ毎 `validateUrlForFilterImport` 再検証）が設定されている
+- [ ] `src/utils/fetch.ts` に hop-level 再検証ヘルパー（`fetchWithRedirectGuard` 仮称）が新設され、`validateUrlForFilterImport`＋private IP ガードをホップ毎に適用する
+- [ ] 正当なリダイレクトの扱い（拒否 or 許可）が ADR またはコメントで明文化されている
+- [ ] リダイレクト PoC（`poc/VULN-016_fetch_url_redirect_ssrf.md` のシナリオ）が失敗するテストを追加
+- [ ] 既存 fetch 系テストが全てグリーン
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: FETCH_URL のリダイレクト到達が不可能になる
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（fetch モックで検証）
+
+### 統合テスト
+- `FETCH_URL` handler × redirect モック: 30x で private IP に飛ぶ応答が拒否されること
+
+### 単体テスト
+- 新規: `src/utils/__tests__/fetchRedirectGuard.test.ts`
+  - ビジネスロジック: ホップ毎検証の通過/拒否
+  - 境界値: 同一オリジン https 昇格、ポート違い、相対 Location
+  - 例外: リダイレクトループ、Location 欠落
+
+## 実装アプローチ
+- **Outside-In**: handler 統合テストを Red（redirect で private 応答が返る）→ `redirect: 'error'` で Green → ヘルパー化
+- **Red-Green-Refactor**: まず最も単純な `redirect: 'error'` で塞ぎ、正当リダイレクトのニーズが確認できたら manual＋再検証へ拡張
+
+## 見積もり
+1pt（要チームでの見積もり — fetch 方針＋ヘルパー＋テスト）
+
+## 技術的考慮事項
+- 依存関係: なし（Wave 1 推奨）。PBI 03（body caps）と `systemHandlers.ts` を共有 → マージ順に注意
+- テスタビリティ: `Response.redirected`/`Response.url` で検証可能
+- 非機能要件: 他 16 fetch サイト（固定ホスト・検証済み）の挙動不変
+- 注意: `manual` モード採用時は opaqueredirect 応答の扱いを確認すること
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '80,110p' src/background/handlers/systemHandlers.ts
+rg -n "redirect" src/utils/fetch.ts src/background/handlers/systemHandlers.ts
+sed -n '180,205p' src/utils/ssrfGuard.ts
+```
+
+### 実装手順
+1. FETCH_URL の fetch オプションに `redirect: 'error'` を設定
+2. 正当リダイレクトの必要性確認（既存フィルタ供給元の実態）→ 必要なら manual＋`fetchWithRedirectGuard` へ
+3. テスト追加、`npm run validate`
+
+### 落とし穴
+- `redirect: 'error'` は http→https 昇格さえ拒否する — フィルタ供給元の実URLを確認してから方針を固定すること
+- `manual` の opaqueredirect は body/status が読めない — ホップ再検証は `Location` ヘッダから自前で追跡することになる
+- Tranco/gist は固定ホストで FETCH_URL のガード対象外（スイープ済み）— 過剰適用しない
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-016 が解消されること

--- a/pbi/2026-08-29-10-fix-log-integrity.md
+++ b/pbi/2026-08-29-10-fix-log-integrity.md
@@ -1,0 +1,105 @@
+# PBI: ログ完全性 — attribution と制御文字無害化（VULN-019/044, CWE-290/117）
+
+## ユーザーストーリー
+開発者として、拡張の永続ログの送信元属性が偽装できず、外部応答の本文が行構造を壊して書き込まれないようにしたい、なぜなら LOG_FORWARD が payload の `source` を鵜呑みにし、Obsidian エラー本文が改行/ANSI/制御文字を含んだまま永続化され、障害解析の一次証跡が信頼できなくなるから
+
+## ビジネス価値
+- VULN-019: `_source='service-worker'` が dashboard.html 送信から forge 可能（実証済み）→ sender 由来に固定
+- VULN-044: Obsidian エラー本文の多行注入＋ANSI＋NUL が永続化（実証済み）→ logger 境界で無害化
+- 測定方法: `_source` が sender.url から派生すること、永続ログに `\n\r`/制御文字/ANSI エスケープが存在しないこと
+
+## 優先度
+- 順位: 10 / 14
+- RICEスコア: 713（Reach=300 / Impact=0.25 / Confidence=95% / Effort=0.1人月）
+  - Reach 300: LOG_FORWARD は extension-only（offscreen 送信が想定）。Obsidian エラー経路は実運用で到達
+  - Impact 0.25: ログ完全性（情報影響。実証の通り現行には dashboard log viewer sink は存在しない）
+  - Confidence 95%: logger 永続化は単一 choke point。PII マスクは維持
+  - Effort 0.1: handler 1 箇所＋logger 1 境界＋テスト
+- 根拠: ログが障害解析・監査の一次証跡であるという位置づけを契約として明文化し、境界で無害化する
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: LOG_FORWARD の attribution は sender 由来になる
+  Given 拡張ページが payload { source: "service-worker" } で LOG_FORWARD を送る
+  When handler がログを書く
+  Then _source は sender.url から派生した値になり、payload の source は表示ヒントとしてのみ扱われる（または無視される）
+
+Scenario: 多行本文は 1 行化されて永続化される
+  Given Obsidian エラー本文に "\n[Logger:fake] forged" が含まれる
+  When addLog が永続化する
+  Then 改行は無害化（区切り置換または除去）され、偽エントリとして解釈できない
+
+Scenario: 制御文字・ANSI エスケープは除去される
+  Given エラー本文に "\u001b[31m" や NUL が含まれる
+  When logger が永続化する
+  Then エスケープシーケンスと制御文字が除去/可視化される
+
+Scenario: PII マスクは現行どおり動作する（回帰防止）
+  Given メッセージに API キー風文字列が含まれる
+  When logger が永続化する
+  Then 既存 sanitizeRegex のマスク結果と一致する
+```
+
+## 受け入れ基準
+- [ ] `src/background/handlers/systemHandlers.ts:258-264` が `_source` を `sender.url`/`sender.origin` から派生させ、payload `source` を trusted として使わない
+- [ ] logger 永続化経路（`src/utils/logger/*`）に `\n`/`\r`/制御文字/ANSI エスケープの無害化が実装されている（PII マスクの前後どちらかを明記）
+- [ ] Obsidian の 2 エラー経路（`obsidianClient.ts:167,200`）が境界修正の恩恵で解消されることをテストで確認
+- [ ] LOG_FORWARD の message/details も同一無害化を通る（VULN-044 の co-parameter）
+- [ ] 新規テストで「attribution 派生」「多行注入」「ANSI/制御文字」「PII 回帰」が検証されている
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: 2 PoC が失敗する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（dashboard log viewer は現行不存在のため）
+
+### 統合テスト
+- `LOG_FORWARD` handler × logger モック: sender 由来 attribution の統合検証
+- `ObsidianClient` エラー経路 × logger: 多行本文の 1 行化
+
+### 単体テスト
+- 新規: `src/utils/logger/__tests__/logNeutralization.test.ts`
+  - ビジネスロジック: 無害化の結果（区切り置換の形式）
+  - 境界値: 空文字、連続改行、混在 ANSI、絵文字（維持）
+  - 例外: 巨大本文（長さ cap との相互作用）
+
+## 実装アプローチ
+- **Outside-In**: handler テストを Red（payload source が使われる）→ sender 派生で Green → logger 無害化を Red→Green
+- **Red-Green-Refactor**: 無害化は 1 ヘルパーに集約し、PII マスクとの適用順を固定
+
+## 見積もり
+1pt（要チームでの見積もり — handler 1 箇所＋logger 1 境界＋テスト）
+
+## 技術的考慮事項
+- 依存関係: Wave 2。PBI 03 と `systemHandlers.ts` を共有 → マージ順に注意
+- テスタビリティ: 無害化関数は純粋関数として抽出
+- 非機能要件: 正常ログの可読性を損なわない（区切りは視認可能な文字列へ置換）
+- 注意: payload `source` を UI 表示ヒントとして残す場合は untrusted として明示ラベルを付ける
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '250,270p' src/background/handlers/systemHandlers.ts
+sed -n '160,205p' src/background/obsidianClient.ts
+rg -n "sanitizeRegex|addLog" src/utils/logger --type ts
+```
+
+### 実装手順
+1. LOG_FORWARD handler の `_source` を sender 派生に
+2. logger 無害化ヘルパー（`\n\r` → 置換、`\u0000-\u001f` 除去、ANSI CSI 除去）を実装
+3. 永続化経路に適用、テスト追加、`npm run validate`
+
+### 落とし穴
+- `_source` の sender.url は offscreen 等で同じ URL になる — コンテキスト判別が必要なら `context` 情報（既存 `_source` の使い方）と合わせて設計すること
+- ANSI 除去で正当な本文中の `\u001b` 相当文字（esc キー）を過剰に壊さないこと — CSI シーケンスのみ対象
+- PII マスクが無害化後に走るとマスク対象が変化する可能性 — 順序をテストで固定
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-019/044 が解消されること

--- a/pbi/2026-08-29-11-fix-storagefallback-mutate.md
+++ b/pbi/2026-08-29-11-fix-storagefallback-mutate.md
@@ -1,0 +1,105 @@
+# PBI: storageFallback ミューテータ統一 — mutate(fn) ヘルパー（VULN-022, CWE-362）
+
+## ユーザーストーリー
+開発者として、OPFS が使えない環境のフォールバック SQLite エンジンで、全ミューテータが同一のロック規律で動くようにしたい、なぜなら 8 ミューテータのうち 6 個がロックなしで load→mutate→save し、purge が同時 toggleStar の全 blob 書き込みで取り消されるから
+
+## ビジネス価値
+- Medium 脆弱性（VULN-022）の解消: update/hardDelete/toggleStar/clearAll/purgeOldRecords/purgeContent のロックなし RMW（実証: purge が toggleStar で取り消される）
+- フォールバック環境でのデータ消失・復活（削除レコードの resurrection）を構造的に封鎖
+- 測定方法: 8/8 ミューテータが `mutate(fn)` を経由すること、並行変異テストで全変異が保持されること
+
+## 優先度
+- 順位: 11 / 14
+- RICEスコア: 475（Reach=100 / Impact=0.5 / Confidence=95% / Effort=0.1人月）
+  - Reach 100: フォールバックモード（OPFS 不利用環境）限定
+  - Impact 0.5: Medium。データ消失・復活という完全性問題
+  - Confidence 95%: `mutate(fn)` ヘルパー 1 本で 8 メソッドを統一。既存 insert の lock 実装が正解パターン
+  - Effort 0.1: ヘルパー抽出＋ミューテータ置換＋レーステスト
+- 根拠: 第二級実装に見えるが、Medium 脆弱性の本体。ヘルパー化により将来のミューテータ追加も安全になる
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: purge と同時 toggleStar で purge が取り消されない
+  Given フォールバックストアにレコード群がある
+  When purgeOldRecords と toggleStar が並行実行される
+  Then mutate(fn) の直列化により、purge の結果が保持される
+
+Scenario: update と hardDelete が重なっても矛盾しない
+  Given 同一レコードに対する update と hardDelete が並行する
+  When 両ミューテータが完了する
+  Then 最終状態はどちらか一意の結果になり、中途半端な blob 状態にならない
+
+Scenario: insert 系は現行どおり動作する（回帰防止）
+  Given 正常な insert/insertBatch が与えられる
+  When 実行する
+  Then 既存テストの期待結果と一致（重複チェック後 ID 確保の挙動維持）
+
+Scenario: lock 待ちのタイムアウトは既存契約どおり
+  Given mutex が長時間保持される
+  When ミューテータが待つ
+  Then 既存 Mutex の timeout 契約に従い reject される（無限待機しない）
+```
+
+## 受け入れ基準
+- [ ] `src/offscreen/storageFallback.ts` に `private async mutate(fn: (data) => data)` が新設され、`this.mutex` 取得→load→fn 適用→save を行う
+- [ ] update / hardDelete / toggleStar / clearAll / purgeOldRecords / purgeContent（6 メソッド）が mutate 経由に置換されている
+- [ ] insert / insertBatch の手書き lock も mutate 経由に統一され、重複チェック→ID 確保の現行順序が維持される
+- [ ] 並行変異テスト（purge×toggleStar、update×hardDelete）が追加され、全変異が保持される
+- [ ] 既存 storageFallback テストが全てグリーン
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: `poc/VULN-022_storage_fallback_unlocked_mutators.md` のシナリオが失敗する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（フォールバックエンジンはオフラインで完全検証可能）
+
+### 統合テスト
+- `FallbackStorage.query/mutate` 経由の並行操作（削除と star 更新の統合）
+
+### 単体テスト
+- 新規: `src/offscreen/__tests__/storageFallbackMutate.test.ts`
+  - ビジネスロジック: 各ミューテータの結果整合
+  - 境界値: 空ストア、単一レコード、バッチ境界
+  - 例外: fn throw 時のロック解放とデータ不変性
+
+## 実装アプローチ
+- **Outside-In**: 並行変異テスト（RED: 現行は purge が失われる）→ mutate(fn) 実装で GREEN → insert 系の統一
+- **Red-Green-Refactor**: insert の「重複チェック後に ID 確保」順序（PBI 2026-08-27-06 で確立）を mutate 内で維持
+
+## 見積もり
+1pt（要チームでの見積もり — ヘルパー 1 本＋8 メソッド置換＋テスト）
+
+## 技術的考慮事項
+- 依存関係: なし（Wave 2）。OPFS 正常経路（opfsWorker）には触れない
+- テスタビリティ: InMemory ストレージで決定的インターリーブが可能（PoC の Python シナリオを移植）
+- 非機能要件: フォールバックモードの性能は現行同等（直列化は現行 insert と同じ単一 mutex）
+- 注意: `loadData` のキャッシュ挙動（ある場合）があれば mutate 内で一貫させる
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '60,95p' src/offscreen/storageFallback.ts
+sed -n '275,300p' src/offscreen/storageFallback.ts
+rg -n "loadData|saveData" src/offscreen/storageFallback.ts
+```
+
+### 実装手順
+1. mutate(fn) ヘルパーを新設（mutex acquire→loadData→fn→saveData→release、try/finally）
+2. 6 ミューテータを置換
+3. insert/insertBatch を mutate 経由に統一
+4. 並行変異テスト追加、`npm run validate`
+
+### 落とし穴
+- fn 内で再帰的に mutate を呼ぶとデッドロックする — fn は純粋変換に限定する契約コメントを付けること
+- saveData 失敗時にロックだけ解放してデータが半端にならないこと（load し直しの原状回復または例外伝播）
+- insertBatch のバッチ内重複フィルタ順序を崩さないこと（既存テスト 2026-08-27-06 を回帰ゲートに）
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-022 が解消されること

--- a/pbi/2026-08-29-12-fix-crypto-policy-ssot.md
+++ b/pbi/2026-08-29-12-fix-crypto-policy-ssot.md
@@ -1,0 +1,121 @@
+# PBI: 暗号・認証ポリシーの単一情報源化（VULN-010/037/038/039/040/052, CWE-312/916/307/362/521）
+
+## ユーザーストーリー
+利用者として、マスターパスワードと API キー保護が単一の強いポリシーで運用されるようにしたい、なぜなら硬化版実装（600k iterations、strict ポリシー、deriveHmacWrappingKey）が死蔵コードで、弱い平行実装が本番に配線され続けているから
+
+## ビジネス価値
+- VULN-010: HMAC KEK が wrapped keys の隣に平文保存（実証済み）→ session-only＋deriveHmacWrappingKey 配線
+- VULN-037/052: PBKDF2 100k（標準 600k）で 5.8 倍速いオフライン攻撃（実証）→ iterations SSOT
+- VULN-038: レート制限カウンタが storage.session でリセット可能（実証: 4000 guesses）→ local 永続化
+- VULN-039: crypto get-or-create の未排他（実証: 分岐トークン）→ encryptionKeyMutex パターン適用
+- VULN-040: パスワードポリシー length≥8 のみ（実証: rockyou 4/4 通過）→ strict ポリシー一本化
+- 測定方法: 暗号パラメータが 1 箇所で定義され、3 KDF 経路が同一 iterations を使うこと
+
+## 優先度
+- 順位: 12 / 14
+- RICEスコア: 453（Reach=400 / Impact=0.4 / Confidence=85% / Effort=0.3人月）
+  - Reach 400: マスターパスワード設定者（API キー保護の実質）
+  - Impact 0.4: KEK 平文・弱 KDF・ロックアウト迂回の複合
+  - Confidence 85%: 硬化版が既存だが、暗号変更は回帰リスクが高い（unlock UX・既存データ互換）
+  - Effort 0.3: SSOT 化＋KEK 配線＋RateLimit 永続化＋init mutex＋平行実装削除
+- 根拠: 6 指摘の根が「平行実装のドリフト」であり、SSOT 化 1 回で class を消す。ただし暗号系のため慎重なリリースが必要
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: KEK は storage.local に存在しない
+  Given HMAC ラップキーが保存されている
+  When storage.local を検査する
+  Then KEK の平文（base64）は存在せず、ラップされたキーのみが存在する
+
+Scenario: 全 KDF 経路が同一 iterations を使う
+  Given settings export / password change / envelope のいずれかが実行される
+  When deriveKey が呼ばれる
+  Then 3 経路とも SSOT の iterations（600k）を使い、format に iterations が保存される
+
+Scenario: レート制限カウンタは再起動後も有効である
+  Given 失敗カウンタが storage.local に永続化されている
+  When 攻撃者が session を clear して再試行する
+  Then カウンタは継続し、5 失敗で LOCKED_UNTIL が設定される
+
+Scenario: 並行 get-or-create は単一の鍵を生成する
+  Given 2 コンテキストが同時に getOrCreateWrappedHmacKey を呼ぶ
+  When 両方が完了する
+  Then 生成される鍵/トークンは 1 つであり、双方が同一の値を得る
+
+Scenario: 弱いパスワードは production 経路で拒否される
+  Given rockyou 上位のパスワードを入力する
+  When マスターパスワードを設定する
+  Then strict ポリシー（強度スコア/文字種）で拒否される
+```
+
+## 受け入れ基準
+- [ ] `src/utils/crypto/hmacKeyStore.ts:132-138` の storage.local への KEK 書き込みが削除され、`:65-87` の `deriveHmacWrappingKey`（master password 経由）が再起動リカバリ経路として配線されている
+- [ ] 暗号パラメータ SSOT（iterations/ポリシー）が 1 モジュールに集約され、`settingsExportImport.ts:110,168`、`masterPassword.ts:213,218`、envelope 経路がすべて参照する
+- [ ] `src/utils/RateLimitService.ts` の FAILED_ATTEMPTS/FIRST_ATTEMPT_TIME が storage.local に永続化され、成功時のみリセットされる
+- [ ] `encryptionSession.ts:431-473`、`hmacKeyStore.ts:215-254`、`confirmTokenManager.ts:25-70` が `encryptionKeyMutex` パターン（generate+persist+cache を 1 locked section）に統一されている
+- [ ] `src/utils/masterPassword.ts:78-86` が strict ポリシー（`encryptionSession.ts:262-274` から抽出した共有 validator）に一本化され、弱い平行実装が削除されている
+- [ ] 既存暗号データの後方互換（旧 iterations 形式の読み込み）がテストされている
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: 6 PoC が全て失敗する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- マスターパスワード設定→アンロック→API キー再暗号化の一連の流れを Playwright または popup/dashboard 統合で確認
+
+### 統合テスト
+- `masterPassword` 変更フロー×deriveKey モック: iterations 600k 使用の検証
+- `RateLimitService` × storage モック: session clear 耐性
+- `hmacKeyStore` × 2 コンテキスト: 単一生成の統合検証
+
+### 単体テスト
+- 新規: `src/utils/crypto/__tests__/cryptoParamsSSOT.test.ts`（SSOT 参照の網羅・旧形式互換）
+- 新規: `src/utils/__tests__/rateLimitPersistence.test.ts`
+- 更新: 既存 `hmacKeyStore`/`encryptionSession` テストの期待値更新
+
+## 実装アプローチ
+- **Outside-In**: 統合テスト（Red）→ SSOT モジュール抽出 → 3 経路の付け替え → 弱い平行実装削除
+- **Red-Green-Refactor**: KEK 配線は unlock UX（master password 未設定時）のフォールバック設計を先に決める
+
+## 見積もり
+3pt（要チームでの見積もり — SSOT 抽出、KEK リカバリ設計、5 モジュール変更、互換移行）
+
+## 技術的考慮事項
+- 依存関係: Wave 3（単独着手推奨）。既存暗号データを持つユーザー環境での移行検証が必須
+- テスタビリティ: crypto は Web Crypto polyfill（@peculiar/webcrypto）で既存テストあり
+- 非機能要件: アンロック性能劣化なし（600k は現行 envelope と同等）。deriveHmacWrappingKey 配線時の初回 unlock に KDF コストが乗る点を UX 評価すること
+- 注意: settings export 形式の iterations フィールド追加は「任意読み込み・既定 600k 書き込み」で後方互換
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '125,145p' src/utils/crypto/hmacKeyStore.ts
+sed -n '60,90p' src/utils/crypto/hmacKeyStore.ts
+sed -n '14,30p' src/utils/crypto/primitives.ts
+sed -n '75,90p' src/utils/masterPassword.ts
+sed -n '205,235p' src/utils/masterPassword.ts
+sed -n '30,98p' src/utils/RateLimitService.ts
+```
+
+### 実装手順
+1. `cryptoParams.ts`（仮称）に SSOT（ITERATIONS、ポリシー validator）を新設
+2. 3 KDF 経路を付け替え（settings export → password change → envelope）
+3. KEK の session-only 化＋deriveHmacWrappingKey リカバリ配線（未設定時フォールバック設計）
+4. RateLimit 永続化
+5. 3 get-or-create 流路の mutex 適用
+6. 弱い平行実装（utils/masterPassword の弱ポリシー）削除
+7. 移行テスト（旧 100k 形式読み込み）＋ `npm run validate`
+
+### 落とし穴
+- KEK を session-only にすると Chrome 再起動後に HMAC 検証ができない期間が出る — deriveHmacWrappingKey の配線と「master password 未設定ユーザー」のフォールバック（平文キー運用の明示化）を必ず設計すること
+- iterations の旧形式読み込み漏れは既存ユーザーのエクスポートを壊す — 読み込み側は 100k 互換を維持
+- RateLimit の local 永続化はストレージ障害時に fail-open にならないよう（成功時のみリセット）をテストで固定
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-010/037/038/039/040/052 が解消されること

--- a/pbi/2026-08-29-13-fix-import-pipeline-safety.md
+++ b/pbi/2026-08-29-13-fix-import-pipeline-safety.md
@@ -1,0 +1,113 @@
+# PBI: インポート経路の安全化 — 認証→上限→パース→検証（VULN-023/030/034/035/036, CWE-400/347/94）
+
+## ユーザーストーリー
+利用者として、settings・logs・backup の各インポートで悪意あるファイルが署名検証前にリソースを消費せず、偽造履歴が受け入れられず、エクスポートの frontmatter が汚染されないようにしたい、なぜなら 3 系統が独立実装で順序規約がなく、logs import は署名ゲート自体が存在しないから
+
+## ビジネス価値
+- VULN-034: settings import が HMAC 検証前に atob 増幅＋KDF＋復号（実証済み）→ 認証先行化
+- VULN-035: log import に署名ゲートなし・validateRow 2/9 フィールド（実証: 偽造行受入）→ 署名＋全フィールド検証
+- VULN-036: backup panel が上限前に全ファイル parse（実証: 192MB 確保）→ 境界で cap
+- VULN-023: log import の無制限 parse/accumulate（実証: 93k+ バッチ）→ サイズ cap
+- VULN-030: export frontmatter の url/tags が生（実証: 注入キーが解決）→ YAML エスケープ
+- 測定方法: 3 系統すべてが共通プリミティブ（auth→cap→parse→validate）を通ること
+
+## 優先度
+- 順位: 13 / 14
+- RICEスコア: 405（Reach=300 / Impact=0.3 / Confidence=90% / Effort=0.2人月）
+  - Reach 300: ファイル import/export 利用者（設定移行・ログ取り込み・バックアップ）
+  - Impact 0.3: 履歴偽造・DoS・export 汚染の複合
+  - Confidence 90%: settings 側 HMAC ゲートが正解実装として存在（fail-closed 実証済み）。プリミティブ化は既知パターンの統合
+  - Effort 0.2: 共通プリミティブ＋3 系統適用＋エスケープ＋テスト
+- 根拠: 「横断比較されてこなかった」ことが根因（5 Whys）。1 PBI で 3 系統の差異を一覧化して統一する
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: 署名不正の settings ファイルはリソース消費なしで拒否される
+  Given 巨大な偽造 settings ファイル（署名なし）が与えられる
+  When import を実行する
+  Then HMAC 検証が先に走り、decode/KDF/復号は実行されない
+
+Scenario: 署名なしの log ファイルは受け入れられない
+  Given 偽造履歴行を含む署名なし log ファイルが与えられる
+  When log import を実行する
+  Then 署名検証で拒否され、1 行も取り込まれない
+
+Scenario: 巨大ファイルは parse 前に拒否される
+  Given 20MB の backup ファイルが与えられる
+  When restore を開始する
+  Then file.size チェックで即時拒否され、parse は走らない
+
+Scenario: エクスポート frontmatter の注入は無効化される
+  Given url に改行と YAML 構造文字を含むレコードがある
+  When ログをエクスポートする
+  Then url/tags がエスケープされ、注入キー（build_meta 等）は解決されない
+```
+
+## 受け入れ基準
+- [ ] 共通インポートプリミティブ（仮称 `importPipeline`: authenticate→sizeCap→parse→validate）が新設され、settings/logs/backup の 3 系統から使用される
+- [ ] `src/utils/settingsExportImport.ts:163-178` が HMAC 検証を decode/KDF/復号より前に移動し、10MB の読み込み cap と typed-array decode（atob 増幅の除去）を適用している
+- [ ] `src/dashboard/importLogsService.ts:27-33,41-77` に settings と同等の HMAC ゲート（export 側で署名付与）と file.size ≤ 10MB、rows ≤ 100k、総行数 cap が実装されている
+- [ ] `validateRow` が全 9 フィールド（日付 parse、数値範囲、文字列長 cap）を検証する
+- [ ] `src/dashboard/encryptedBackupPanel.ts:72-79` が file.size チェックを parse 前に行い、envelope 長検証を境界に移動している
+- [ ] `src/dashboard/exportLogsService.ts:62-71` に YAML エスケープヘルパー（url/title/tags）が適用されている
+- [ ] `npm run type-check` と `npm run validate` が成功する
+- [ ] VulnHunter 再検証: 5 PoC が全て失敗する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし（ファイル I/O はモック＋jsdom）
+
+### 統合テスト
+- 3 系統の import UI × 共通プリミティブ: 認証順序・cap・検証の統合検証
+- export → import ラウンドトリップ（正当ファイルの互換維持）
+
+### 単体テスト
+- 新規: `importPipeline.test.ts`（順序契約: auth 呼び出しが parse より先）
+- 新規: `validateRow` 全フィールドの境界値テスト
+- 新規: `yamlFrontmatterEscape.test.ts`（注入キー・改行・構造文字）
+
+## 実装アプローチ
+- **Outside-In**: 順序契約テスト（Red: 現行は復号が先）→ プリミティブ実装（Green）→ 3 系統の移行
+- **Red-Green-Refactor**: 既存 HMAC 実装（settingsExportImport.ts:377-407）をプリミティブに昇格させる（再実装しない）
+
+## 見積もり
+2pt（要チームでの見積もり — プリミティブ＋3 系統移行＋署名付与＋テスト）
+
+## 技術的考慮事項
+- 依存関係: Wave 2。PBI 12（crypto SSOT）の iterations に依存しうるが、本 PBI 単独でも着手可能（既定 iterations のまま）
+- テスタビリティ: File/Blob は jsdom で生成可能
+- 非機能要件: 正当ファイルの import/export 互換を壊さない（署名なき旧 log ファイルの扱いを仕様として決める — 移行期間の許可フラグ or 拒否）
+- 注意: log export に署名を付けると旧拡張バージョンとの相互運用が変わる — CHANGELOG と PRIVACY ドキュメントの更新を含める
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '160,180p' src/utils/settingsExportImport.ts
+sed -n '375,410p' src/utils/settingsExportImport.ts
+sed -n '25,80p' src/dashboard/importLogsService.ts
+sed -n '68,82p' src/dashboard/encryptedBackupPanel.ts
+sed -n '58,75p' src/dashboard/exportLogsService.ts
+```
+
+### 実装手順
+1. `importPipeline.ts`（仮称）に 4 段階プリミティブを新設
+2. settings import を HMAC 先行化（既存ゲートの呼び出し順を入れ替え）
+3. log import/export に署名付与＋cap＋validateRow 全フィールド化
+4. backup panel の size cap 前置き
+5. YAML エスケープヘルパー適用
+6. テスト追加、`npm run validate`
+
+### 落とし穴
+- HMAC 先行化で「envelope 全体に対する署名」の対象バイト範囲を既存実装と厳密一致させること（ずれると正当ファイルが拒否される）
+- validateRow の厳格化で過去バージョンの正当 log ファイルが拒否される可能性 — 旧形式フィールドの許容範囲を先に棚卸しすること
+- YAML エスケープは `summary` の既存サニタイザ（exportLogsService.ts:69）と重複させず、1 ヘルパーに統一すること
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで VULN-023/030/034/035/036 が解消されること

--- a/pbi/2026-08-29-14-fix-security-hardening-code-quality.md
+++ b/pbi/2026-08-29-14-fix-security-hardening-code-quality.md
@@ -1,0 +1,109 @@
+# PBI: Code Quality ハードニング一括 — 機能バグ1件＋将来攻撃面6件
+
+## ユーザーストーリー
+開発者として、pending パネルのホワイトリスト追加が正しいストレージキーに書かれるようにし、CSP/URL 許可の自己許可構造や旧 href パネルなど、現在不発でも将来の攻撃面になるハードニング指摘を一括で解消したい、なぜなら沈黙した機能バグは信頼を損ない、ハードニングは前提変化時に脆弱性へ昇格するから
+
+## ビジネス価値
+- **機能バグ（実質のユーザー影響）**: popup pending パネルの「ホワイトリストへ追加」が orphan キー `'domainWhitelist'` に書かれ、正キー `domain_whitelist` の読み手がゼロ — 機能が沈黙して効いていない
+- 7 ハードニング: CSPValidator 自己許可（cspValidator.ts:143-170）、urlWhitelist 自己許可（urlWhitelist.ts:134-144）、Gemini model path 生補間（GeminiProvider.ts:71-73）、TSV 数式無害化欠落（auditLogTsv.ts:21-26）、models-dev asset スキーマ検証（models-dev-dialog.ts:417-427,457-459）、旧 a.href パネルの isSecureUrl 欠落（historyEntryRow.ts:114, historyPendingPanel.ts:94/177）
+- 測定方法: orphan キー書き込み 0 件、各ハードニングの検証テスト追加
+
+## 優先度
+- 順位: 14 / 14
+- RICEスコア: 255（Reach=300 / Impact=0.15 / Confidence=85% / Effort=0.15人月）
+  - Reach 300: orphan キーは whitelist 利用者に実害。ハードニングは将来前提
+  - Impact 0.15: 機能不具合＋防御深度（現行 exploitable ではない — VulnHunter Phase 2b の Code Quality 分類）
+  - Confidence 85%: 各修正は小さいが、7 件の横断でハズレがないかの確認が必要
+  - Effort 0.15: 7 件の小修正を束ねて 1 PBI
+- 根拠: 個々は 1pt 未満だが束ねることで追跡コストを 1 件に圧縮。orphan キーは機能バグとして最優先項目
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: pending パネルのホワイトリスト追加が有効になる
+  Given ユーザーが pending パネルでドメインをホワイトリストに追加する
+  When 保存が実行される
+  Then StorageKeys.DOMAIN_WHITELIST 経由で正キーに書かれ、録画判定で許可される
+
+Scenario: CSP ドメインの自己許可が封じられる
+  Given 設定由来の CSP ドメイン検証が走る
+  When validateCspDomains が評価する
+  Then 拡張自身のオリジン/任意オリジンを無条件許可する経路が存在しない
+
+Scenario: allowedUrls は ublock origin を自己許可しない
+  Given フィルタ URL の許可判定が走る
+  When buildAllowedUrls が評価する
+  Then ublock 系 origin が無条件に許可リストに入らない
+
+Scenario: TSV エクスポートは数式トリガー文字を無害化する
+  Given 監査ログのフィールドが "=" で始まる値を持つ
+  When TSV エクスポートが実行される
+  then escapeTsvField が数式トリガーを無効化する
+```
+
+## 受け入れ基準
+- [ ] `src/popup/pendingPages.ts:59-75` が `StorageKeys.DOMAIN_WHITELIST`（`storage/types.ts:60`）経由で書き込み、SettingsRepository パターンに統一されている
+- [ ] `src/background/cspValidator.ts:143-170` の自己許可経路が削除または明示的なレビュー根拠付きに修正されている
+- [ ] `src/utils/urlWhitelist.ts:134-144` の ublock origin 自己許可が修正されている
+- [ ] `src/background/ai/providers/GeminiProvider.ts:71-73` に `encodeURIComponent`/segment 検証が追加されている
+- [ ] `src/utils/auditLogTsv.ts:21-26` に `escapeCsv`（exportLogsService.ts:84）相当の数式トリガー無害化が適用されている
+- [ ] `src/dashboard/models-dev-dialog.ts:417-427,457-459` に `doc`/`api` の https: 検証＋読み込み時スキーマ検証が追加されている
+- [ ] `historyEntryRow.ts:114`、`historyPendingPanel.ts:94/177` に `isSecureUrl` ゲートが適用されている
+- [ ] `npm run type-check` と `npm run validate` が成功する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- pending パネル → ホワイトリスト追加 → 同一ドメインの録画許可を popup 操作で確認（実機能の回帰）
+
+### 統合テスト
+- `domainFilter` × pending 追加: 正キーへの書き込みと反映
+
+### 単体テスト
+- 更新: `escapeTsvField` の境界値テスト（`=`/`+`/`-`/`@` 先頭）
+- 新規: models-dev スキーマ検証のテスト（不正 doc/api の拒否）
+- 更新: href パネルの isSecureUrl テスト（javascript: 拒否）
+
+## 実装アプローチ
+- **Outside-In**: orphan キー修正（ユーザー実害）を先に E2E で Red→Green。ハードニング 6 件は単体テスト先行で各 1 コミット
+- **Red-Green-Refactor**: orphan キー修正後、`StorageKeys` 経由でない literal キー書き込みを grep で棚卸し（将来の再発防止）
+
+## 見積もり
+1pt（要チームでの見積もり — 7 小修正＋orphan キー E2E）
+
+## 技術的考慮事項
+- 依存関係: なし（任意タイミング）。他 PBI とファイル触接なし
+- テスタビリティ: 各修正が独立し、単体テストで閉じる
+- 非機能要件: CSP/allowedUrls の締め直しが正当な設定利用を壊さないこと（既存設定の棚卸しを先に）
+- 注意: models-dev JSON は bundled asset（`chrome.runtime.getURL`）であり、リモート取得に変わった場合のみ脅威が変わる — コメントで前提を明記
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+sed -n '55,78p' src/popup/pendingPages.ts
+rg -n "'domainWhitelist'|domain_whitelist" src --type ts
+sed -n '140,172p' src/background/cspValidator.ts
+sed -n '130,148p' src/utils/urlWhitelist.ts
+sed -n '68,76p' src/background/ai/providers/GeminiProvider.ts
+sed -n '18,28p' src/utils/auditLogTsv.ts
+```
+
+### 実装手順
+1. orphan キー修正＋E2E（最優先）
+2. TSV 無害化＋Gemini path エンコード（単純な 2 件）
+3. models-dev スキーマ検証、href パネル isSecureUrl
+4. CSPValidator/urlWhitelist の自己許可締め直し（設定棚卸し後に着手）
+5. テスト追加、`npm run validate`
+
+### 落とし穴
+- orphan キー修正で「既に orphan キーに書かれたデータ」の救済（移行 or 廃棄）を決めること — 利用者は追加が効いていない認識なので廃棄でよい（要コメント）
+- CSPValidator の締め直しは正当な AI provider カスタム baseUrl を壊す可能性 — cspDomains.ts の LOCAL_PORTS/aiConnectSrc 経路を先に確認
+- 旧 href パネルへの isSecureUrl 適用で、http:// ページの再オープン（tabs.create）が変わる可能性 — pendingPages の DESIGN-INTENT（自身の訪問 URL 再オープン）と衝突しないよう範囲を限定
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter Code Quality 指摘の再スキャンで該当項目が解消されること

--- a/src/background/__tests__/manualContentFetcher.branches.test.ts
+++ b/src/background/__tests__/manualContentFetcher.branches.test.ts
@@ -1,0 +1,166 @@
+/**
+ * manualContentFetcher.branches.test.ts
+ * Branch-coverage focused tests for ManualContentFetcher
+ * (sanitization fallbacks, TTL expiry, and injected func execution).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSanitizeRegex = vi.fn();
+vi.mock('../../utils/piiSanitizer.js', () => ({
+  sanitizeRegex: (...args: unknown[]) => mockSanitizeRegex(...args),
+}));
+
+import { ManualContentFetcher } from '../manualContentFetcher.js';
+
+const mockScriptResult = 'Extracted page content';
+
+type ExecuteScriptOptions = {
+  target: { tabId: number };
+  func: (...args: unknown[]) => unknown;
+  args: unknown[];
+};
+
+function setupChromeMock(executeScriptImpl?: (opts: ExecuteScriptOptions) => Promise<unknown>): void {
+  (globalThis as Record<string, unknown>).chrome = {
+    tabs: {
+      query: vi.fn(() => Promise.resolve([])),
+      create: vi.fn(() => Promise.resolve({ id: 999, url: 'https://example.com' })),
+      remove: vi.fn(() => Promise.resolve()),
+      onUpdated: {
+        addListener: vi.fn((cb: (tabId: number, info: { status?: string }) => void) => {
+          setTimeout(() => cb(999, { status: 'complete' }), 0);
+        }),
+        removeListener: vi.fn(),
+      },
+    },
+    scripting: {
+      executeScript: executeScriptImpl ?? vi.fn(() => Promise.resolve([{ result: mockScriptResult }])),
+    },
+  };
+}
+
+function setDocumentStub(body: unknown): void {
+  (globalThis as Record<string, unknown>).document = { body };
+}
+
+function deleteDocumentStub(): void {
+  delete (globalThis as Record<string, unknown>).document;
+}
+
+describe('ManualContentFetcher - branch coverage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSanitizeRegex.mockReset();
+    mockSanitizeRegex.mockResolvedValue({ text: mockScriptResult });
+  });
+
+  it('returns raw content when sanitization yields empty text', async () => {
+    setupChromeMock();
+    mockSanitizeRegex.mockResolvedValue({ text: '' });
+
+    const fetcher = new ManualContentFetcher();
+    const content = await fetcher.fetchContent('https://example.com');
+    expect(content).toBe(mockScriptResult);
+  });
+
+  it('returns raw content when sanitization fails', async () => {
+    setupChromeMock();
+    mockSanitizeRegex.mockRejectedValue(new Error('sanitizer crash'));
+
+    const fetcher = new ManualContentFetcher();
+    const content = await fetcher.fetchContent('https://example.com');
+    expect(content).toBe(mockScriptResult);
+  });
+
+  it('re-fetches from a new tab when the cache entry has expired', async () => {
+    setupChromeMock();
+    const fetcher = new ManualContentFetcher(1000, 10);
+    await fetcher.fetchContent('https://example.com');
+    expect(fetcher.getCacheSize()).toBe(1);
+
+    const createFn = (chrome.tabs.create as ReturnType<typeof vi.fn>);
+    createFn.mockClear();
+
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 5000);
+    try {
+      const content = await fetcher.fetchContent('https://example.com');
+      expect(content).toBe(mockScriptResult);
+      expect(fetcher.getCacheSize()).toBe(1);
+      expect(createFn).toHaveBeenCalled();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('returns empty string when the page has no body', async () => {
+    setupChromeMock(
+      vi.fn(async (opts: ExecuteScriptOptions) => [{ result: await opts.func(...opts.args) }])
+    );
+    setDocumentStub(null);
+    try {
+      const fetcher = new ManualContentFetcher();
+      const content = await fetcher.fetchContent('https://example.com');
+      expect(content).toBe('');
+      expect(fetcher.getCacheSize()).toBe(0);
+    } finally {
+      deleteDocumentStub();
+    }
+  });
+
+  it('extracts text from the cloned page body', async () => {
+    setupChromeMock(
+      vi.fn(async (opts: ExecuteScriptOptions) => [{ result: await opts.func(...opts.args) }])
+    );
+    setDocumentStub({
+      cloneNode: () => ({
+        querySelectorAll: () => ({ forEach: () => {} }),
+        innerText: '  page text  ',
+      }),
+    });
+    try {
+      mockSanitizeRegex.mockImplementation(async (text: string) => ({ text }));
+      const fetcher = new ManualContentFetcher();
+      const content = await fetcher.fetchContent('https://example.com');
+      expect(content).toBe('page text');
+      expect(fetcher.getCacheSize()).toBe(1);
+    } finally {
+      deleteDocumentStub();
+    }
+  });
+
+  it('returns empty string when the extracted text is empty', async () => {
+    setupChromeMock(
+      vi.fn(async (opts: ExecuteScriptOptions) => [{ result: await opts.func(...opts.args) }])
+    );
+    setDocumentStub({
+      cloneNode: () => ({
+        querySelectorAll: () => ({ forEach: () => {} }),
+        innerText: '',
+      }),
+    });
+    try {
+      const fetcher = new ManualContentFetcher();
+      const content = await fetcher.fetchContent('https://example.com');
+      expect(content).toBe('');
+    } finally {
+      deleteDocumentStub();
+    }
+  });
+
+  it('returns empty string when executeScript returns no results', async () => {
+    setupChromeMock(vi.fn(() => Promise.resolve([])));
+
+    const fetcher = new ManualContentFetcher();
+    const content = await fetcher.fetchContent('https://example.com');
+    expect(content).toBe('');
+  });
+
+  it('returns empty string when executeScript resolves undefined', async () => {
+    setupChromeMock(vi.fn(() => Promise.resolve(undefined)));
+
+    const fetcher = new ManualContentFetcher();
+    const content = await fetcher.fetchContent('https://example.com');
+    expect(content).toBe('');
+  });
+});

--- a/src/dashboard/settings/__tests__/privacySettings.test.ts
+++ b/src/dashboard/settings/__tests__/privacySettings.test.ts
@@ -411,4 +411,139 @@ describe('privacySettings', () => {
       expect(() => init()).not.toThrow();
     });
   });
+
+  describe('cloud provider guard (toggleCloudProviderSettings)', () => {
+    function setupProviderDOM() {
+      document.body.innerHTML = `
+        <input type="radio" name="privacyMode" value="masked_cloud" />
+        <input type="radio" name="privacyMode" value="full_pipeline" checked />
+        <input type="radio" name="privacyMode" value="local_only" />
+        <input type="checkbox" id="piiConfirm" />
+        <input type="radio" name="autoSavePrivacyBehavior" value="save" checked />
+        <button id="savePrivacySettings">Save</button>
+        <div id="privacyStatus"></div>
+        <div id="providerWrap">
+          <div class="form-group">
+            <select id="aiProvider"><option value="gemini">Gemini</option></select>
+          </div>
+          <div id="geminiSettings"><input type="text" /></div>
+          <div id="openaiSettings"><input type="text" /></div>
+          <div id="openai2Settings"><input type="text" /></div>
+        </div>
+      `;
+    }
+
+    it('disables cloud provider settings when local_only is selected', async () => {
+      setupProviderDOM();
+      mockGetSettings.mockResolvedValue({});
+
+      const { init, loadPrivacySettings } = await import('../privacySettings.js');
+      await loadPrivacySettings();
+      init();
+
+      const localOnly = document.querySelector('input[name="privacyMode"][value="local_only"]') as HTMLInputElement;
+      localOnly.checked = true;
+      localOnly.dispatchEvent(new Event('change'));
+
+      expect((document.getElementById('aiProvider') as HTMLSelectElement).disabled).toBe(true);
+      expect(
+        (document.querySelector('#geminiSettings input') as HTMLInputElement).disabled
+      ).toBe(true);
+      expect(
+        (document.querySelector('#openaiSettings input') as HTMLInputElement).disabled
+      ).toBe(true);
+      expect(
+        (document.querySelector('#openai2Settings input') as HTMLInputElement).disabled
+      ).toBe(true);
+      expect((document.getElementById('providerWrap') as HTMLElement).style.opacity).toBe('0.5');
+      expect((document.getElementById('providerWrap') as HTMLElement).style.pointerEvents).toBe('none');
+    });
+
+    it('re-enables cloud provider settings when a non-local mode is selected', async () => {
+      setupProviderDOM();
+      mockGetSettings.mockResolvedValue({ privacy_mode: 'local_only' });
+
+      const { init, loadPrivacySettings } = await import('../privacySettings.js');
+      await loadPrivacySettings();
+      init();
+
+      // Start disabled (local_only loaded), then switch to masked_cloud
+      expect((document.getElementById('aiProvider') as HTMLSelectElement).disabled).toBe(true);
+
+      const maskedCloud = document.querySelector('input[name="privacyMode"][value="masked_cloud"]') as HTMLInputElement;
+      maskedCloud.checked = true;
+      maskedCloud.dispatchEvent(new Event('change'));
+
+      expect((document.getElementById('aiProvider') as HTMLSelectElement).disabled).toBe(false);
+      expect(
+        (document.querySelector('#geminiSettings input') as HTMLInputElement).disabled
+      ).toBe(false);
+      expect((document.getElementById('providerWrap') as HTMLElement).style.opacity).toBe('1');
+      expect((document.getElementById('providerWrap') as HTMLElement).style.pointerEvents).toBe('');
+    });
+
+    it('ignores change events on unchecked radios', async () => {
+      setupProviderDOM();
+      mockGetSettings.mockResolvedValue({});
+
+      const { init, loadPrivacySettings } = await import('../privacySettings.js');
+      await loadPrivacySettings();
+      init();
+
+      // Dispatch change without checking the radio → guard must not run
+      const localOnly = document.querySelector('input[name="privacyMode"][value="local_only"]') as HTMLInputElement;
+      localOnly.checked = false;
+      localOnly.dispatchEvent(new Event('change'));
+
+      expect((document.getElementById('aiProvider') as HTMLSelectElement).disabled).toBe(false);
+    });
+  });
+
+  describe('savePrivacySettings validation fallbacks', () => {
+    it('shows modeRequired error when no privacy mode radio is selected', async () => {
+      document.body.innerHTML = `
+        <input type="radio" name="privacyMode" value="masked_cloud" />
+        <input type="radio" name="privacyMode" value="full_pipeline" />
+        <button id="savePrivacySettings">Save</button>
+        <div id="privacyStatus"></div>
+      `;
+      mockGetSettings.mockResolvedValue({ privacy_mode: 'unknown_mode' });
+
+      const { init, loadPrivacySettings } = await import('../privacySettings.js');
+      await loadPrivacySettings();
+      init();
+
+      (document.getElementById('savePrivacySettings') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => {
+        expect(mockShowStatus).toHaveBeenCalledWith('privacyStatus', 'modeRequired', 'error');
+      });
+      expect(mockSaveSettings).not.toHaveBeenCalled();
+    });
+
+    it('defaults confirmation to true and behavior to save when elements are missing', async () => {
+      document.body.innerHTML = `
+        <input type="radio" name="privacyMode" value="full_pipeline" checked />
+        <button id="savePrivacySettings">Save</button>
+        <div id="privacyStatus"></div>
+      `;
+      mockGetSettings.mockResolvedValue({});
+      mockSaveSettings.mockResolvedValue(undefined);
+
+      const { init, loadPrivacySettings } = await import('../privacySettings.js');
+      await loadPrivacySettings();
+      init();
+
+      (document.getElementById('savePrivacySettings') as HTMLButtonElement).click();
+
+      await vi.waitFor(() => {
+        expect(mockSaveSettings).toHaveBeenCalled();
+      });
+      expect(mockSaveSettings).toHaveBeenCalledWith({
+        privacy_mode: 'full_pipeline',
+        pii_confirmation_ui: true,
+        auto_save_privacy_behavior: 'save',
+      });
+    });
+  });
 });

--- a/src/dashboard/settings/ublockImport/__tests__/sourceManager.test.ts
+++ b/src/dashboard/settings/ublockImport/__tests__/sourceManager.test.ts
@@ -439,4 +439,79 @@ describe('ublockImport - SourceManager Module', () => {
       expect(state2.settings[StorageKeys.UBLOCK_SOURCES]).toHaveLength(1);
     });
   });
+
+  describe('未設定の ublock_sources へのフォールバック', () => {
+    test('loadAndDisplaySources は未設定の場合空配列をコールバックに渡す', async () => {
+      storageMocks.setStorageState({ settings: { ublock_sources: undefined } });
+
+      const renderCallback = vi.fn();
+      await loadAndDisplaySources(renderCallback);
+
+      expect(renderCallback).toHaveBeenCalledWith([]);
+    });
+
+    test('deleteSource は未設定の場合何もしない', async () => {
+      storageMocks.setStorageState({ settings: { ublock_sources: undefined } });
+
+      const renderCallback = vi.fn();
+      await deleteSource(0, renderCallback);
+
+      expect(renderCallback).not.toHaveBeenCalled();
+    });
+
+    test('reloadSource は未設定の場合エラーを投げる', async () => {
+      storageMocks.setStorageState({ settings: { ublock_sources: undefined } });
+
+      const fetchFromUrlCallback = vi.fn();
+      await expect(reloadSource(0, fetchFromUrlCallback)).rejects.toThrow('無効なインデックス');
+    });
+
+    test('saveUblockSettings は未設定の場合新規ソースとして追加する', async () => {
+      storageMocks.setStorageState({ settings: { ublock_sources: undefined } });
+
+      const result = await saveUblockSettings('||example.com^');
+
+      expect(result.action).toBe('追加');
+      expect(result.sources).toHaveLength(1);
+      expect(result.sources[0].url).toBe('manual');
+    });
+  });
+
+  describe('一部無効な行を含むフィルター', () => {
+    test('reloadSource は有効ルールがあれば警告付きで更新する', async () => {
+      storageMocks.setStorageState({
+        settings: {
+          ublock_sources: [
+            { url: 'https://example.com/filters.txt', ruleCount: 1, blockDomains: ['example.com'], exceptionDomains: [] }
+          ],
+          ublock_rules: {},
+          ublock_format_enabled: false
+        }
+      });
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const fetchFromUrlCallback = vi.fn().mockResolvedValue('||example.com^\ninvalid line without caret');
+        const result = await reloadSource(0, fetchFromUrlCallback);
+
+        expect(result.ruleCount).toBe(1);
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    test('saveUblockSettings は有効ルールがあれば警告付きで保存する', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const result = await saveUblockSettings('||example.com^\ninvalid line without caret');
+
+        expect(result.action).toBe('追加');
+        expect(result.ruleCount).toBe(1);
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
 });

--- a/src/popup/__tests__/onboardingWizard.test.ts
+++ b/src/popup/__tests__/onboardingWizard.test.ts
@@ -150,4 +150,90 @@ describe('onboardingWizard', () => {
       expect.objectContaining({ url: expect.stringContaining('?section=ai-provider') })
     );
   });
+
+  it('creates wizard DOM and backdrop when neither exists', () => {
+    document.body.innerHTML = '';
+    initOnboardingWizard();
+
+    const wizard = document.getElementById('onboardingWizard');
+    expect(wizard).not.toBeNull();
+    expect(wizard?.getAttribute('role')).toBe('dialog');
+    expect(wizard?.getAttribute('aria-modal')).toBe('true');
+    expect(wizard?.classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('wizardBackdrop')).not.toBeNull();
+    // Created wizard contains all four steps including the minimal finish step
+    expect(wizard?.querySelectorAll('.wizard-step')).toHaveLength(4);
+  });
+
+  it('reuses an existing backdrop when creating the wizard DOM', () => {
+    document.body.innerHTML = '<div id="wizardBackdrop"></div>';
+    initOnboardingWizard();
+
+    expect(document.querySelectorAll('#wizardBackdrop')).toHaveLength(1);
+    expect(document.getElementById('onboardingWizard')).not.toBeNull();
+  });
+
+  it('skips listener setup when the wizard is already initialized', () => {
+    initOnboardingWizard();
+    const trapSpy = vi.spyOn(focusTrapManager, 'trap');
+    initOnboardingWizard();
+    // Second init returns early without re-arming the focus trap
+    expect(trapSpy).not.toHaveBeenCalled();
+    trapSpy.mockRestore();
+  });
+
+  it('rebinds listeners when re-initialized after the initialized flag is cleared', async () => {
+    initOnboardingWizard();
+    const wizard = document.getElementById('onboardingWizard') as HTMLElement;
+    wizard.dataset.initialized = '';
+    initOnboardingWizard();
+
+    const obsidianBtn = document.querySelector('[data-type="obsidian"]') as HTMLButtonElement;
+    obsidianBtn.click();
+    expect(document.querySelector('[data-step="obsidian"]')?.classList.contains('hidden')).toBe(false);
+  });
+
+  it('falls back to the minimal type when finishing with no visible step', async () => {
+    initOnboardingWizard();
+    document.querySelectorAll('.wizard-step').forEach(step => step.classList.add('hidden'));
+    (document.querySelector('[data-step="obsidian"] .wizard-next') as HTMLButtonElement).click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(mockStorage.get(StorageKeys.ONBOARDING_WIZARD_TYPE)).toBe('minimal');
+    expect(chrome.tabs.create).toHaveBeenCalledWith(
+      expect.objectContaining({ url: expect.stringContaining('?section=general') })
+    );
+  });
+
+  it('does not navigate to the dashboard when skipNavigation is true', async () => {
+    initOnboardingWizard(true);
+    (document.querySelector('[data-type="obsidian"]') as HTMLButtonElement).click();
+    (document.querySelector('[data-step="obsidian"] .wizard-next') as HTMLButtonElement).click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(mockStorage.get(StorageKeys.ONBOARDING_WIZARD_COMPLETED)).toBe(true);
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the type step title for an unknown step name', () => {
+    const customBtn = document.createElement('button');
+    customBtn.className = 'wizard-option';
+    customBtn.setAttribute('data-type', 'custom');
+    document.querySelector('.wizard-options')?.appendChild(customBtn);
+
+    initOnboardingWizard();
+    customBtn.click();
+
+    // titleMap['custom'] is undefined → falls back to titleMap['type']
+    expect(document.getElementById('wizardTitle')?.textContent).toBe('wizardTitle');
+  });
+
+  it('uses hardcoded fallback titles when i18n messages are unavailable', () => {
+    (chrome as unknown as Record<string, unknown>).i18n = {
+      getMessage: vi.fn(() => ''),
+    };
+    initOnboardingWizard();
+
+    expect(document.getElementById('wizardTitle')?.textContent).toBe('Welcome to Yasumaro');
+  });
 });

--- a/src/utils/__tests__/permissionManager.test.ts
+++ b/src/utils/__tests__/permissionManager.test.ts
@@ -730,6 +730,120 @@ describe('PermissionManager - P0 - Error handling', () => {
     global.chrome = originalChrome;
   });
 });
+describe('PermissionManager - P0 - Domain validation and eviction', () => {
+  // Earlier "Error handling" suites replace global.chrome without restoring it,
+  // so this suite rebuilds the storage-backed chrome mock for isolation.
+  function rebuildChromeMock(): void {
+    global.chrome = {
+      storage: {
+        local: {
+          get: vi.fn().mockImplementation((keys: unknown, callback?: (result: Record<string, unknown>) => void) => {
+            const result: Record<string, unknown> = {};
+            if (typeof keys === 'object' && keys !== null && !Array.isArray(keys)) {
+              Object.entries(keys as Record<string, unknown>).forEach(([key, defaultVal]) => {
+                result[key] = mockStorage.has(key) ? mockStorage.get(key) : defaultVal;
+              });
+            } else {
+              const keyArray = Array.isArray(keys) ? keys : keys === undefined || keys === null ? [] : [keys];
+              keyArray.forEach(key => {
+                if (mockStorage.has(key)) {
+                  result[key as string] = mockStorage.get(key);
+                }
+              });
+            }
+            if (callback) {
+              callback(result);
+            }
+            return Promise.resolve(result);
+          }),
+          set: vi.fn().mockImplementation((items: Record<string, unknown>, callback?: () => void) => {
+            Object.entries(items).forEach(([key, value]) => {
+              mockStorage.set(key, value);
+            });
+            if (callback) {
+              callback();
+            }
+            return Promise.resolve();
+          }),
+        },
+      },
+      permissions: {
+        contains: vi.fn(),
+        request: vi.fn(),
+      },
+    } as any;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStorage.clear();
+    rebuildChromeMock();
+  });
+
+  it('should reject invalid domain formats without touching storage', async () => {
+    mockStorage.set('denied_domains', {});
+    const { getPermissionManager } = await import('../permissionManager.js');
+    const manager = getPermissionManager();
+
+    await manager.recordDeniedVisit('');                                              // falsy
+    await manager.recordDeniedVisit(undefined as unknown as string);                  // non-string
+    await manager.recordDeniedVisit(123 as unknown as string);                        // non-string
+    await manager.recordDeniedVisit('a'.repeat(254) + '.com');                        // > 253 chars
+    await manager.recordDeniedVisit('example..com');                                  // empty label
+    await manager.recordDeniedVisit('a'.repeat(64) + '.com');                         // label > 63 chars
+    await manager.recordDeniedVisit('exa_mple.com');                                  // invalid chars
+    await manager.recordDeniedVisit('-example.com');                                  // leading hyphen
+
+    const stored = mockStorage.get('denied_domains');
+    expect(stored).toEqual({});
+  });
+
+  it('should treat null denied_domains as empty when reading frequent domains', async () => {
+    mockStorage.set('denied_domains', null);
+    const { getPermissionManager } = await import('../permissionManager.js');
+    const manager = getPermissionManager();
+
+    const result = await manager.getFrequentDeniedDomains();
+    expect(result).toEqual([]);
+  });
+
+  it('should treat null denied_domains as empty when recording a visit', async () => {
+    mockStorage.set('denied_domains', null);
+    const { getPermissionManager } = await import('../permissionManager.js');
+    const manager = getPermissionManager();
+
+    await manager.recordDeniedVisit('example.com');
+
+    const stored = mockStorage.get('denied_domains');
+    expect(stored['example.com']).toBeDefined();
+    expect(stored['example.com'].count).toBe(1);
+  });
+
+  it('should evict the entry with an invalid lastDenied date when at the 100 domain limit', async () => {
+    const domains: Record<string, { count: number; lastDenied: string; lastDismissed?: string }> = {};
+    // 99 valid entries with increasing lastDenied
+    for (let i = 0; i < 99; i++) {
+      domains[`domain${i}.com`] = {
+        count: 1,
+        lastDenied: new Date(Date.now() - (100 - i) * 60000).toISOString(),
+      };
+    }
+    // 1 entry with an unparseable date (treated as oldest)
+    domains['bad-date.com'] = { count: 1, lastDenied: 'not-a-date' };
+    mockStorage.set('denied_domains', domains);
+
+    const { getPermissionManager } = await import('../permissionManager.js');
+    const manager = getPermissionManager();
+
+    await manager.recordDeniedVisit('newdomain.com');
+
+    const stored = mockStorage.get('denied_domains');
+    expect(stored['newdomain.com']).toBeDefined();
+    expect(stored['bad-date.com']).toBeUndefined();
+    expect(Object.keys(stored)).toHaveLength(100);
+  });
+});
+
 describe('PermissionManager - P0 - Error handling', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary

Two changes bundled on this branch:

1. **VulnHunter security audit backlog + 14 remediation PBIs** — the 2026-08-29
   scan (run `obsidian-smart-history_VULNHUNT_RESULTS_2026-08-29-165536`) confirmed
   48 findings (3 Medium / 45 Low) plus 9 code-quality items. This PR turns them
   into 14 prioritized PBIs grouped by root cause, with RICE scoring, five-whys
   analysis, BDD scenarios, and per-finding fix strategies. A backlog file
   documents candidate clustering, a VULN-to-PBI traceability table, and a
   suggested wave plan (Wave 1: 5 parallel quick fixes → Wave 2: 6 parallel →
   Wave 3: 2 high-risk semantic changes).

2. **Branch-coverage tests** — new and extended test suites for
   `manualContentFetcher`, `privacySettings`, `ublockImport/sourceManager`,
   `onboardingWizard`, and `permissionManager` to raise branch coverage, plus
   archiving of the completed release-check-blocker PBI.

## Why

The audit report alone (in the untracked results directory) does not create
follow-up work. Converting each root-cause cluster into a reviewable PBI with
acceptance criteria makes the remediation plan actionable and keeps the 48
findings from collapsing into a vague "harden security" backlog item. No
production source is changed in this PR — fixes will follow the PBIs.

## Notes for reviewers

- All 48 findings are traceable: see the traceability table in
  `pbi/2026-08-29-00-backlog-vulnhunt-audit.md`.
- Medium findings: VULN-001 (markdown sanitizer HTML passthrough), VULN-022
  (storageFallback unlocked mutators), VULN-025 (ReDoS in DOMAIN_VALIDATION).
- 6 findings were verified as false positives and 2 as dead code in the audit;
  they are intentionally not turned into PBIs.
- Top-priority PBI (RICE 4750): `01-fix-regex-safety` — a single regex
  replacement eliminates the empirically-verified 8.3s exponential ReDoS.