### PR TITLE
fix(sqlite): クエリ limit の両側クランプで LIMIT -1 全件展開を封じる（VULN-017/021/048/049）

### DIFF
--- a/src/background/handlers/__tests__/dashboardSqliteHandlers-extra.test.ts
+++ b/src/background/handlers/__tests__/dashboardSqliteHandlers-extra.test.ts
@@ -339,6 +339,32 @@ describe('handleDashboardSqlite — query', () => {
     }));
   });
 
+  it.each([
+    ['negative', -1, 100],
+    ['zero', 0, 100],
+    ['non-integer', 0.5, 100],
+    ['huge', 1e9, 1000],
+    ['normal', 50, 50],
+  ])('clamps limit=%s at the trust boundary (query)', async (_label, raw, expected) => {
+    const mock = createMockSqliteClient();
+    await dispatchDashboardSqlite({ subtype: 'query', limit: raw as number }, mock as any);
+    expect(mock.query).toHaveBeenCalledWith(expect.objectContaining({ limit: expected }));
+  });
+
+  it('clamps a negative search limit to the search default (50)', async () => {
+    const mock = createMockSqliteClient();
+    await dispatchDashboardSqlite({ subtype: 'search', query: 'x', limit: -1 }, mock as any);
+    expect(mock.query).toHaveBeenCalledWith(expect.objectContaining({ kind: 'search', limit: 50 }));
+  });
+
+  it('clamps a negative audit_log_query limit to a positive value within cap', async () => {
+    const mock = createMockSqliteClient();
+    await dispatchDashboardSqlite({ subtype: 'audit_log_query', limit: -1 } as any, mock as any);
+    const call = mock.query.mock.calls.find((c: unknown[]) => (c[0] as { kind?: string }).kind === 'auditLog');
+    expect(call[0].limit).toBeGreaterThanOrEqual(1);
+    expect(call[0].limit).toBeLessThanOrEqual(1000);
+  });
+
   it('returns error when sqliteClient.query fails', async () => {
     const mock = createMockSqliteClient();
     mock.query.mockResolvedValue({ success: false, error: { kind: 'unknown', message: 'Query failed', retriable: false } });

--- a/src/background/handlers/dashboardSqlite/readOnlyHandler.ts
+++ b/src/background/handlers/dashboardSqlite/readOnlyHandler.ts
@@ -2,6 +2,7 @@ import type { DashboardSqliteRequest, DashboardSqliteSubtype } from '../dashboar
 import type { ReadOnlyDeps } from './deps.js';
 import { toFailure } from './deps.js';
 import { pickDefined } from '../../../utils/objectUtils.js';
+import { clampLimit } from '../../../offscreen/queryPlan.js';
 
 /**
  * Subtypes this handler owns. The router derives its dispatch from this set,
@@ -24,7 +25,7 @@ export function createReadOnlyHandler(deps: ReadOnlyDeps) {
       }
       case 'query': {
         const result = await deps.query({
-          limit: payload.limit ?? 100,
+          limit: clampLimit(payload.limit, 1000, 100),
           offset: payload.offset ?? 0,
           domain: payload.domain,
           isStarred: payload.isStarred,
@@ -42,7 +43,7 @@ export function createReadOnlyHandler(deps: ReadOnlyDeps) {
       case 'search': {
         const result = await deps.search(
           payload.query || '',
-          payload.limit ?? 50,
+          clampLimit(payload.limit, 100000, 50),
           payload.offset ?? 0,
           pickDefined({ orderBy: payload.orderBy, orderDir: payload.orderDir }),
         );
@@ -77,7 +78,10 @@ export function createReadOnlyHandler(deps: ReadOnlyDeps) {
       }
       case 'audit_log_query': {
         const result = await deps.queryAuditLog(
-          pickDefined({ limit: payload.limit, offset: payload.offset }),
+          pickDefined({
+            limit: payload.limit === undefined ? undefined : clampLimit(payload.limit, 1000, 1000),
+            offset: payload.offset,
+          }),
         );
         if (!result.success) {
           return toFailure(result);

--- a/src/offscreen/IdbVfsBackend.ts
+++ b/src/offscreen/IdbVfsBackend.ts
@@ -11,7 +11,7 @@ import type {
 import type { BrowsingLogRecord, BrowsingLogEntry, StorageQuery, AuditLogRecord, AuditLogEntry } from '../utils/sqlite-types.js';
 import { INSERT_SQL, INSERT_IGNORE_SQL, buildInsertParams, UPDATABLE_FIELDS } from './schema.js';
 import { extractDomain, DB_FILENAME } from './sqliteEngineContext.js';
-import { buildQuerySpec, QUERY_CAPS } from './queryPlan.js';
+import { buildQuerySpec, QUERY_CAPS, clampLimit } from './queryPlan.js';
 import { pickDefined } from '../utils/objectUtils.js';
 import { withTransaction } from './opfsWorker/handlers.js';
 
@@ -368,7 +368,7 @@ export class IdbVfsBackend implements StorageBackend {
 
   async queryAuditLog(options: { limit?: number; offset?: number }): Promise<BackendOrError<AuditLogQueryResult>> {
     this.ensureDb();
-    const limit = Math.min(options.limit ?? 100, 100000);
+    const limit = clampLimit(options.limit, 100000, 100);
     const offset = options.offset ?? 0;
 
     const rows: AuditLogEntry[] = [];

--- a/src/offscreen/__tests__/IdbVfsBackend-search-sort.test.ts
+++ b/src/offscreen/__tests__/IdbVfsBackend-search-sort.test.ts
@@ -74,3 +74,20 @@ describe('IdbVfsBackend.query — search ORDER BY branch', () => {
     expect(rowQuery).toBeUndefined();
   });
 });
+
+describe('IdbVfsBackend.queryAuditLog — limit clamp', () => {
+  it.each([
+    ['negative', -1, 100],
+    ['zero', 0, 100],
+    ['non-integer', 0.5, 100],
+    ['huge', 1e9, 100000],
+    ['normal', 50, 50],
+  ])('clamps limit=%s to %s in the LIMIT param', async (_label, raw, expected) => {
+    const { engine, calls } = makeStubEngine();
+    const backend = new IdbVfsBackend(engine as never);
+    (backend as unknown as { ensureDb: () => void }).ensureDb = () => {};
+    await backend.queryAuditLog({ limit: raw as number });
+    const rowQuery = calls.find(c => /FROM audit_log ORDER BY/i.test(c.sql));
+    expect(rowQuery?.params[0]).toBe(expected);
+  });
+});

--- a/src/offscreen/__tests__/auditLogLimitClamp.test.ts
+++ b/src/offscreen/__tests__/auditLogLimitClamp.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleAuditLogQuery } from '../opfsWorker/auditHandlers.js';
+import type { SqliteRow } from '../sqliteEngine.js';
+
+/**
+ * The audit_log read path builds `LIMIT ?` from `payload.limit`. SQLite treats
+ * `LIMIT -1` as unlimited, so a both-sided clamp must reach the bound value,
+ * not just an upper cap.
+ */
+function makeCtx(captured: { limitParam?: unknown }) {
+  return {
+    engine: {
+      exec: vi.fn().mockResolvedValue(undefined),
+      query: vi.fn(async (sql: string, params: unknown[]): Promise<SqliteRow[]> => {
+        if (sql.includes('FROM audit_log ORDER BY')) {
+          captured.limitParam = params[0];
+          return [];
+        }
+        return [{ c: 0 } as unknown as SqliteRow];
+      }),
+    },
+  } as never;
+}
+
+describe('handleAuditLogQuery limit clamp', () => {
+  it.each([
+    ['negative', -1, 100],
+    ['zero', 0, 100],
+    ['non-integer', 0.5, 100],
+    ['huge', 1e9, 1000],
+    ['normal', 50, 50],
+  ])('clamps limit=%s to %s', async (_label, raw, expected) => {
+    const captured: { limitParam?: unknown } = {};
+    await handleAuditLogQuery(makeCtx(captured), { limit: raw as number });
+    expect(captured.limitParam).toBe(expected);
+  });
+});

--- a/src/offscreen/__tests__/queryPlanClamp.test.ts
+++ b/src/offscreen/__tests__/queryPlanClamp.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { clampLimit, buildQuerySpec, QUERY_CAPS } from '../queryPlan.js';
+
+describe('clampLimit', () => {
+  const cap = 1000;
+  const fallback = 100;
+
+  it('returns fallback for negative raw', () => {
+    expect(clampLimit(-1, cap, fallback)).toBe(fallback);
+  });
+
+  it('returns fallback for zero', () => {
+    expect(clampLimit(0, cap, fallback)).toBe(fallback);
+  });
+
+  it('returns fallback for non-integer raw', () => {
+    expect(clampLimit(0.5, cap, fallback)).toBe(fallback);
+  });
+
+  it('returns fallback for non-finite raw', () => {
+    expect(clampLimit(Infinity, cap, fallback)).toBe(fallback);
+    expect(clampLimit(NaN, cap, fallback)).toBe(fallback);
+  });
+
+  it('returns fallback for non-number raw', () => {
+    expect(clampLimit('50', cap, fallback)).toBe(fallback);
+    expect(clampLimit(undefined, cap, fallback)).toBe(fallback);
+    expect(clampLimit(null, cap, fallback)).toBe(fallback);
+  });
+
+  it('caps large raw at cap', () => {
+    expect(clampLimit(1e9, cap, fallback)).toBe(cap);
+  });
+
+  it('passes a normal value through', () => {
+    expect(clampLimit(50, cap, fallback)).toBe(50);
+  });
+});
+
+describe('buildQuerySpec limit clamp', () => {
+  it('clamps negative limit to the plain default (100)', () => {
+    const spec = buildQuerySpec({ limit: -1 });
+    expect(spec.limit).toBeGreaterThanOrEqual(1);
+    expect(spec.limit).toBeLessThanOrEqual(QUERY_CAPS.plain);
+    expect(spec.limit).toBe(100);
+  });
+
+  it('clamps 0.5 to default', () => {
+    expect(buildQuerySpec({ limit: 0.5 }).limit).toBe(100);
+  });
+
+  it('caps 1e9 at the plain cap', () => {
+    expect(buildQuerySpec({ limit: 1e9 }).limit).toBe(QUERY_CAPS.plain);
+  });
+
+  it('passes 50 through', () => {
+    expect(buildQuerySpec({ limit: 50 }).limit).toBe(50);
+  });
+});

--- a/src/offscreen/__tests__/recordsRepo-coverage.test.ts
+++ b/src/offscreen/__tests__/recordsRepo-coverage.test.ts
@@ -96,6 +96,16 @@ describe('recordsRepo — coverage 90% (PBI 10)', () => {
       const arg = mockBackend.query.mock.calls[0][0] as { limit: number };
       expect(arg.limit).toBe(100000);
     });
+
+    it.each([
+      ['負値', -1],
+      ['ゼロ', 0],
+      ['非整数', 0.5],
+      ['非有限', Infinity],
+    ])('%s は既定値 100 にフォールバックする', async (_label, raw) => {
+      await query({ limit: raw as number });
+      expect(mockBackend.query).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
+    });
   });
 
   // ── query: tag / text truncation (FTS_QUERY_MAX_LENGTH=200) ────────────

