### PR TITLE
fix(offscreen): storageFallback の全ミューテータを mutate ヘルパーで直列化（VULN-022）

### DIFF
--- a/src/offscreen/__tests__/storageFallbackMutate.test.ts
+++ b/src/offscreen/__tests__/storageFallbackMutate.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { FallbackStorage } from '../storageFallback.js';
+import type { BrowsingLogRecord } from '../../utils/sqlite-types.js';
+
+/**
+ * These tests prove that all fallback mutators share a single serialization
+ * discipline (the `mutate` helper on `this.mutex`). Without it, a concurrent
+ * `purgeOldRecords` and `toggleStar` do lock-free load -> mutate -> save and
+ * one clobbers the other (VULN-022 / CWE-362).
+ *
+ * The interleave is made deterministic by stalling the FIRST few reads of the
+ * records blob and returning a deep clone (real chrome.storage hands each
+ * caller its own copy, unlike the shared-reference in-memory mock). When the
+ * mutators are NOT serialized both read the same pre-mutation snapshot during
+ * the stall and the later save wins, dropping the other mutation. When they
+ * ARE serialized the second mutator only reads after the first has fully saved.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const STORAGE_KEY = 'FALLBACK_STORAGE_DATA';
+
+function record(overrides: Partial<BrowsingLogRecord>): BrowsingLogRecord {
+  return {
+    url: 'https://example.com/',
+    created_at: Date.now(),
+    is_starred: 0,
+    is_deleted: 0,
+    ...overrides,
+  } as BrowsingLogRecord;
+}
+
+/**
+ * Stall the first `times` reads of the records blob by a few ms so two
+ * overlapping mutators have a window to interleave. Uses the real (unspied)
+ * mock implementation captured before installing the wrapper.
+ */
+function stallRecordReads(times: number): () => void {
+  const original = chrome.storage.local.get as unknown as (
+    keys?: string | string[] | null,
+  ) => Promise<Record<string, unknown>>;
+  let remaining = times;
+  chrome.storage.local.get = (async (keys?: string | string[] | null) => {
+    const result = await original(keys);
+    if (remaining > 0 && keys === STORAGE_KEY) {
+      remaining--;
+      await new Promise(resolve => setTimeout(resolve, 5));
+    }
+    // Real chrome.storage returns a fresh copy per read; the in-memory mock
+    // shares a reference, which would hide the RMW race.
+    return structuredClone(result);
+  }) as typeof chrome.storage.local.get;
+  return () => {
+    chrome.storage.local.get = original as typeof chrome.storage.local.get;
+  };
+}
+
+describe('FallbackStorage.mutate serialization', () => {
+  let storage: FallbackStorage;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    storage = new FallbackStorage();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves purge when toggleStar runs concurrently', async () => {
+    const old = Date.now() - 200 * DAY_MS;
+    await storage.insertBatch([
+      record({ url: 'https://a/', created_at: old }),
+      record({ url: 'https://b/', created_at: Date.now() }),
+    ]);
+
+    const restore = stallRecordReads(2);
+    try {
+      await Promise.all([storage.purgeOldRecords(90), storage.toggleStar(2)]);
+    } finally {
+      restore();
+    }
+
+    const all = await storage.getAllRecords();
+    // purge must have removed the stale record #1 ...
+    expect(all.map(r => r.url)).toEqual(['https://b/']);
+    // ... and the star toggle on #2 must also be persisted.
+    expect(all[0]!.is_starred).toBe(1);
+  });
+
+  it('preserves both update and hardDelete when they overlap', async () => {
+    await storage.insertBatch([
+      record({ url: 'https://keep/', created_at: 1000 }),
+      record({ url: 'https://drop/', created_at: 2000 }),
+    ]);
+
+    const restore = stallRecordReads(2);
+    try {
+      await Promise.all([
+        storage.update(1, { title: 'updated' }),
+        storage.hardDelete(2),
+      ]);
+    } finally {
+      restore();
+    }
+
+    const all = await storage.getAllRecords();
+    expect(all.map(r => r.url)).toEqual(['https://keep/']);
+    expect(all[0]!.title).toBe('updated');
+  });
+
+  describe('boundaries', () => {
+    it('empty store: purge and clearAll are no-ops without throwing', async () => {
+      await expect(storage.purgeOldRecords(1)).resolves.toEqual({ success: true, purged: 0 });
+      await expect(storage.clearAll()).resolves.toEqual({ success: true });
+      expect(await storage.getAllRecords()).toEqual([]);
+    });
+
+    it('single record: toggleStar then hardDelete leaves an empty store', async () => {
+      await storage.insert(record({ url: 'https://only/', created_at: 1 }));
+      await storage.toggleStar(1);
+      await storage.hardDelete(1);
+      expect(await storage.getAllRecords()).toEqual([]);
+    });
+
+    it('batch boundary: dedupe-check then id allocation ordering is preserved', async () => {
+      const r1 = await storage.insert(record({ url: 'https://x/', created_at: 1 }));
+      expect(r1).toEqual({ success: true, id: 1 });
+      const batch = await storage.insertBatch([
+        record({ url: 'https://x/', created_at: 1 }),
+        record({ url: 'https://y/', created_at: 2 }),
+      ]);
+      expect(batch).toEqual({ success: true, count: 1 });
+      const all = await storage.getAllRecords();
+      expect(all.find(r => r.url === 'https://y/')!.id).toBe(2);
+    });
+  });
+
+  describe('exception handling', () => {
+    it('releases the lock and leaves data unchanged when saveData fails', async () => {
+      await storage.insert(record({ url: 'https://safe/', created_at: 1 }));
+      const before = await storage.getAllRecords();
+
+      vi.spyOn(chrome.storage.local, 'set').mockRejectedValueOnce(new Error('disk full'));
+      const res = await storage.toggleStar(1);
+      expect(res.success).toBe(false);
+
+      const after = await storage.getAllRecords();
+      expect(after).toEqual(before);
+
+      // lock released: a subsequent mutator still completes
+      const ok = await storage.update(1, { title: 't' });
+      expect(ok).toEqual({ success: true });
+      expect((await storage.getAllRecords())[0]!.title).toBe('t');
+    });
+
+    it('propagates a pure-fn throw as a failed result with the lock released', async () => {
+      await storage.insert(record({ url: 'https://z/', created_at: 1 }));
+      // UPDATABLE_FIELDS iteration is safe; force a throw via a getter trap on changes
+      const hostile = new Proxy(
+        {},
+        {
+          has() {
+            throw new Error('boom');
+          },
+        },
+      ) as Partial<BrowsingLogRecord>;
+      const res = await storage.update(1, hostile);
+      expect(res).toEqual({ success: false, error: 'Error: boom' });
+
+      const ok = await storage.hardDelete(1);
+      expect(ok).toEqual({ success: true });
+    });
+  });
+});

