### PR TITLE
feat(guard): LLMの縮退出力（繰り返し・非文）を検出して保存・表示を抑止する

### DIFF
--- a/src/background/__tests__/llmOutputGuardIntegration.test.ts
+++ b/src/background/__tests__/llmOutputGuardIntegration.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PrivacyPipeline, DEGENERATE_SUMMARY_FALLBACK } from '../privacyPipeline.js';
+import { StorageKeys } from '../../utils/storage.js';
+import { addLog } from '../../utils/logger.js';
+
+vi.mock('../../utils/logger.js', () => ({
+  addLog: vi.fn(),
+  LogType: { WARN: 'warn', ERROR: 'error', INFO: 'info', DEBUG: 'debug', SANITIZE: 'sanitize' },
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+vi.mock('../../utils/pendingStorage.js', () => ({
+  addPendingPage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../utils/promptSanitizer.js', () => ({
+  // Pass the summary through unchanged so the guard sees the real LLM text.
+  sanitizePromptContent: vi.fn((text: string) => ({
+    sanitized: text,
+    warnings: [],
+    dangerLevel: 'low',
+  })),
+  DangerLevel: { LOW: 'low', MEDIUM: 'medium', HIGH: 'high' },
+}));
+
+const mockSanitizers = {
+  sanitizeRegex: vi.fn().mockResolvedValue({ text: 'masked content', maskedItems: [] }),
+};
+
+function makeAi(summary: string) {
+  return {
+    getSupportedModes: vi.fn().mockReturnValue(['full_pipeline']),
+    generateSummary: vi.fn().mockResolvedValue({ summary, providerName: 'openai-compatible' }),
+  };
+}
+
+describe('LLM output guard — privacyPipeline integration', () => {
+  const settings = {
+    [StorageKeys.PRIVACY_MODE]: 'masked_cloud',
+    [StorageKeys.PII_SANITIZE_LOGS]: false,
+  };
+
+  beforeEach(() => {
+    vi.mocked(addLog).mockClear();
+  });
+
+  it('replaces a degenerate cloud summary with the Japanese fallback', async () => {
+    const degenerate = Array.from({ length: 200 }, () => '豚肉').join(' | ');
+    // @ts-expect-error partial AIService mock
+    const pipeline = new PrivacyPipeline(settings, makeAi(degenerate), mockSanitizers);
+
+    const result = await pipeline.process('content', {});
+
+    expect(result.summary).toBe(DEGENERATE_SUMMARY_FALLBACK);
+  });
+
+  it('logs a WARN with reason, repetitionRate and providerName on fallback', async () => {
+    const degenerate = Array.from({ length: 200 }, () => '豚肉').join(' | ');
+    // @ts-expect-error partial AIService mock
+    const pipeline = new PrivacyPipeline(settings, makeAi(degenerate), mockSanitizers);
+
+    await pipeline.process('content', {});
+
+    const warn = vi.mocked(addLog).mock.calls.find(
+      (c) => c[1] === 'Degenerate LLM output detected',
+    );
+    expect(warn).toBeDefined();
+    const ctx = warn?.[2] as { reason?: string; repetitionRate?: number; providerName?: string };
+    expect(ctx.reason).toBe('repetition');
+    expect(ctx.repetitionRate).toBeGreaterThan(0.3);
+    expect(ctx.providerName).toBe('openai-compatible');
+  });
+
+  it('lets a natural summary through untouched', async () => {
+    const natural =
+      '大戸屋の期間限定メニューは豚肉の生姜焼きが中心となっている。ご飯が進む甘辛い味付けで、多くの利用者から好評を得ている。数量限定のため早めの来店が推奨されている。';
+    // @ts-expect-error partial AIService mock
+    const pipeline = new PrivacyPipeline(settings, makeAi(natural), mockSanitizers);
+
+    const result = await pipeline.process('content', {});
+
+    expect(result.summary).toContain('大戸屋');
+    expect(result.summary).not.toBe(DEGENERATE_SUMMARY_FALLBACK);
+  });
+
+  it('does not flag a legit 5-tag tagSummaryMode output (guard runs on body only)', async () => {
+    const tagged =
+      '#フード・レシピ #ライフスタイル・雑記 #エンタメ・ゲーム #ビジネス・経済 #トラベル・アウトドア | 大戸屋の期間限定メニューを紹介する記事です。豚肉料理が中心となっています。';
+    // @ts-expect-error partial AIService mock
+    const pipeline = new PrivacyPipeline(settings, makeAi(tagged), mockSanitizers);
+
+    const result = await pipeline.process('content', { tagSummaryMode: true });
+
+    expect(result.summary).not.toBe(DEGENERATE_SUMMARY_FALLBACK);
+    expect(result.summary).toContain('大戸屋');
+    expect(result.tags).toEqual(
+      expect.arrayContaining(['フード・レシピ', 'エンタメ・ゲーム']),
+    );
+  });
+});
+
+describe('LLM output guard — BrowsingLogRecord is not polluted', () => {
+  const settings = {
+    [StorageKeys.PRIVACY_MODE]: 'masked_cloud',
+    [StorageKeys.PII_SANITIZE_LOGS]: false,
+  };
+
+  it('a degenerate AI result maps to a record carrying the fallback, not the spam', async () => {
+    const degenerate = Array.from({ length: 200 }, () => '豚肉').join(' | ');
+    // @ts-expect-error partial AIService mock
+    const pipeline = new PrivacyPipeline(settings, makeAi(degenerate), mockSanitizers);
+    const privacyResult = await pipeline.process('content', {});
+
+    const { mapToBrowsingLogRecord } = await import(
+      '../pipeline/mappers/BrowsingLogRecordMapper.js'
+    );
+    const record = mapToBrowsingLogRecord({
+      data: { url: 'https://example.com', title: 't', content: 'c' },
+      privacyResult,
+      settings: {},
+    } as never);
+
+    expect(record.summary).toBe(DEGENERATE_SUMMARY_FALLBACK);
+    expect(record.summary).not.toContain('豚肉 | 豚肉');
+  });
+});

--- a/src/background/privacyPipeline.ts
+++ b/src/background/privacyPipeline.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SETTINGS } from '../utils/storage/defaults.js';
 import { parseTagsFromSummary, normalizeTags } from '../utils/tagUtils.js';
 import type { TagNormalizationEntry } from '../utils/types.js';
 import { sanitizePromptContent, DangerLevel } from '../utils/promptSanitizer.js';
+import { isDegenerateOutput } from '../utils/llmOutputGuard.js';
 import { addPendingPage } from '../utils/pendingStorage.js';
 import type { AIService, AISummaryResult } from './ai/AIService.js';
 import type { MaskedItem } from '../messaging/types.js';
@@ -32,6 +33,9 @@ function estimateTokens(text: string): number {
   // English: ~4 characters per token
   return Math.ceil(text.length / 4);
 }
+
+/** Substituted for a summary the guard flags as degenerate (repetition loop, keyword spam). */
+export const DEGENERATE_SUMMARY_FALLBACK = '要約に失敗しました（AI出力が不自然なため）';
 
 interface ISanitizers {
   sanitizeRegex(text: string): Promise<{ text: string; maskedItems: MaskedItem[] }>;
@@ -277,6 +281,20 @@ export class PrivacyPipeline {
       tags = normalizedTags.length > 0 ? normalizedTags : undefined;
       sanitizedSummary = parsed.summary;
       sanitizedSummary = sanitizedSummary.replace(/\n+/g, ' ').replace(/  +/g, ' ').trim();
+
+      // Single guard choke point for all cloud/Ollama/LM Studio provider paths.
+      // Runs on the summary body only, after parseTagsFromSummary has split off
+      // tags, so a legitimate `tag1 | tag2 | tag3` output is not misread as
+      // degenerate keyword spam.
+      const guard = isDegenerateOutput(sanitizedSummary);
+      if (guard.isDegenerate) {
+        addLog(LogType.WARN, 'Degenerate LLM output detected', {
+          reason: guard.reason,
+          repetitionRate: guard.metrics?.repetitionRate,
+          providerName: aiResult.providerName,
+        });
+        sanitizedSummary = DEGENERATE_SUMMARY_FALLBACK;
+      }
     }
 
     return {

--- a/src/dashboard/__tests__/historyEntryRow.test.ts
+++ b/src/dashboard/__tests__/historyEntryRow.test.ts
@@ -206,6 +206,26 @@ describe('AI Summary', () => {
     );
     expect(row.querySelector('.history-entry-ai-summary')).toBeNull();
   });
+
+  it('masks a stored degenerate summary with the fallback at display time', () => {
+    const degenerate = Array.from({ length: 200 }, () => '豚肉').join(' | ');
+    const row = makeHistoryEntryRow(
+      createMinimalEntry({ aiSummary: degenerate }), 0, 0, createMockState(), createMockElements(), vi.fn(), vi.fn(),
+    );
+    const el = row.querySelector('.history-entry-ai-summary');
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toContain('要約に失敗しました（AI出力が不自然なため）');
+    expect(el?.textContent).not.toContain('豚肉 | 豚肉');
+  });
+
+  it('renders a natural stored summary unchanged', () => {
+    const natural = '大戸屋の期間限定メニューは豚肉の生姜焼きが中心です。ご飯が進む味付けで好評を得ています。';
+    const row = makeHistoryEntryRow(
+      createMinimalEntry({ aiSummary: natural }), 0, 0, createMockState(), createMockElements(), vi.fn(), vi.fn(),
+    );
+    const el = row.querySelector('.history-entry-ai-summary');
+    expect(el?.textContent).toContain('大戸屋');
+  });
 });
 
 describe('Token Display', () => {

--- a/src/dashboard/historyEntryRow.ts
+++ b/src/dashboard/historyEntryRow.ts
@@ -6,6 +6,10 @@ import { makeCleansingProgressBar } from './cleansingStatsView.js';
 import { makeRecordTypeBadge, makeMaskBadge, makeCleansedBadge, makePrivacyModeBadge } from './historyBadges.js';
 import { openTagEditModal } from './historyTagEditModal.js';
 import { getCachedMessage } from './historyState.js';
+import { isDegenerateOutput } from '../utils/llmOutputGuard.js';
+
+/** Shown in place of a stored summary that the guard flags as degenerate. */
+const DEGENERATE_SUMMARY_FALLBACK = '要約に失敗しました（AI出力が不自然なため）';
 import type { HistoryPanelState, TagEditElements } from './historyState.js';
 
 const _cleanseReasonLabels: Record<string, string> = {
@@ -136,7 +140,11 @@ export function makeHistoryEntryRow(
     const aiSummaryEl = document.createElement('div');
     aiSummaryEl.className = 'history-entry-ai-summary';
     const aiSummaryLabel = getMessage('historyAiSummary') || 'AI要約';
-    aiSummaryEl.textContent = `${aiSummaryLabel}: ${aiSummary}`;
+    // Display-time masking for summaries stored before the guard existed.
+    const displaySummary = isDegenerateOutput(aiSummary).isDegenerate
+      ? DEGENERATE_SUMMARY_FALLBACK
+      : aiSummary;
+    aiSummaryEl.textContent = `${aiSummaryLabel}: ${displaySummary}`;
     info.appendChild(aiSummaryEl);
   }
 

--- a/src/utils/__tests__/llmOutputGuard.test.ts
+++ b/src/utils/__tests__/llmOutputGuard.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { isDegenerateOutput } from '../llmOutputGuard.js';
+
+describe('isDegenerateOutput', () => {
+  it('detects the real "豚肉 | 豚肉 ..." x200 degenerate example as repetition', () => {
+    const summary = Array.from({ length: 200 }, () => '豚肉').join(' | ');
+    const result = isDegenerateOutput(summary);
+    expect(result.isDegenerate).toBe(true);
+    expect(result.reason).toBe('repetition');
+  });
+
+  it('passes a natural 3-sentence Japanese summary', () => {
+    const summary =
+      '大戸屋の期間限定メニューは、豚肉の生姜焼きが中心となっている。ご飯が進む甘辛い味付けで、多くの利用者から好評を得ている。数量限定のため、早めの来店が推奨されている。';
+    const result = isDegenerateOutput(summary);
+    expect(result.isDegenerate).toBe(false);
+  });
+
+  it('detects English "apple | apple ..." x100 as degenerate', () => {
+    const summary = Array.from({ length: 100 }, () => 'apple').join(' | ');
+    const result = isDegenerateOutput(summary);
+    expect(result.isDegenerate).toBe(true);
+  });
+
+  it('does not flag a short response like "了解。" (too short to judge)', () => {
+    const result = isDegenerateOutput('了解。');
+    expect(result.isDegenerate).toBe(false);
+  });
+
+  it('boundary: repetition rate 29% is not degenerate', () => {
+    // 29 copies of "foo" + 71 distinct filler tokens => most-frequent rate 0.29
+    const tokens = [
+      ...Array.from({ length: 29 }, () => 'foo'),
+      ...Array.from({ length: 71 }, (_v, i) => `w${i}word`),
+    ];
+    const result = isDegenerateOutput(tokens.join(' '));
+    expect(result.isDegenerate).toBe(false);
+  });
+
+  it('boundary: repetition rate 31% is degenerate', () => {
+    const tokens = [
+      ...Array.from({ length: 31 }, () => 'foo'),
+      ...Array.from({ length: 69 }, (_v, i) => `w${i}word`),
+    ];
+    const result = isDegenerateOutput(tokens.join(' '));
+    expect(result.isDegenerate).toBe(true);
+    expect(result.reason).toBe('repetition');
+  });
+
+  it('boundary: unique rate 9% is degenerate (lowDiversity)', () => {
+    // 9 unique short tokens spread over 100 total, each below the repetition
+    // threshold; chars-per-unique-token kept under the compressibility bound.
+    const alpha = 'abcdefghi'.split('');
+    const tokens: string[] = [];
+    for (let i = 0; i < 100; i++) tokens.push(alpha[i % 9] as string);
+    const result = isDegenerateOutput(tokens.join(' '));
+    expect(result.isDegenerate).toBe(true);
+    expect(['lowDiversity', 'repetition', 'highlyCompressible']).toContain(result.reason);
+  });
+
+  it('boundary: unique rate 11% is not degenerate', () => {
+    // 11 unique short tokens over 100 total; max frequency under 0.3 and
+    // chars-per-unique-token under the compressibility bound.
+    const alpha = 'abcdefghijk'.split('');
+    const tokens: string[] = [];
+    for (let i = 0; i < 100; i++) tokens.push(alpha[i % 11] as string);
+    const result = isDegenerateOutput(tokens.join(' '));
+    expect(result.isDegenerate).toBe(false);
+  });
+
+  it('does not flag a natural sentence that has a predicate but no period', () => {
+    const summary =
+      'この記事では新しい料理の作り方をわかりやすく説明しています。家庭でも簡単に再現できると書かれています';
+    const result = isDegenerateOutput(summary);
+    expect(result.isDegenerate).toBe(false);
+  });
+
+  it('treats empty / null / undefined as not degenerate', () => {
+    expect(isDegenerateOutput('').isDegenerate).toBe(false);
+    // @ts-expect-error testing null input
+    expect(isDegenerateOutput(null).isDegenerate).toBe(false);
+    // @ts-expect-error testing undefined input
+    expect(isDegenerateOutput(undefined).isDegenerate).toBe(false);
+  });
+
+  it('does not flag a legit 5-tag tagSummaryMode body once tags are separated', () => {
+    // Guard operates on the summary body only; a short factual body is fine.
+    const body = 'この記事は5つのタグで分類されており、内容は料理レシピの紹介です。';
+    const result = isDegenerateOutput(body);
+    expect(result.isDegenerate).toBe(false);
+  });
+});

--- a/src/utils/llmOutputGuard.ts
+++ b/src/utils/llmOutputGuard.ts
@@ -1,0 +1,110 @@
+/**
+ * llmOutputGuard.ts
+ * Pure guard that detects degenerate LLM summaries (token-repetition loops,
+ * delimiter-joined keyword spam, non-sentence output) before they are saved
+ * to the browsing log or rendered in the dashboard.
+ *
+ * Layer: utils. No dependencies on other project modules — safe to import from
+ * background pipeline and dashboard without creating import cycles.
+ */
+
+/** Below this trimmed length the text is too short to judge reliably. */
+const MIN_JUDGEABLE_LENGTH = 20;
+
+/** Splits on whitespace plus the delimiters LLMs use for keyword spam. */
+const TOKEN_SPLIT_PATTERN = /[\s|、,]+/;
+
+/** Most-frequent-token rate above this => repetition loop. */
+const MAX_REPETITION_RATE = 0.3;
+
+/** unique tokens / total tokens below this => degenerate keyword spam. */
+const MIN_UNIQUE_RATE = 0.1;
+
+/**
+ * Compressibility proxy without adding a compression dependency:
+ * chars per distinct token. A real summary carries many distinct tokens, so
+ * this stays low; a repeated single token pushes it very high.
+ */
+const MAX_CHARS_PER_UNIQUE_TOKEN = 50;
+
+/**
+ * Rate-based checks need enough tokens to be meaningful. Japanese prose without
+ * ASCII whitespace tokenizes into very few large tokens, where a rate like
+ * "most-frequent / total" is trivially high and would false-positive on
+ * legitimate text. The degenerate cases this guard targets are long keyword
+ * spam with hundreds of tokens.
+ */
+const MIN_TOKENS_FOR_RATE_CHECKS = 10;
+
+/** Japanese predicate / sentence-ending markers used as a supplementary signal. */
+const PREDICATE_PATTERN = /です|ます|だ|である|した/;
+
+export interface DegenerateOutputResult {
+  isDegenerate: boolean;
+  reason?: string;
+  metrics?: {
+    repetitionRate: number;
+    uniqueRate: number;
+  };
+}
+
+function tokenize(summary: string): string[] {
+  return summary.split(TOKEN_SPLIT_PATTERN).filter(Boolean);
+}
+
+function mostFrequentTokenRate(tokens: string[]): number {
+  const counts = new Map<string, number>();
+  let max = 0;
+  for (const token of tokens) {
+    const next = (counts.get(token) ?? 0) + 1;
+    counts.set(token, next);
+    if (next > max) max = next;
+  }
+  return tokens.length === 0 ? 0 : max / tokens.length;
+}
+
+function isNotSentence(summary: string): boolean {
+  return !summary.includes('。') && !PREDICATE_PATTERN.test(summary);
+}
+
+/**
+ * Detects degenerate LLM output. Pure function.
+ * Empty / null / undefined and too-short inputs are reported as not degenerate;
+ * callers handle those cases separately.
+ */
+export function isDegenerateOutput(summary: string): DegenerateOutputResult {
+  if (!summary || summary.trim().length < MIN_JUDGEABLE_LENGTH) {
+    return { isDegenerate: false };
+  }
+
+  const tokens = tokenize(summary);
+  if (tokens.length === 0) {
+    return { isDegenerate: false };
+  }
+
+  const uniqueCount = new Set(tokens).size;
+  const repetitionRate = mostFrequentTokenRate(tokens);
+  const uniqueRate = uniqueCount / tokens.length;
+  const charsPerUniqueToken = summary.length / uniqueCount;
+  const metrics = { repetitionRate, uniqueRate };
+
+  if (tokens.length >= MIN_TOKENS_FOR_RATE_CHECKS) {
+    if (repetitionRate > MAX_REPETITION_RATE) {
+      return { isDegenerate: true, reason: 'repetition', metrics };
+    }
+    if (uniqueRate < MIN_UNIQUE_RATE) {
+      return { isDegenerate: true, reason: 'lowDiversity', metrics };
+    }
+    if (charsPerUniqueToken > MAX_CHARS_PER_UNIQUE_TOKEN) {
+      return { isDegenerate: true, reason: 'highlyCompressible', metrics };
+    }
+  }
+
+  // Supplementary signal only: never degenerate on its own. Reported so callers
+  // and logs can see it, but isDegenerate stays false.
+  if (isNotSentence(summary)) {
+    return { isDegenerate: false, reason: 'notSentence', metrics };
+  }
+
+  return { isDegenerate: false, metrics };
+}


### PR DESCRIPTION
## 背景

`ollama/gemma3:1b` 等の小モデルがクレンジング後の短い入力に対し、`料理 | 豚肉 | 豚しんこ | ... | 豚肉 | 豚肉 |` のような同一トークンの大量繰り返し（200回超、非文）を出力した。これがそのまま履歴DB・Obsidianノートに保存・表示され、後続の検索・振り返りのノイズになる。

## 実装

### `src/utils/llmOutputGuard.ts`（新規・依存なし・純粋関数）
`isDegenerateOutput(summary)` が以下のいずれかで縮退と判定:
- 最頻出トークン率 > 0.3 → `repetition`
- ユニーク率 < 0.1 → `lowDiversity`
- `length / uniqueTokens > 50` → `highlyCompressible`
- `notSentence`（句点・述語なし）は補助シグナルのみ（単独では縮退としない）
- `trim().length < 20` / 空 / null / undefined → 判定対象外
- レート系チェックはトークン数10以上のときのみ（日本語散文の誤検出回避）
- 閾値はすべて名前付き定数

### 組込み（単一チェックポイント）
`src/background/privacyPipeline.ts` の `_processCloudResult`、`parseTagsFromSummary` によるタグ分離後の1箇所のみ。cloud/Ollama/LM Studio の全プロバイダ経路をカバー。`tagSummaryMode` の `#tag1 #tag2` は分離後の本文のみ判定するため誤検出しない。

縮退時: `sanitizedSummary` を `要約に失敗しました（AI出力が不自然なため）` に置換 + `addLog(WARN, 'Degenerate LLM output detected', {reason, repetitionRate, providerName})`。

### `src/dashboard/historyEntryRow.ts`
保存済みの縮退データは表示時にフォールバックへマスク（DBマイグレーションなし）。

## テスト（TDD）
- `llmOutputGuard.test.ts`（11）: 豚肉×200 → true、自然な3文 → false、英語 apple×100 → true、`了解。` → false、境界値
- `llmOutputGuardIntegration.test.ts`（5）: privacyPipeline でフォールバック置換、BrowsingLogRecord 非汚染、5タグ出力を誤検出しない
- `historyEntryRow.test.ts`（2）: マスク

再試行は本PRのスコープ外。

## ゲート
- `tsc --noEmit`: クリーン
- `npm test`: 10606 passing / 0 failures
- lint: 増分ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)