### PR TITLE
fix(storage): リトライキューと通知ハンドラの並行 RMW を直列化（VULN-056/009 部分）

### DIFF
--- a/src/background/__tests__/persistentRetryQueueInterleave.test.ts
+++ b/src/background/__tests__/persistentRetryQueueInterleave.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PersistentRetryQueue, type RetryableItem } from '../persistentRetryQueue.js';
+import type { QueueStorageAdapter } from '../queueStorageAdapter.js';
+
+interface TestItem extends RetryableItem {
+  id: string;
+}
+function makeItem(id: string): TestItem {
+  return { id, createdAt: Date.now(), retryCount: 0 };
+}
+
+/**
+ * VULN-056 interleave reproduction. A job is enqueued while flush() is mid-cycle.
+ * Without the queue lock, enqueue reads the pre-flush snapshot and its save
+ * clobbers flush's write, losing the new job (['A','B'] -> ['A']).
+ */
+function gatedAdapter(): QueueStorageAdapter & { store: Record<string, unknown[]>; releaseLoad: () => void } {
+  const store: Record<string, unknown[]> = {};
+  let gate: Promise<void> | null = null;
+  let release: (() => void) | null = null;
+  return {
+    store,
+    releaseLoad: () => release?.(),
+    load: vi.fn(async (key: string) => {
+      if (!gate) {
+        gate = new Promise<void>((r) => { release = r; });
+        await gate;
+      }
+      return (store[key] ?? []) as unknown[];
+    }),
+    save: vi.fn(async (key: string, items: unknown[]) => { store[key] = items; }),
+  };
+}
+
+describe('PersistentRetryQueue concurrent enqueue during flush (VULN-056)', () => {
+  let adapter: ReturnType<typeof gatedAdapter>;
+
+  beforeEach(() => {
+    adapter = gatedAdapter();
+  });
+
+  it('does not lose a job enqueued while flush runs', async () => {
+    adapter.store['q'] = [makeItem('A')];
+    const queue = new PersistentRetryQueue<TestItem>(adapter, { storageKey: 'q', maxSize: 10, logLabel: 'test' });
+
+    // flush A: handler fails so A is retained.
+    const flushP = queue.flush(async () => false);
+    // Let flush park on its gated load().
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    const enqueueP = queue.enqueue(makeItem('B'));
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+
+    adapter.releaseLoad();
+    await Promise.all([flushP, enqueueP]);
+
+    const ids = (adapter.store['q'] as TestItem[]).map((i) => i.id).sort();
+    expect(ids).toEqual(['A', 'B']);
+  });
+});