--- a/src/offscreen/storageFallback.ts
+++ b/src/offscreen/storageFallback.ts
@@ -33,6 +33,37 @@ export class FallbackStorage {
     await chrome.storage.local.set({ [STORAGE_KEY]: data });
   }
 
+  /**
+   * Serialized read-modify-write helper.
+   *
+   * Acquires `this.mutex`, loads the current data, applies the pure transform
+   * `fn`, persists the returned `next` state, and releases the lock in a
+   * `finally` block. This is the single locking discipline every mutator must
+   * use so that concurrent mutations (e.g. purgeOldRecords vs toggleStar)
+   * cannot clobber each other's blob writes.
+   *
+   * Contract for `fn`:
+   * - MUST be a pure transform: derive `next` from the given `data` and return
+   *   it together with the caller's `result` value. Do not perform storage I/O.
+   * - MUST NOT call `mutate` (directly or transitively) — the mutex is not
+   *   reentrant and doing so deadlocks.
+   *
+   * If `saveData` throws, the exception propagates to the caller and the lock
+   * is still released by `finally`. The persisted state is left untouched
+   * (the failed write never landed), so no half-written blob results.
+   */
+  private async mutate<T>(fn: (data: StoredData) => { next: StoredData; result: T }): Promise<T> {
+    await this.mutex.acquire();
+    try {
+      const data = await this.loadData();
+      const { next, result } = fn(data);
+      await this.saveData(next);
+      return result;
+    } finally {
+      this.mutex.release();
+    }
+  }
+
   private async getNextId(): Promise<number> {
     return this.allocateIds(1);
   }
@@ -61,6 +92,13 @@ export class FallbackStorage {
     await this.saveData(data);
   }
 
