### PR TITLE
fix(security): FETCH_URL のリダイレクト追跡による SSRF を封鎖（VULN-016）

### DIFF
--- a/dev-docs/ADR/2026-08-29-fetch-redirect-policy.md
+++ b/dev-docs/ADR/2026-08-29-fetch-redirect-policy.md
@@ -1,0 +1,54 @@
+# ADR: FETCH_URL Redirect Policy — redirect: 'error'
+
+## ステータス
+採用
+
+## 日付
+2026-08-29
+
+## コンテキスト
+`FETCH_URL` メッセージハンドラ (`src/background/handlers/systemHandlers.ts`) は
+uBlock フィルタリストの import 用に任意 URL を fetch する。URL は
+`validateUrlForFilterImport` (protocol + private IP + localhost ガード) で検証
+されるが、検証されるのは初期 URL のみである。
+
+`fetch` はブラウザ既定の `redirect: 'follow'` でリダイレクトを黙って追跡する
+ため、許可された URL が 30x で `http://127.0.0.1:9222` 等の内部アドレスへ
+リダイレクトすると、Service Worker がその内部応答を取得して呼び出し元へ返す
+(SSRF / CWE-918, VULN-016)。拡張ページから直接到達できない private IP への
+SW 仲介アクセスという新たな capability になる。
+
+対策の選択肢:
+1. `redirect: 'error'` — リダイレクトが起きた時点で fetch を失敗させる。1 行。
+2. `redirect: 'manual'` + ホップ毎に `validateUrlForFilterImport` で再検証。
+
+## 決定
+`FETCH_URL` の fetch には **`redirect: 'error'`** を設定する。
+
+既定・カスタムを含む既知のフィルタリスト供給元
+(`raw.githubusercontent.com` / `gitlab.com` / `easylist.to` / `pgl.yoyo.org` /
+`nsfw.oisd.nl` 等) はいずれも固定 HTTPS ホストで、http→https 昇格やミラー
+リダイレクトに依存していない。したがって最も厳格な `redirect: 'error'` を
+選んでも正当なユースケースを損なわない。
+
+多層防御として、ハンドラは `response.redirected` も確認し、true の場合は
+body を返さない。
+
+将来、リダイレクトを正当に必要とする攻撃者影響 URL の fetch が現れた場合の
+規約として、`src/utils/fetch.ts` に `fetchWithRedirectGuard(url, options)` を
+新設する。これは `redirect: 'manual'` でリダイレクトを自前追跡し、各ホップの
+`Location` に `validateUrlForFilterImport` を再適用する (最大 5 ホップ、
+相対 Location は現在のホップ URL に対して解決、Location 欠落・ループは reject)。
+`FETCH_URL` は現状これを使わないが、契約として出荷する。
+
+## 結果
+- VULN-016 の実証済み攻撃経路 (許可 URL → 30x → private IP body 返却) が塞がれる。
+- 他 16 の fetch サイト (tranco / gist / obsidian / AI プロバイダ — 固定ホスト)
+  は挙動不変。リダイレクト方針の変更は `FETCH_URL` 系のみ。
+- ホップ毎再検証ヘルパーが将来の fetch 追加のための規約として存在する。
+
+## 参照
+- `src/background/handlers/systemHandlers.ts` — `createFetchUrlHandler`
+- `src/utils/fetch.ts` — `fetchWithRedirectGuard`
+- `src/utils/ssrfGuard.ts` — `validateUrlForFilterImport` / `isPrivateIpAddress`
+- PBI: `pbi/2026-08-29-09-fix-fetch-redirect-ssrf.md`

--- a/src/background/handlers/__tests__/systemHandlers.test.ts
+++ b/src/background/handlers/__tests__/systemHandlers.test.ts
@@ -133,6 +133,50 @@ describe('createFetchUrlHandler', () => {
     expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
     expect(logError).toHaveBeenCalled();
   });