--- a/src/background/handlers/__tests__/notificationSingleFlight.test.ts
+++ b/src/background/handlers/__tests__/notificationSingleFlight.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createNotificationHandlers } from '../notificationHandlers.js';
+import { getPendingPages, removePendingPages } from '../../../utils/pendingStorage.js';
+
+/**
+ * VULN-009 reproduction: a fast double-click delivers two onButtonClicked events
+ * for the same notification/URL. Without a single-flight guard both read the
+ * page as pending and both call record() (double record). With the guard,
+ * record() runs exactly once.
+ */
+
+vi.mock('../urlNotificationHandlers.js', () => ({
+  decodeUrlFromNotificationId: vi.fn(async () => 'https://example.com/page'),
+}));
+
+const pendingPage = {
+  url: 'https://example.com/page',
+  title: 'Example',
+  timestamp: 1,
+  reason: 'cache-control' as const,
+  expiry: Date.now() + 60_000,
+};
+
+vi.mock('../../../utils/pendingStorage.js', () => ({
+  getPendingPages: vi.fn(),
+  removePendingPages: vi.fn(async () => {}),
+}));
+
+vi.mock('../../notificationHelper.js', () => ({
+  PRIVACY_CONFIRM_NOTIFICATION_PREFIX: 'privacy-confirm-',
+}));
+
+vi.mock('../../../utils/logger.js', () => ({
+  logWarn: vi.fn(async () => {}),
+  logError: vi.fn(async () => {}),
+  ErrorCode: { UNKNOWN_ERROR: 'x', INVALID_INPUT: 'x', INTERNAL_ERROR: 'x' },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as Record<string, unknown>).chrome = {
+    notifications: { clear: vi.fn(() => Promise.resolve()) },
+  };
+});
+
+describe('notification button single-flight (VULN-009)', () => {
+  it('records only once for two concurrent clicks on the same URL', async () => {
+    // getPendingPages resolves slowly so the second click enters before the
+    // first has removed the page.
+    let resolveGet!: (v: unknown[]) => void;
+    (getPendingPages as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((r) => { resolveGet = r as (v: unknown[]) => void; })
+    );
+
+    const record = vi.fn(async () => ({ success: true }) as never);
+    const { onButtonClicked } = createNotificationHandlers({ record });
+
+    const p1 = onButtonClicked('privacy-confirm-abc', 0);
+    await Promise.resolve();
+    const p2 = onButtonClicked('privacy-confirm-abc', 0);
+    await Promise.resolve();
+
+    resolveGet([pendingPage]);
+    await Promise.all([p1, p2]);
+
+    expect(record).toHaveBeenCalledTimes(1);
+    expect(removePendingPages).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/background/handlers/notificationHandlers.ts
+++ b/src/background/handlers/notificationHandlers.ts
@@ -31,6 +31,15 @@ export interface NotificationHandlersDeps {
 }
 
 export function createNotificationHandlers(deps: NotificationHandlersDeps) {
+    // VULN-009 (CWE-362): a fast double-click delivers two onButtonClicked
+    // events for the same notification before the first finishes its
+    // getPendingPages -> record -> removePendingPages sequence. Both read the
+    // page as still pending and both call record(), double-recording it.
+    // A single-flight map keyed by URL collapses concurrent handling of the
+    // same URL onto one in-flight promise, modeled on contextMenuHandlers'
+    // contextMenuRecordInProgress guard.
+    const inFlightByUrl = new Map<string, Promise<void>>();
+
     async function onButtonClicked(notificationId: string, buttonIndex: number): Promise<void> {
         try {
             if (!notificationId.startsWith(PRIVACY_CONFIRM_NOTIFICATION_PREFIX)) return;
@@ -61,21 +70,35 @@ export function createNotificationHandlers(deps: NotificationHandlersDeps) {
                 return;
             }
 
-            if (buttonIndex === 0) {
-                const pages = await getPendingPages();
-                const page = pages.find(p => p.url === url);
-                if (page) {
-                    await deps.record({
-                        title: page.title,
-                        url: page.url,
-                        content: '',
-                        force: true,
-                        skipDuplicateCheck: true,
-                        recordType: 'auto',
-                    });
-                }
+            const existing = inFlightByUrl.get(url);
+            if (existing) {
+                await existing;
+                return;
             }
-            await removePendingPages([url]);
+
+            const run = (async () => {
+                if (buttonIndex === 0) {
+                    const pages = await getPendingPages();
+                    const page = pages.find(p => p.url === url);
+                    if (page) {
+                        await deps.record({
+                            title: page.title,
+                            url: page.url,
+                            content: '',
+                            force: true,
+                            skipDuplicateCheck: true,
+                            recordType: 'auto',
+                        });
+                    }
+                }
+                await removePendingPages([url]);
+            })();
+            inFlightByUrl.set(url, run);
+            try {
+                await run;
+            } finally {
+                inFlightByUrl.delete(url);
+            }
         } catch (error) {
             await logError(
                 'Notification button click handler failed',

--- a/src/background/persistentRetryQueue.ts
+++ b/src/background/persistentRetryQueue.ts
@@ -54,15 +54,36 @@ export interface RetryableItem {
  * Deep queue module: owns retry semantics, delegates persistence to adapter.
  */
 export class PersistentRetryQueue<T> {
+  // VULN-056 (CWE-362): enqueue/flush/flushBatch all do load -> mutate -> save
+  // on the same storage key. An enqueue that interleaves with a flush reads the
+  // pre-flush snapshot and its save clobbers the flush result (job lost:
+  // ['A','B'] -> ['A']). A promise-chain lock runs these one-at-a-time; the SW
+  // is single-threaded so chaining is sufficient and avoids a Mutex import
+  // cycle through the logger.
+  private queueLock: Promise<void> = Promise.resolve();
+
   constructor(
     private readonly adapter: QueueStorageAdapter,
     private readonly options: PersistentRetryQueueOptions
   ) {}
 
+  private withQueueLock<R>(fn: () => Promise<R>): Promise<R> {
+    const run = this.queueLock.then(fn, fn);
+    this.queueLock = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
   /**
    * Enqueue an item. Best-effort: a failure is logged but not thrown.
    */
-  async enqueue(item: T): Promise<void> {
+  enqueue(item: T): Promise<void> {
+    return this.withQueueLock(() => this.enqueueUnlocked(item));
+  }
+
+  private async enqueueUnlocked(item: T): Promise<void> {
     try {
       // Payload size check (for retryable items with payload)
       if (this.options.maxPayloadBytes && isRetryable(item)) {
@@ -104,7 +125,11 @@ export class PersistentRetryQueue<T> {
    *
    * Returns remaining items. Saves remaining items back to storage.
    */
-  async flush(handler: (item: T) => Promise<boolean>): Promise<T[]> {
+  flush(handler: (item: T) => Promise<boolean>): Promise<T[]> {
+    return this.withQueueLock(() => this.flushUnlocked(handler));
+  }
+
+  private async flushUnlocked(handler: (item: T) => Promise<boolean>): Promise<T[]> {
     const items = await this.adapter.load<T>(this.options.storageKey);
     if (items.length === 0) return [];
 
@@ -166,7 +191,14 @@ export class PersistentRetryQueue<T> {
    *
    * Always persists per-item for Service Worker resilience.
    */
-  async flushBatch(
+  flushBatch(
+    handler: (items: T[]) => Promise<boolean[]>,
+    batchSize: number
+  ): Promise<T[]> {
+    return this.withQueueLock(() => this.flushBatchUnlocked(handler, batchSize));
+  }
+
+  private async flushBatchUnlocked(
     handler: (items: T[]) => Promise<boolean[]>,
     batchSize: number
   ): Promise<T[]> {


### PR DESCRIPTION
## 脆弱性

MV3 では SW / popup / dashboard が並行動作し、共有ストレージキーへの `get → mutate → set` が stale スナップショットで互いを上書きする（VULN-003/005/009/012/050/056, CWE-362/367）。

## 修正（本 PR は 2/6 サイト）

| ファイル | 変更 |
|---|---|
| `src/background/persistentRetryQueue.ts` | `enqueue`/`flush`/`flushBatch` を promise-chain lock（`queueLock`）で1件ずつ実行。`flush` 中の `enqueue` がキューを取りこぼす問題（`['A','B']→['A']`、VULN-056）を解消。SW 単一スレッドのため chain で十分、Mutex import 循環も回避 |
| `src/background/handlers/notificationHandlers.ts` | `onButtonClicked` に URL キーの single-flight ガードを追加。高速ダブルクリックで `getPendingPages → record → removePendingPages` が二重実行され録画が重複する問題（VULN-009）を解消。`contextMenuHandlers` の `contextMenuRecordInProgress` パターンに倣う |

## スコープ縮小（本 PR 外）

PBI 2026-08-29-04 の 6 サイトのうち以下は本 PR に含めない:
- `MarkdownBufferManager` / `pendingStorage` の CAS 化（VULN-003/005）
- `logger/storageAdapter` の CAS 化（VULN-050）
- `optimisticLock` の verify→set 区間の Mutex 直列化（VULN-012）

**理由**: これら4サイトは `withOptimisticLock`/`withAtomicKeys` の verify→write 区間を Mutex で直列化する必要があるが、その process-wide Mutex を入れると fake timer を使う既存テスト15件以上が「`Mutex.acquire()` がタイマー前進まで解決しない」ため RED になる。CAS のみでは verify→set の TOCTOU 窓が残り、決定的インターリーブテスト（`set()` をゲート）が通らない。key 粒度 Mutex + fake-timer 互換の設計を要する別 PBI として切り出す。

## テスト（TDD）
- 新規 `persistentRetryQueueInterleave.test.ts` / `notificationSingleFlight.test.ts`
- RED（直列化なしでジョブ消失・二重記録）→ GREEN

## ゲート
- `tsc --noEmit`: クリーン
- `npm test`: 587 files pass / 0 failures（9ブランチ統合マージでも確認）
- lint: 増分ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)