--- a/src/offscreen/opfsWorker/auditHandlers.ts
+++ b/src/offscreen/opfsWorker/auditHandlers.ts
@@ -4,6 +4,7 @@
  */
 
 import { sqlExec, sqlQuery, type HandlerContext } from './handlers.js';
+import { clampLimit } from '../queryPlan.js';
 import type { AuditLogQueryPayload } from './types.js';
 
 export async function handleAuditLogInsert(
@@ -24,7 +25,7 @@ export async function handleAuditLogQuery(
   ctx: HandlerContext,
   payload: AuditLogQueryPayload,
 ): Promise<{ rows: Array<{ id: number; provider: string; url: string; created_at: number }>; total: number }> {
-  const limit = Math.min(payload.limit ?? 100, 1000);
+  const limit = clampLimit(payload.limit, 1000, 100);
   const offset = payload.offset ?? 0;
 
   const rows: Array<{ id: number; provider: string; url: string; created_at: number }> = [];

--- a/src/offscreen/queryPlan.ts
+++ b/src/offscreen/queryPlan.ts
@@ -17,6 +17,22 @@ export const QUERY_CAPS = {
   plain: 1000,
 } as const;
 
+/**
+ * Both-sided LIMIT clamp for the trust boundary.
+ *
+ * SQLite treats `LIMIT -1` as "unlimited", so an upper-bound-only `Math.min`
+ * lets a negative or non-finite value materialize an entire table. Non-finite,
+ * non-integer, or non-positive input falls back to the caller's documented
+ * default rather than being coerced to 1, so `0.5` does not silently become a
+ * 1-row query.
+ */
+export function clampLimit(raw: unknown, cap: number, fallback: number): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || !Number.isInteger(raw) || raw <= 0) {
+    return fallback;
+  }
+  return Math.max(1, Math.min(cap, Math.floor(raw)));
+}
+
 export interface QuerySpec {
   where: string;
   order: string;
@@ -75,9 +91,8 @@ export function buildQuerySpec(
     };
   }
 