+  // insert / insertBatch keep bespoke locking rather than routing through
+  // `mutate`, but on the SAME `this.mutex`, so they still serialize against
+  // every other mutator. They cannot use `mutate`'s pure-fn contract because
+  // the "dedupe-check THEN allocate IDs" ordering (PBI 2026-08-27-06) requires
+  // side-effecting storage I/O in the middle of the RMW: `ensureQuotaSpace`
+  // and `allocateIds` both touch chrome.storage and must run after the dedupe
+  // check but before the records are appended.
   async insert(record: BrowsingLogRecord): Promise<{ success: true; id: number } | { success: false; error: string }> {
     await this.mutex.acquire();
     try {
@@ -277,20 +315,18 @@ export class FallbackStorage {
 
   async update(id: number, changes: Partial<BrowsingLogRecord>): Promise<{ success: true } | { success: false; error: string }> {
     try {
-      const data = await this.loadData();
-      const record = data.records.find(r => r.id === id);
-      if (!record) {
-        return { success: true };
-      }
-
-      for (const field of UPDATABLE_FIELDS) {
-        const f = field as keyof BrowsingLogRecord;
-        if (f in changes) {
-          Object.assign(record, { [f]: changes[f] });
+      await this.mutate<void>(data => {
+        const record = data.records.find(r => r.id === id);
+        if (record) {
+          for (const field of UPDATABLE_FIELDS) {
+            const f = field as keyof BrowsingLogRecord;
+            if (f in changes) {
+              Object.assign(record, { [f]: changes[f] });
+            }
+          }
         }
-      }
-
-      await this.saveData(data);
+        return { next: data, result: undefined };
+      });
       return { success: true };
     } catch (error) {
       return { success: false, error: String(error) };
@@ -299,9 +335,10 @@ export class FallbackStorage {
 
   async hardDelete(id: number): Promise<{ success: true } | { success: false; error: string }> {
     try {
-      const data = await this.loadData();
-      data.records = data.records.filter(r => r.id !== id);
-      await this.saveData(data);
+      await this.mutate<void>(data => {
+        data.records = data.records.filter(r => r.id !== id);
+        return { next: data, result: undefined };
+      });
       return { success: true };
     } catch (error) {
       return { success: false, error: String(error) };
@@ -310,15 +347,18 @@ export class FallbackStorage {
 
   async toggleStar(id: number): Promise<{ success: true; is_starred: number } | { success: false; error: string }> {
     try {
-      const data = await this.loadData();
-      const record = data.records.find(r => r.id === id);
-      if (!record) {
+      const nextStarred = await this.mutate<number | null>(data => {
+        const record = data.records.find(r => r.id === id);
+        if (!record) {
+          return { next: data, result: null };
+        }
+        record.is_starred = record.is_starred === 0 ? 1 : 0;
+        return { next: data, result: record.is_starred };
+      });
+      if (nextStarred === null) {
         return { success: false, error: 'Record not found' };
       }
-
-      record.is_starred = record.is_starred === 0 ? 1 : 0;
-      await this.saveData(data);
-      return { success: true, is_starred: record.is_starred };
+      return { success: true, is_starred: nextStarred };
     } catch (error) {
       return { success: false, error: String(error) };
     }
@@ -336,7 +376,7 @@ export class FallbackStorage {
 
   async clearAll(): Promise<{ success: boolean; error?: string }> {
     try {
-      await this.saveData({ records: [] });
+      await this.mutate<void>(() => ({ next: { records: [] }, result: undefined }));
       await chrome.storage.local.set({ [STORAGE_KEY_COUNTER]: 0 });
       return { success: true };
     } catch (error) {
@@ -346,34 +386,34 @@ export class FallbackStorage {
 
   async purgeOldRecords(retentionDays: number = 90, maxRecords: number = 1000): Promise<{ success: true; purged: number } | { success: false; error: string }> {
     try {
-      const data = await this.loadData();
-      const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
-      let purged = 0;
+      const purged = await this.mutate<number>(data => {
+        const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+        let count = 0;
 
-      const _before = data.records.length;
-      data.records = data.records.filter(r => {
-        if (r.is_starred === 1 || r.is_deleted === 1) return true;
-        if (r.created_at < cutoffMs) {
-          purged++;
-          return false;
-        }
-        return true;
-      });
-
-      const activeRecords = data.records.filter(r => r.is_deleted === 0);
-      if (activeRecords.length > maxRecords) {
-        const sorted = [...activeRecords].sort((a, b) => a.created_at - b.created_at);
-        const toRemove = new Set(sorted.slice(0, activeRecords.length - maxRecords).map(r => r.id));
         data.records = data.records.filter(r => {
-          if (toRemove.has(r.id)) {
-            purged++;
+          if (r.is_starred === 1 || r.is_deleted === 1) return true;
+          if (r.created_at < cutoffMs) {
+            count++;
             return false;
           }
           return true;
         });
-      }
 
-      await this.saveData(data);
+        const activeRecords = data.records.filter(r => r.is_deleted === 0);
+        if (activeRecords.length > maxRecords) {
+          const sorted = [...activeRecords].sort((a, b) => a.created_at - b.created_at);
+          const toRemove = new Set(sorted.slice(0, activeRecords.length - maxRecords).map(r => r.id));
+          data.records = data.records.filter(r => {
+            if (toRemove.has(r.id)) {
+              count++;
+              return false;
+            }
+            return true;
+          });
+        }
+
+        return { next: data, result: count };
+      });
       return { success: true, purged };
     } catch (error) {
       return { success: false, error: String(error) };
@@ -386,45 +426,46 @@ export class FallbackStorage {
     includeStarred?: boolean,
   ): Promise<{ success: true; purged: number } | { success: false; error: string }> {
     try {
-      const data = await this.loadData();
-      const includeAll = includeStarred === true;
-      let totalPurged = 0;
+      const totalPurged = await this.mutate<number>(data => {
+        const includeAll = includeStarred === true;
+        let count = 0;
 
-      // Filter: records with non-null content
-      let candidates = data.records.filter(r => r.content != null && r.content !== undefined);
-      if (!includeAll) {
-        candidates = candidates.filter(r => r.is_starred !== 1);
-      }
-
-      // 1. Days-based
-      if (retentionDays != null && retentionDays > 0) {
-        const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
-        const toPurge = candidates.filter(r => r.created_at < cutoffMs);
-        for (const r of toPurge) {
-          r.content = null;
-        }
-        totalPurged += toPurge.length;
-      }
-
-      // 2. Count-based
-      if (maxRecords != null && maxRecords > 0) {
-        let remaining = data.records.filter(r => r.content != null);
+        // Filter: records with non-null content
+        let candidates = data.records.filter(r => r.content != null && r.content !== undefined);
         if (!includeAll) {
-          remaining = remaining.filter(r => r.is_starred !== 1);
+          candidates = candidates.filter(r => r.is_starred !== 1);
         }
-        if (remaining.length > maxRecords) {
-          const excess = remaining.length - maxRecords;
-          const sorted = [...remaining].sort((a, b) => a.created_at - b.created_at);
-          const toPurge = sorted.slice(0, excess);
-          for (const r of toPurge) {
-            const record = data.records.find(rec => rec.id === r.id);
-            if (record) record.content = null;
-          }
-          totalPurged += toPurge.length;
-        }
-      }
 
-      await this.saveData(data);
+        // 1. Days-based
+        if (retentionDays != null && retentionDays > 0) {
+          const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+          const toPurge = candidates.filter(r => r.created_at < cutoffMs);
+          for (const r of toPurge) {
+            r.content = null;
+          }
+          count += toPurge.length;
+        }
+
+        // 2. Count-based
+        if (maxRecords != null && maxRecords > 0) {
+          let remaining = data.records.filter(r => r.content != null);
+          if (!includeAll) {
+            remaining = remaining.filter(r => r.is_starred !== 1);
+          }
+          if (remaining.length > maxRecords) {
+            const excess = remaining.length - maxRecords;
+            const sorted = [...remaining].sort((a, b) => a.created_at - b.created_at);
+            const toPurge = sorted.slice(0, excess);
+            for (const r of toPurge) {
+              const record = data.records.find(rec => rec.id === r.id);
+              if (record) record.content = null;
+            }
+            count += toPurge.length;
+          }
+        }
+
+        return { next: data, result: count };
+      });
       return { success: true, purged: totalPurged };
     } catch (error) {
       return { success: false, error: String(error) };


### PR DESCRIPTION
## 脆弱性

`src/offscreen/storageFallback.ts`（OPFS 非対応環境のフォールバック SQLite エンジン）は 8 ミューテータのうち 6 個がロックなしで `load → mutate → save` の RMW を行う。`purgeOldRecords` と `toggleStar` が並行すると片方が全 blob 書き込みで他方を取り消す（削除→復活。VULN-022, CWE-362）。

## 修正

`private async mutate<T>(fn: (data: StoredData) => { next: StoredData; result: T }): Promise<T>` を新設:
`this.mutex.acquire()` → `loadData()` → `fn` 適用 → `saveData(next)` → `finally` で `release()`。

- `update` / `hardDelete` / `toggleStar` / `clearAll` / `purgeOldRecords` / `purgeContent` の 6 メソッドを経由化
- `insert` / `insertBatch` は「重複チェック→ID 確保」順序（`ensureQuotaSpace`/`allocateIds` が I/O 副作用）が純粋 fn 契約に載らないため、**同一 `this.mutex`** を使う bespoke 実装を維持（コメントで理由明記）。他 6 ミューテータと同じ mutex で直列化される
- `fn` の再帰 `mutate` 呼び出し禁止を契約コメントで明記。`saveData` 失敗時は例外伝播 + `finally` でロック解放、失敗した書き込みは永続化されず原状維持

## テスト（TDD）
- 新規 `storageFallbackMutate.test.ts`（7件）: `purgeOldRecords × toggleStar` / `update × hardDelete` の決定的インターリーブ（`chrome.storage.local.get` を stall + `structuredClone` で per-read コピー挙動を再現）。RED（直列化なしで purge/delete 消失）→ GREEN。境界（空/単一/バッチ）、例外（`saveData` 失敗・`fn` throw でのロック解放）

## ゲート
- `tsc --noEmit`: クリーン
- `npm test`: 10595 passing / 0 failures
- lint: 増分ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)