### PR TITLE
fix(popup): pending パネルのホワイトリスト追加が無効な機能バグを修正（orphan key）

### DIFF
--- a/src/popup/__tests__/main.test.ts
+++ b/src/popup/__tests__/main.test.ts
@@ -1711,7 +1711,7 @@ describe('main', () => {
     });
 
     it('should add domains to whitelist when type is domain', async () => {
-      mockChrome.storage.local.get.mockResolvedValueOnce({ domainWhitelist: [] });
+      mockChrome.storage.local.get.mockResolvedValueOnce({ domain_whitelist: [] });
 
       const list = document.getElementById('pending-pages-list')!;
       list.innerHTML = `<input type="checkbox" class="pending-checkbox" value="https://example.com/page" checked>`;
@@ -1724,7 +1724,7 @@ describe('main', () => {
       await saveSelectedPages('domain');
 
       expect(mockChrome.storage.local.set).toHaveBeenCalledWith(
-        expect.objectContaining({ domainWhitelist: expect.arrayContaining(['example.com']) })
+        expect.objectContaining({ domain_whitelist: expect.arrayContaining(['example.com']) })
       );
     });
   });

--- a/src/popup/__tests__/pendingPages.test.ts
+++ b/src/popup/__tests__/pendingPages.test.ts
@@ -336,9 +336,46 @@ describe('saveSelectedPages', () => {
         const sendMessageSpy = vi.spyOn(chrome.runtime, 'sendMessage').mockResolvedValue({});
         await saveSelectedPages('path');
         expect(storageSetSpy).toHaveBeenCalledWith({
-            domainWhitelist: expect.arrayContaining(['^https://example\\.com/page$'])
+            domain_whitelist: expect.arrayContaining(['^https://example\\.com/page$'])
         });
         expect(sendMessageSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'record' }));
+    });
+
+    it('writes whitelist entries under domain_whitelist, never the orphan domainWhitelist key', async () => {
+        document.body.innerHTML += `
+            <input type="checkbox" class="pending-checkbox" value="https://example.com/page" checked>
+        `;
+        (getPendingPages as ReturnType<typeof vi.fn>).mockResolvedValue([
+            { url: 'https://example.com/page', title: 'Example Page', reason: 'test', headerValue: '' }
+        ]);
+        const getSpy = vi.spyOn(chrome.storage.local, 'get').mockResolvedValue({});
+        const setSpy = vi.spyOn(chrome.storage.local, 'set').mockResolvedValue(undefined);
+        vi.spyOn(chrome.runtime, 'sendMessage').mockResolvedValue({});
+
+        await saveSelectedPages('domain');
+
+        expect(getSpy).toHaveBeenCalledWith('domain_whitelist');
+        const setArg = setSpy.mock.calls[0][0] as Record<string, unknown>;
+        expect(setArg).toHaveProperty('domain_whitelist');
+        expect(setArg).not.toHaveProperty('domainWhitelist');
+        expect(setArg.domain_whitelist).toEqual(['example.com']);
+    });
+
+    it('appends to existing domain_whitelist values without overwriting', async () => {
+        document.body.innerHTML += `
+            <input type="checkbox" class="pending-checkbox" value="https://new.example.com/x" checked>
+        `;
+        (getPendingPages as ReturnType<typeof vi.fn>).mockResolvedValue([
+            { url: 'https://new.example.com/x', title: 'New', reason: 'test', headerValue: '' }
+        ]);
+        vi.spyOn(chrome.storage.local, 'get').mockResolvedValue({ domain_whitelist: ['old.example.com'] });
+        const setSpy = vi.spyOn(chrome.storage.local, 'set').mockResolvedValue(undefined);
+        vi.spyOn(chrome.runtime, 'sendMessage').mockResolvedValue({});
+
+        await saveSelectedPages('domain');
+
+        const setArg = setSpy.mock.calls[0][0] as { domain_whitelist: string[] };
+        expect(setArg.domain_whitelist).toEqual(['old.example.com', 'new.example.com']);
     });
 });
 

--- a/src/popup/pendingPages.ts
+++ b/src/popup/pendingPages.ts
@@ -3,6 +3,7 @@ import { logError, ErrorCode } from '../utils/logger.js';
 import { getMessage } from '../utils/i18n.js';
 import { showSuccess } from './errorUtils.js';
 import { escapeHtml } from './domUtils.js';
+import { StorageKeys } from '../utils/storage/types.js';
 
 export async function loadPendingPages(): Promise<void> {
   try {
@@ -58,7 +59,11 @@ function escapeRegex(string: string): string {
 }
 
 async function addDomainsOrPathsToWhitelist(urls: string[], type: 'domain' | 'path'): Promise<void> {
-  const { domainWhitelist = [] } = await chrome.storage.local.get('domainWhitelist') as { domainWhitelist?: string[] };
+  // Read/write the shared key every other consumer uses. Any data left under the
+  // legacy orphan key 'domainWhitelist' is discarded, not migrated: the user
+  // already perceives those adds as having done nothing.
+  const stored = await chrome.storage.local.get(StorageKeys.DOMAIN_WHITELIST) as { [key: string]: string[] | undefined };
+  const currentList = stored[StorageKeys.DOMAIN_WHITELIST] ?? [];
 
   const newEntries = urls.map(url => {
     if (type === 'domain') {
@@ -70,8 +75,8 @@ async function addDomainsOrPathsToWhitelist(urls: string[], type: 'domain' | 'pa
     }
   });
 
-  const updatedList = [...domainWhitelist, ...newEntries];
-  await chrome.storage.local.set({ domainWhitelist: updatedList });
+  const updatedList = [...currentList, ...newEntries];
+  await chrome.storage.local.set({ [StorageKeys.DOMAIN_WHITELIST]: updatedList });
 }
 
 export async function saveSelectedPages(whitelistType?: 'domain' | 'path'): Promise<void> {


### PR DESCRIPTION
## 機能バグ

`src/popup/pendingPages.ts` の `addDomainsOrPathsToWhitelist` が camelCase の `'domainWhitelist'` を `chrome.storage.local` に読み書きしていた。コードベースの他の全利用箇所は `StorageKeys.DOMAIN_WHITELIST`（`'domain_whitelist'`、snake_case）を参照する。結果、pending パネルの「ホワイトリストに追加」が**誰も読まないキーへ書き込み、機能が完全に無効化されていた**（実機で確認済み）。

VulnHunter 2026-08-29 監査の C14 に含まれていたが、実在のユーザー影響があるため単独 PBI（`2026-08-29-15`）に分離。

## 修正

- `StorageKeys.DOMAIN_WHITELIST` 経由で読み書き（literal `'domainWhitelist'` を廃止）
- 既存の `domain_whitelist` 値を読み取り、上書きせず追記
- 孤立キー `'domainWhitelist'` の既存データは移行せず破棄（利用者は追加が効いていない認識のため。コメントで明記）
- `src/popup/__tests__/main.test.ts` の期待値を snake_case に更新

## テスト（TDD）
- `pendingPages.test.ts` に回帰テスト2件追加: (a) `domain_whitelist` へ書き込み・孤立キーを作らない、(b) 既存値を保持して追記
- RED（camelCase 書き込み）→ GREEN 確認
- `npx vitest run src/popup/__tests__/` → 816 tests pass

## ゲート
- `tsc --noEmit`: クリーン
- lint: 増分ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)