-  const rawLimit = query.limit ?? 100;
   const cap = useFts ? caps.fts : caps.plain;
-  const limit = Math.min(rawLimit, cap);
+  const limit = clampLimit(query.limit, cap, 100);
   const offset = query.offset ?? 0;
 
   // FTS tag handling

--- a/src/offscreen/recordsRepo.ts
+++ b/src/offscreen/recordsRepo.ts
@@ -9,6 +9,7 @@
 import { errorMessage } from '../utils/errorUtils.js';
 import { logError, ErrorCode } from '../utils/logger.js';
 import { engine, DB_FILENAME, MAX_QUERY_LIMIT } from './sqliteEngineContext.js';
+import { clampLimit } from './queryPlan.js';
 import type { SqliteValue } from './sqliteEngine.js';
 import { FTS_QUERY_MAX_LENGTH } from './schema.js';
 import { pickDefined } from '../utils/objectUtils.js';
@@ -41,7 +42,7 @@ export async function insertBatch(records: BrowsingLogRecord[]): Promise<{ succe
 export async function query(q: StorageQuery = {}): Promise<{
   success: true; rows: (BrowsingLogEntry & { rank: number })[]; total: number
 } | { success: false; error: string }> {
-  const cappedLimit = Math.min(q.limit ?? 100, MAX_QUERY_LIMIT);
+  const cappedLimit = clampLimit(q.limit, MAX_QUERY_LIMIT, 100);
   // Truncate tag and text to prevent expensive FTS5 queries on extremely long input
   const tag = q.tag ? q.tag.slice(0, FTS_QUERY_MAX_LENGTH) : q.tag;
   const text = q.text ? q.text.slice(0, FTS_QUERY_MAX_LENGTH) : q.text;


### PR DESCRIPTION
## 脆弱性

SQLite は `LIMIT -1` を「無制限」と解釈する。ダッシュボード SQLite の読み取り系は `Math.min(...)` のみで上限クランプしていたため、負値/非有限の `limit` が素通りし、`audit_log`・閲覧履歴の全件 materialization が可能（VULN-017/021/048/049, CWE-400。実証: 50万行、監査ログ全件流出）。

## 修正

`src/offscreen/queryPlan.ts` に純粋ヘルパー `clampLimit(raw, cap, fallback)` を新設:
- 非有限 / 非整数 / 非正 → `fallback`（既定値）
- それ以外 → `Math.max(1, Math.min(cap, floor(raw)))`

配線先（5シンク）:
- `queryPlan.ts` の `buildQuerySpec`
- `readOnlyHandler.ts`（query=100 / search=50 / audit_log_query）
- `opfsWorker/auditHandlers.ts`（cap 1000）
- `IdbVfsBackend.ts` の `queryAuditLog`（cap 100000）
- `recordsRepo.ts`（`MAX_QUERY_LIMIT`）

fts:100000 / plain:1000 の2種capは ADR `2026-08-27-limit-policy` に従い温存。`FallbackStorage.ts` の `slice` は JS セマンティクスで負値安全のため未変更。

## テスト（TDD）
- 新規 `queryPlanClamp.test.ts`（11）/ `auditLogLimitClamp.test.ts`（5）
- 既存拡張: `IdbVfsBackend-search-sort` / `recordsRepo-coverage` / `dashboardSqliteHandlers-extra`
- 境界値: `-1 / 0 / 0.5 / 1e9 / 正常値`

## ゲート
- `tsc --noEmit`: クリーン
- `npm test`: 10620 passing / 0 failures
- lint: 増分ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)