+
+  it('requests redirect: "error" so the SW never follows a redirect (VULN-016)', async () => {
+    vi.mocked(validateUrlForFilterImport).mockImplementation(() => {});
+    vi.mocked(fetchWithTimeout).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      redirected: false,
+      url: 'https://example.com/list.txt',
+      headers: { get: vi.fn().mockReturnValue(null) },
+      text: vi.fn().mockResolvedValue('content'),
+    } as any);
+
+    const handler = createFetchUrlHandler(deps);
+    const sendResponse = vi.fn();
+    await handler({ payload: { url: 'https://example.com/list.txt' } } as any, {} as any, sendResponse);
+
+    const opts = vi.mocked(fetchWithTimeout).mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.redirect).toBe('error');
+  });
+
+  it('does NOT return a body from a redirected response pointing at a private IP (VULN-016)', async () => {
+    // Defense in depth: even if a redirect somehow slipped through, a response
+    // whose final URL is a private address must not be handed back.
+    vi.mocked(validateUrlForFilterImport).mockImplementation(() => {});
+    vi.mocked(fetchWithTimeout).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      redirected: true,
+      url: 'http://127.0.0.1:9222/json',
+      headers: { get: vi.fn().mockReturnValue(null) },
+      text: vi.fn().mockResolvedValue('{"internal":"devtools"}'),
+    } as any);
+
+    const handler = createFetchUrlHandler(deps);
+    const sendResponse = vi.fn();
+    await handler({ payload: { url: 'https://example.com/list.txt' } } as any, {} as any, sendResponse);
+
+    expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    const arg = sendResponse.mock.calls[0][0];
+    expect(JSON.stringify(arg)).not.toContain('devtools');
+    expect(logError).toHaveBeenCalled();
+  });
 });
 
 describe('createContentCleansingExecutedHandler', () => {

--- a/src/background/handlers/systemHandlers.ts
+++ b/src/background/handlers/systemHandlers.ts
@@ -84,11 +84,29 @@ export function createFetchUrlHandler(deps: FetchUrlHandlerDeps) {
       const settings = await deps.getSettings();
       const allowedUrls = deps.buildAllowedUrls(settings);
 
+      // VULN-016 (CWE-918): validateUrlForFilterImport only checks the initial
+      // URL. With the browser default `redirect: 'follow'`, an allow-listed URL
+      // could 30x-redirect to a private address (e.g. http://127.0.0.1:9222)
+      // and the SW would fetch + return the internal response. We use
+      // `redirect: 'error'` here so any redirect aborts the request.
+      //
+      // Decision: `redirect: 'error'` (not `manual` + per-hop re-validation).
+      // All known filter-list sources are fixed HTTPS hosts and none rely on
+      // http->https or mirror redirects, so the stricter policy costs nothing.
+      // See dev-docs/ADR/2026-08-29-fetch-redirect-policy.md. If a future source
+      // needs redirects, switch to fetchWithRedirectGuard() from utils/fetch.ts.
       const response = await fetchWithTimeout(message.payload.url, {
         method: 'GET',
         cache: 'no-cache',
+        redirect: 'error',
         allowedUrls,
       });
+
+      // Defense in depth: `redirect: 'error'` should already have rejected, but
+      // never hand back a body whose response was redirected.
+      if (response.redirected) {
+        throw new Error('Redirected responses are not allowed for filter list imports');
+      }
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/src/utils/__tests__/fetchRedirectGuard.test.ts
+++ b/src/utils/__tests__/fetchRedirectGuard.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../storage/settingsStore.js', () => ({
+  getSettings: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../logger.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger.js')>();
+  return {
+    ...actual,
+    logDebug: vi.fn().mockResolvedValue(undefined),
+    logWarn: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { fetchWithRedirectGuard } from '../fetch.js';
+
+function makeResponse(init: {
+  status: number;
+  location?: string | null;
+  url?: string;
+  body?: string;
+}): Response {
+  const headers = new Map<string, string>();
+  if (init.location != null) {
+    headers.set('location', init.location);
+  }
+  return {
+    status: init.status,
+    url: init.url ?? '',
+    redirected: false,
+    ok: init.status >= 200 && init.status < 300,
+    headers: {
+      get: (name: string) => headers.get(name.toLowerCase()) ?? null,
+    },
+    text: vi.fn().mockResolvedValue(init.body ?? ''),
+  } as unknown as Response;
+}
+
+describe('fetchWithRedirectGuard', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the response when there is no redirect', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ status: 200, url: 'https://example.com/list.txt', body: 'ok' }),
+    );
+
+    const res = await fetchWithRedirectGuard('https://example.com/list.txt', { method: 'GET' });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].redirect).toBe('manual');
+  });
+
+  it('follows a same-origin http->https upgrade redirect after re-validation', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makeResponse({ status: 301, location: 'https://example.com/list.txt' }),
+      )
+      .mockResolvedValueOnce(makeResponse({ status: 200, body: 'upgraded' }));
+
+    const res = await fetchWithRedirectGuard('http://example.com/list.txt', { method: 'GET' });
+    expect(await res.text()).toBe('upgraded');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe('https://example.com/list.txt');
+  });
+
+  it('follows a redirect that changes port on a public host', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makeResponse({ status: 302, location: 'https://example.com:8443/list.txt' }),
+      )
+      .mockResolvedValueOnce(makeResponse({ status: 200, body: 'port-changed' }));
+
+    const res = await fetchWithRedirectGuard('https://example.com/list.txt', { method: 'GET' });
+    expect(await res.text()).toBe('port-changed');
+  });
+
+  it('resolves a relative Location against the current hop URL', async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeResponse({ status: 302, location: '/mirror/list.txt' }))
+      .mockResolvedValueOnce(makeResponse({ status: 200, body: 'relative-ok' }));
+
+    const res = await fetchWithRedirectGuard('https://example.com/a/b.txt', { method: 'GET' });
+    expect(await res.text()).toBe('relative-ok');
+    expect(fetchMock.mock.calls[1][0]).toBe('https://example.com/mirror/list.txt');
+  });
+
+  it('rejects a redirect to 127.0.0.1', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ status: 302, location: 'http://127.0.0.1:9222/json' }),
+    );
+
+    await expect(
+      fetchWithRedirectGuard('https://example.com/list.txt', { method: 'GET' }),
+    ).rejects.toThrow(/private|redirect/i);
+  });
+
+  it('rejects a redirect to a private 10.x address', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ status: 301, location: 'http://10.0.0.5/secret' }),
+    );
+
+    await expect(
+      fetchWithRedirectGuard('https://example.com/list.txt', { method: 'GET' }),
+    ).rejects.toThrow(/private/i);
+  });
+
+  it('rejects a redirect to link-local cloud metadata 169.254.169.254', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ status: 302, location: 'http://169.254.169.254/latest/meta-data/' }),
+    );
+
+    await expect(
+      fetchWithRedirectGuard('https://example.com/list.txt', { method: 'GET' }),
+    ).rejects.toThrow(/private/i);
+  });
+
+  it('rejects a redirect to localhost by name', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ status: 302, location: 'http://localhost:9222/json' }),
+    );
+
+    await expect(
+      fetchWithRedirectGuard('https://example.com/list.txt', { method: 'GET' }),
+    ).rejects.toThrow(/localhost/i);
+  });
+
+  it('rejects a redirect response with a missing Location header', async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ status: 302, location: null }));
+
+    await expect(
+      fetchWithRedirectGuard('https://example.com/list.txt', { method: 'GET' }),
+    ).rejects.toThrow(/location/i);
+  });
+
+  it('rejects when the redirect chain exceeds the hop limit (loop)', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse({ status: 302, location: 'https://example.com/loop' }),
+    );
+
+    await expect(
+      fetchWithRedirectGuard('https://example.com/loop', { method: 'GET' }),
+    ).rejects.toThrow(/too many redirects/i);
+  });
+});

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -16,7 +16,7 @@ import { CSPValidator, getCspErrorMessage } from './cspValidator.js';
 import { getSettings } from './storage/settingsStore.js';
 import { StorageKeys } from './storage/types.js';
 import { logDebug, logWarn } from './logger.js';
-import { validateUrl } from './ssrfGuard.js';
+import { validateUrl, validateUrlForFilterImport } from './ssrfGuard.js';
 
 export {
   normalizeIpHostname,
@@ -154,6 +154,77 @@ export async function fetchWithTimeout(url: string, options: FetchOptions = {}, 
     }
     throw error;
   }
+}
+
+/**
+ * Maximum number of redirect hops fetchWithRedirectGuard will follow before
+ * giving up. Matches the browser default (20) is unnecessary here; filter-list
+ * mirrors realistically need at most a couple of hops.
+ */
+const MAX_REDIRECT_HOPS = 5;
+
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * fetch that follows redirects manually, re-validating every hop's target with
+ * validateUrlForFilterImport (protocol + private-IP + localhost guard).
+ *
+ * The platform `fetch` follows redirects silently with `redirect: 'follow'`,
+ * so an allow-listed URL can 30x-redirect to an internal address (SSRF /
+ * CWE-918). This helper closes that hole for attacker-influenced URLs (e.g.
+ * user-supplied uBlock filter-list sources) by using `redirect: 'manual'` and
+ * checking each `Location` before issuing the next request.
+ *
+ * The current FETCH_URL handler uses `redirect: 'error'` (see ADR
+ * 2026-08-29-fetch-redirect-policy); this helper is the contract for any future
+ * fetch of an attacker-influenced URL that legitimately needs to follow
+ * redirects.
+ *
+ * @param url - initial request URL (assumed already validated by the caller)
+ * @param options - fetch options; `redirect` is forced to `'manual'`
+ * @param timeoutMs - per-hop timeout
+ */
+export async function fetchWithRedirectGuard(
+  url: string,
+  options: FetchOptions = {},
+  timeoutMs: number = 30000,
+): Promise<Response> {
+  let currentUrl = url;
+
+  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    const response = await fetchWithTimeout(
+      currentUrl,
+      // CSP validation targets AI-provider URLs; filter-list fetches gate on
+      // allowedUrls + validateUrlForFilterImport instead, applied per hop below.
+      { ...options, redirect: 'manual', skipCspValidation: true },
+      timeoutMs,
+    );
+
+    if (!REDIRECT_STATUS_CODES.has(response.status)) {
+      return response;
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      throw new Error(`Redirect response ${response.status} is missing a Location header`);
+    }
+
+    // Resolve relative Location against the current hop URL.
+    let nextUrl: string;
+    try {
+      nextUrl = new URL(location, currentUrl).toString();
+    } catch {
+      throw new Error(`Invalid redirect Location: ${location}`);
+    }
+
+    // Re-apply the full SSRF guard to the redirect target.
+    validateUrlForFilterImport(nextUrl);
+
+    logDebug('Following validated redirect', { from: currentUrl, to: nextUrl, status: response.status }, 'fetchWithRedirectGuard');
+    currentUrl = nextUrl;
+  }
+
+  throw new Error(`Too many redirects (limit ${MAX_REDIRECT_HOPS})`);
 }
 
 /**


### PR DESCRIPTION
## 脆弱性

`FETCH_URL` ハンドラは `validateUrlForFilterImport` で初期 URL のみ検証し、`fetch` がブラウザ既定でリダイレクトを黙って追跡していた。許可 URL が 30x で `http://127.0.0.1:9222` 等の private IP へリダイレクトすると、SW が内部応答を取得・返却する（VULN-016, CWE-918 — 拡張ページからは到達できない新 capability）。

## 決定: `redirect: 'error'`

`src/utils/allowedUrls.ts` の固定フィルタ供給元（`raw.githubusercontent.com` / `gitlab.com` / `easylist.to` / `pgl.yoyo.org` / `nsfw.oisd.nl`）はすべて固定 HTTPS ホストで http→https 昇格やミラーリダイレクトに依存しない。ユーザー設定の `ublock_sources` も origin ベース。よって最厳格の `redirect: 'error'` で正当なユースケースを損なわない。

## 修正

| ファイル | 変更 |
|---|---|
| `src/background/handlers/systemHandlers.ts` | FETCH_URL の fetch に `redirect: 'error'`。多層防御として `response.redirected` も確認 |
| `src/utils/fetch.ts` | `fetchWithRedirectGuard` を新設。`redirect: 'manual'` でホップを自前追跡し各ホップの `Location` に `validateUrlForFilterImport` を再適用（最大5ホップ、相対Location解決、Location欠落・ループ拒否）。将来の攻撃者影響URL fetch 向け規約 |
| `dev-docs/ADR/2026-08-29-fetch-redirect-policy.md` | 新規 ADR |

## テスト（TDD）
- 新規 `fetchRedirectGuard.test.ts`（11ケース）
- `systemHandlers.test.ts` に2ケース追加（`redirect: 'error'` 付与 / private IP を指す `redirected: true` の body が返らない）
- 他16 fetch サイト（固定ホスト）は挙動不変

## ゲート
- `tsc --noEmit`: クリーン
- `npm test`: 10600 passing / 0 failures
- lint: 増分ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)