### PR TITLE
fix(compute): 二次計算の O(n²) 入力上限を追加（VULN-041/051/053）

### DIFF
--- a/src/dashboard/__tests__/tagClusterLayoutPerf.test.ts
+++ b/src/dashboard/__tests__/tagClusterLayoutPerf.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { computeTagCooccurrence, narrowEntriesToTopTags, limitToTopNodes } from '../tagCooccurrence.js';
+import { computeLayout, computeCanvasSize } from '../tagClusterLayout.js';
+import { MAX_TAG_CLUSTER_TAGS } from '../../utils/computeLimits.js';
+
+const MAX_NODES = 50;
+
+function bigHistory(uniqueTags: number): Array<{ tags: string }> {
+  return Array.from({ length: uniqueTags * 3 }, (_, i) => ({
+    tags: `#tag${i % uniqueTags} #tag${(i + 1) % uniqueTags} #tag${(i + 7) % uniqueTags}`,
+  }));
+}
+
+// AC8: the tag-cluster render path must not get slower as the raw history grows,
+// because narrowing now happens before cooccurrence.
+describe('tagCluster render path is bounded regardless of history size', () => {
+  const render = (uniqueTags: number): number => {
+    const rows = bigHistory(uniqueTags);
+    const start = performance.now();
+    const narrowed = narrowEntriesToTopTags(rows, MAX_TAG_CLUSTER_TAGS);
+    const { nodes, edges } = computeTagCooccurrence(narrowed);
+    const limited = limitToTopNodes(nodes, edges, MAX_NODES);
+    const size = computeCanvasSize(limited.nodes.length);
+    computeLayout(limited.nodes, limited.edges, size.width, size.height);
+    return performance.now() - start;
+  };
+
+  it('4x unique tags does not make rendering ~16x slower', () => {
+    render(500);
+    const t1 = Math.max(render(500), 0.5);
+    const t4 = render(2000);
+    expect(t4).toBeLessThan(t1 * 8);
+  });
+
+  it('layout node count never exceeds the render cap', () => {
+    const rows = bigHistory(3000);
+    const narrowed = narrowEntriesToTopTags(rows, MAX_TAG_CLUSTER_TAGS);
+    const { nodes, edges } = computeTagCooccurrence(narrowed);
+    const limited = limitToTopNodes(nodes, edges, MAX_NODES);
+    expect(limited.nodes.length).toBeLessThanOrEqual(MAX_NODES);
+  });
+});

--- a/src/dashboard/__tests__/tagCooccurrenceCap.test.ts
+++ b/src/dashboard/__tests__/tagCooccurrenceCap.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeTagCooccurrence,
+  narrowEntriesToTopTags,
+} from '../tagCooccurrence.js';
+import { MAX_TAGS_PER_RECORD, MAX_TAG_CLUSTER_TAGS } from '../../utils/computeLimits.js';
+
+function makeTagString(count: number, prefix = 't'): string {
+  return Array.from({ length: count }, (_, i) => `#${prefix}${i}`).join(' ');
+}
+
+describe('computeTagCooccurrence input cap (VULN-041)', () => {
+  it('caps unique tags per record to MAX_TAGS_PER_RECORD before the double loop', () => {
+    const entry = { tags: makeTagString(500) };
+    const { nodes, edges } = computeTagCooccurrence([entry]);
+
+    expect(nodes.length).toBe(MAX_TAGS_PER_RECORD);
+    // edges bounded by C(cap, 2)
+    expect(edges.length).toBe((MAX_TAGS_PER_RECORD * (MAX_TAGS_PER_RECORD - 1)) / 2);
+  });
+
+  it('keeps the first N tags in parse order', () => {
+    const { nodes } = computeTagCooccurrence([{ tags: makeTagString(MAX_TAGS_PER_RECORD + 5) }]);
+    const kept = new Set(nodes.map(n => n.tag));
+    expect(kept.has('t0')).toBe(true);
+    expect(kept.has(`t${MAX_TAGS_PER_RECORD - 1}`)).toBe(true);
+    expect(kept.has(`t${MAX_TAGS_PER_RECORD}`)).toBe(false);
+  });
+
+  it('boundary: exactly cap tags is unchanged', () => {
+    const { nodes, edges } = computeTagCooccurrence([{ tags: makeTagString(MAX_TAGS_PER_RECORD) }]);
+    expect(nodes.length).toBe(MAX_TAGS_PER_RECORD);
+    expect(edges.length).toBe((MAX_TAGS_PER_RECORD * (MAX_TAGS_PER_RECORD - 1)) / 2);
+  });
+
+  it('boundary: cap+1 tags drops exactly one', () => {
+    const { nodes } = computeTagCooccurrence([{ tags: makeTagString(MAX_TAGS_PER_RECORD + 1) }]);
+    expect(nodes.length).toBe(MAX_TAGS_PER_RECORD);
+  });
+
+  it('normal-size data (tens of tags) is identical to naive result', () => {
+    const entries = [{ tags: '#a #b #c' }, { tags: '#b #c #d' }];
+    const { nodes, edges } = computeTagCooccurrence(entries);
+    expect(nodes).toContainEqual({ tag: 'b', count: 2 });
+    expect(edges).toContainEqual({ source: 'b', target: 'c', weight: 2 });
+  });
+
+  it('perf: 4x tags/record does NOT give ~16x time (capped, near-constant)', () => {
+    const time = (tagsPerRecord: number): number => {
+      const entries = Array.from({ length: 50 }, () => ({ tags: makeTagString(tagsPerRecord) }));
+      const start = performance.now();
+      computeTagCooccurrence(entries);
+      return performance.now() - start;
+    };
+    // warm up
+    time(100);
+    const t1 = Math.max(time(125), 0.01);
+    const t4 = time(500);
+    expect(t4).toBeLessThan(t1 * 8);
+  });
+});
+
+describe('narrowEntriesToTopTags (VULN-053 pre-narrowing)', () => {
+  it('keeps only the top-N tags by cross-record frequency', () => {
+    const entries = [
+      { tags: '#hot #hot-ignore-this' },
+      ...Array.from({ length: 10 }, () => ({ tags: '#hot' })),
+      { tags: '#rare1' },
+      { tags: '#rare2' },
+    ];
+    const narrowed = narrowEntriesToTopTags(entries, 1);
+    const { nodes } = computeTagCooccurrence(narrowed);
+    expect(nodes.map(n => n.tag)).toEqual(['hot']);
+  });
+
+  it('boundary: top-N tail — Nth and N+1th by frequency', () => {
+    const entries = [
+      ...Array.from({ length: 5 }, () => ({ tags: '#a' })),
+      ...Array.from({ length: 4 }, () => ({ tags: '#b' })),
+      ...Array.from({ length: 3 }, () => ({ tags: '#c' })),
+    ];
+    const narrowed = narrowEntriesToTopTags(entries, 2);
+    const { nodes } = computeTagCooccurrence(narrowed);
+    const tags = new Set(nodes.map(n => n.tag));
+    expect(tags.has('a')).toBe(true);
+    expect(tags.has('b')).toBe(true);
+    expect(tags.has('c')).toBe(false);
+  });
+
+  it('no-op when unique tags <= limit', () => {
+    const entries = [{ tags: '#a #b' }, { tags: '#c' }];
+    const narrowed = narrowEntriesToTopTags(entries, MAX_TAG_CLUSTER_TAGS);
+    expect(narrowed).toBe(entries);
+  });
+
+  it('perf: 4x unique tags does NOT blow up cooccurrence when pre-narrowed', () => {
+    const build = (uniqueTags: number): Array<{ tags: string }> =>
+      Array.from({ length: uniqueTags }, (_, i) => ({ tags: `#u${i} #u${(i + 1) % uniqueTags}` }));
+    const run = (uniqueTags: number): number => {
+      const entries = narrowEntriesToTopTags(build(uniqueTags), MAX_TAG_CLUSTER_TAGS);
+      const start = performance.now();
+      computeTagCooccurrence(entries);
+      return performance.now() - start;
+    };
+    run(500);
+    const t1 = Math.max(run(500), 0.01);
+    const t4 = run(2000);
+    expect(t4).toBeLessThan(t1 * 8);
+  });
+});

--- a/src/dashboard/panels/asyncData/tagClusterPanel.ts
+++ b/src/dashboard/panels/asyncData/tagClusterPanel.ts
@@ -4,7 +4,8 @@
  */
 
 import { queryLogs, getSqliteStatus, isServiceError } from '../../dashboardSqliteService.js';
-import { computeTagCooccurrence, limitToTopNodes } from '../../tagCooccurrence.js';
+import { computeTagCooccurrence, limitToTopNodes, narrowEntriesToTopTags } from '../../tagCooccurrence.js';
+import { MAX_TAG_CLUSTER_TAGS } from '../../../utils/computeLimits.js';
 import { computeLayout, computeCanvasSize } from '../../tagClusterLayout.js';
 import { TagClusterLoadingManager } from '../../tagClusterLoading.js';
 import { TagClusterPanZoomController } from '../../tagClusterPanZoom.js';
@@ -47,7 +48,10 @@ export function createTagClusterPanel(): PanelLifecycle {
         const rows = await loadRowsWithRetry();
         loadingManager.updateStep(0);
 
-        const { nodes, edges } = computeTagCooccurrence(rows);
+        // Narrow to the most frequent tags BEFORE cooccurrence so the O(n^2)
+        // double loop and force-directed layout stay bounded (VULN-053).
+        const narrowedRows = narrowEntriesToTopTags(rows, MAX_TAG_CLUSTER_TAGS);
+        const { nodes, edges } = computeTagCooccurrence(narrowedRows);
         loadingManager.updateStep(1);
 
         if (nodes.length === 0) {

--- a/src/dashboard/tagCooccurrence.ts
+++ b/src/dashboard/tagCooccurrence.ts
@@ -4,6 +4,7 @@
  */
 
 import { parseTagsForDisplay } from '../utils/tagUtils.js';
+import { MAX_TAGS_PER_RECORD } from '../utils/computeLimits.js';
 
 export interface TagNode {
   tag: string;
@@ -26,7 +27,11 @@ export function computeTagCooccurrence(
     const tags = parseTagsForDisplay(entry.tags);
     if (tags.length === 0) continue;
 
-    const uniqueTags = Array.from(new Set(tags));
+    // Cap tags per record BEFORE the double loop: bounds iterations to
+    // C(MAX_TAGS_PER_RECORD, 2) and edge count likewise (VULN-041, CWE-400).
+    // Kept: first N in parse order — per-record selection is frequency-agnostic;
+    // cross-record importance is handled by limitToTopNodes / narrowEntriesToTopTags.
+    const uniqueTags = Array.from(new Set(tags)).slice(0, MAX_TAGS_PER_RECORD);
 
     for (const tag of uniqueTags) {
       nodeCounts.set(tag, (nodeCounts.get(tag) ?? 0) + 1);
@@ -48,6 +53,41 @@ export function computeTagCooccurrence(
   });
 
   return { nodes, edges };
+}
+
+/**
+ * Narrow a list of log entries so that only the top-N tags by cross-record
+ * frequency remain, BEFORE cooccurrence is computed (VULN-053). This keeps the
+ * cooccurrence double loop and the downstream force-directed layout bounded even
+ * when the history contains thousands of unique tags. Entries keep their other
+ * fields; only the `tags` string is filtered. Returns the input array unchanged
+ * when the unique-tag count is already within `limit`.
+ */
+export function narrowEntriesToTopTags<T extends { tags?: string | null }>(
+  entries: T[],
+  limit: number
+): T[] {
+  const freq = new Map<string, number>();
+  for (const entry of entries) {
+    for (const tag of new Set(parseTagsForDisplay(entry.tags))) {
+      freq.set(tag, (freq.get(tag) ?? 0) + 1);
+    }
+  }
+  if (freq.size <= limit) {
+    return entries;
+  }
+
+  const keep = new Set(
+    Array.from(freq.entries())
+      .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))
+      .slice(0, limit)
+      .map(([tag]) => tag)
+  );
+
+  return entries.map(entry => {
+    const filtered = parseTagsForDisplay(entry.tags).filter(t => keep.has(t));
+    return { ...entry, tags: filtered.map(t => `#${t}`).join(' ') };
+  });
 }
 
 export function limitToTopNodes(

--- a/src/offscreen/__tests__/browsingLogCodec-comprehensive.test.ts
+++ b/src/offscreen/__tests__/browsingLogCodec-comprehensive.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { buildRecordFromPayload } from '../browsingLogCodec.js';
+import { MAX_TAGS_PER_RECORD } from '../../utils/computeLimits.js';
 
 describe('buildRecordFromPayload', () => {
   // ── Normal operation ─────────────────────────────────────────────────
@@ -309,6 +310,17 @@ describe('buildRecordFromPayload', () => {
       visit_duration: Infinity,
     });
     expect(record.visit_duration).toBeNull();
+  });
+
+  it('caps stored tags to MAX_TAGS_PER_RECORD (VULN-041/053 write-path defense)', () => {
+    const many = Array.from({ length: 500 }, (_, i) => `#t${i}`).join(' ');
+    const record = buildRecordFromPayload({ url: 'https://test.com', created_at: 1, tags: many });
+    expect(record.tags!.split(/\s+/).filter(Boolean).length).toBe(MAX_TAGS_PER_RECORD);
+  });
+
+  it('leaves a normal-size tag string untouched', () => {
+    const record = buildRecordFromPayload({ url: 'https://test.com', created_at: 1, tags: '#a #b #c' });
+    expect(record.tags).toBe('#a #b #c');
   });
 
   it('handles negative zero', () => {

--- a/src/offscreen/browsingLogCodec.ts
+++ b/src/offscreen/browsingLogCodec.ts
@@ -7,6 +7,19 @@
  */
 
 import type { BrowsingLogRecord } from '../utils/sqlite-types.js';
+import { MAX_TAGS_PER_RECORD } from '../utils/computeLimits.js';
+
+/**
+ * Defense-in-depth tag cap on the SQLite write path: a stored record must not
+ * carry an unbounded number of tags, since those tags later flow into O(n^2)
+ * dashboard computations (VULN-041/053). Whitespace-separated; first N kept.
+ */
+function capTags(raw: string): string {
+  const parts = raw.split(/\s+/).filter(Boolean);
+  return parts.length <= MAX_TAGS_PER_RECORD
+    ? raw
+    : parts.slice(0, MAX_TAGS_PER_RECORD).join(' ');
+}
 
 /**
  * Build a BrowsingLogRecord from an untrusted payload dictionary.
@@ -23,7 +36,7 @@ export function buildRecordFromPayload(payload: Record<string, unknown>): Browsi
     url: payload.url != null ? String(payload.url) : '',
     title: payload.title != null ? String(payload.title) : null,
     summary: payload.summary != null ? String(payload.summary) : null,
-    tags: payload.tags != null ? String(payload.tags) : null,
+    tags: payload.tags != null ? capTags(String(payload.tags)) : null,
     created_at: payload.created_at != null ? (toFiniteNumber(payload.created_at) ?? Date.now()) : Date.now(),
     domain: payload.domain != null ? String(payload.domain) : null,
     visit_duration: payload.visit_duration != null ? toFiniteNumber(payload.visit_duration) : null,

--- a/src/utils/__tests__/sentenceExtractorCap.test.ts
+++ b/src/utils/__tests__/sentenceExtractorCap.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { extractSentences } from '../sentenceExtractor.js';
+import { MAX_SENTENCES_FOR_TEXTRANK } from '../computeLimits.js';
+
+function buildText(sentenceCount: number, len = 40): string {
+  return Array.from(
+    { length: sentenceCount },
+    (_, i) => `This is sentence number ${i} padded ${'x'.repeat(len)}.`
+  ).join(' ');
+}
+
+describe('sentenceExtractor TextRank input cap (VULN-051)', () => {
+  it('completes quickly for 5000 sentences (capped)', () => {
+    const text = buildText(5000);
+    const start = performance.now();
+    const out = extractSentences(text, { topK: 10, minLength: 20 });
+    const elapsed = performance.now() - start;
+    expect(out.length).toBe(10);
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it('perf: 4x sentences does NOT give ~16x time', () => {
+    const run = (n: number): number => {
+      const text = buildText(n);
+      const start = performance.now();
+      extractSentences(text, { topK: 10, minLength: 20 });
+      return performance.now() - start;
+    };
+    run(500);
+    const t1 = Math.max(run(500), 0.5);
+    const t4 = run(2000);
+    expect(t4).toBeLessThan(t1 * 8);
+  });
+
+  it('normal-size input (tens of sentences) unaffected by the cap', () => {
+    const text = buildText(30);
+    const out = extractSentences(text, { topK: 5, minLength: 20 });
+    expect(out.length).toBe(5);
+  });
+
+  it('boundary: cap and cap+1 sentences both bounded to the cap', () => {
+    const atCap = extractSentences(buildText(MAX_SENTENCES_FOR_TEXTRANK), { topK: 10, minLength: 20 });
+    const overCap = extractSentences(buildText(MAX_SENTENCES_FOR_TEXTRANK + 1), { topK: 10, minLength: 20 });
+    expect(atCap.length).toBe(10);
+    expect(overCap.length).toBe(10);
+  });
+
+  it('prefers minLength-passing sentences when capping', () => {
+    // Many short (below minLength) sentences followed by long ones.
+    const shorts = Array.from({ length: 400 }, () => 'hi.').join(' ');
+    const longs = Array.from(
+      { length: 20 },
+      (_, i) => `Meaningful long sentence ${i} with enough characters here.`
+    ).join(' ');
+    const out = extractSentences(shorts + ' ' + longs, { topK: 5, minLength: 20 });
+    expect(out.length).toBeGreaterThan(0);
+    for (const s of out) {
+      expect(s.length).toBeGreaterThanOrEqual(20);
+    }
+  });
+});

--- a/src/utils/computeLimits.ts
+++ b/src/utils/computeLimits.ts
@@ -1,0 +1,33 @@
+/**
+ * computeLimits.ts
+ * Input caps for O(n^2) computations over stored data (VULN-041/051/053, CWE-400).
+ *
+ * Stored tag strings and extracted sentences flow into double-loop / similarity-matrix
+ * computations with no upper bound. Uncapped, a bloated or hostile page can push a single
+ * record into hundreds of tags (C(n,2) edges) or thousands of sentences (n^2 similarity
+ * matrix), making the dashboard freeze. These caps bound each such computation.
+ *
+ * Values match existing precedent (MAX_TAGS_AFTER_TRUNCATION = 50 in
+ * pendingChromeStorageQueue.ts, MAX_NODES = 50 in tagClusterPanel.ts).
+ */
+
+/**
+ * Max unique tags considered per record in tag-cooccurrence.
+ * Bounds the per-record double loop to C(50, 2) = 1225 iterations.
+ * Tags kept: first N in original parse order (per-record, frequency-agnostic —
+ * cross-record frequency is handled later by limitToTopNodes / top-N narrowing).
+ */
+export const MAX_TAGS_PER_RECORD = 50;
+
+/**
+ * Max sentences fed into TextRank. Bounds the similarity matrix to 200^2.
+ * Applied after the minLength filter, preferring minLength-passing sentences.
+ */
+export const MAX_SENTENCES_FOR_TEXTRANK = 200;
+
+/**
+ * Max unique tags fed into tag-cooccurrence for the tag-cluster panel,
+ * selected by cross-record frequency BEFORE cooccurrence runs. Matches the
+ * downstream MAX_NODES render cap so no work is done on nodes that would be dropped.
+ */
+export const MAX_TAG_CLUSTER_TAGS = 50;

--- a/src/utils/sentenceExtractor.ts
+++ b/src/utils/sentenceExtractor.ts
@@ -11,6 +11,7 @@
 
 import { splitSentences, containsJapanese, getBigrams } from './text/tokenizer.js';
 import { jaccardSimilarity } from './text/similarity.js';
+import { MAX_SENTENCES_FOR_TEXTRANK } from './computeLimits.js';
 
 export { splitSentences };
 
@@ -208,6 +209,15 @@ export function extractSentences(
     sentencesForExtraction = sentences;
   } else {
     sentencesForExtraction = validSentences;
+  }
+
+  // Cap the sentence count fed into TextRank: the similarity graph is O(n^2)
+  // and had no bound (VULN-051, CWE-400). Applied after the minLength filter so
+  // minLength-passing sentences are preferred; a leading slice is acceptable here
+  // because upstream content is already byte-truncated before this step, so the
+  // first MAX_SENTENCES_FOR_TEXTRANK sentences still span the retained article.
+  if (sentencesForExtraction.length > MAX_SENTENCES_FOR_TEXTRANK) {
+    sentencesForExtraction = sentencesForExtraction.slice(0, MAX_SENTENCES_FOR_TEXTRANK);
   }
 
   // Build similarity graph (index-qualified keys — see buildSentenceGraph)


### PR DESCRIPTION
> フォローアップ PBI `2026-08-29-18`（PR #75 = 29-08 の見送り分から分離）

## 脆弱性

保存済みデータが上限なく O(n²) 計算に流入し、実測「4x 入力 → 29x 時間」（VULN-041/051/053, CWE-400）。

| 経路 | 爆発点 |
|---|---|
| VULN-041 タグ共起 | `computeTagCooccurrence` の per-entry `for i { for j>i }`。500タグ/レコード → ~125k反復/レコード、エッジ C(n,2) |
| VULN-051 要約抽出 | `sentenceExtractor` TextRank の類似度行列 O(n²)、文数上限なし |
| VULN-053 タグクラスタ | 力学配置 × ノード²。`limitToTopNodes` はあるが共起計算が先に走る |

## 修正

`src/utils/computeLimits.ts`（新規）に名前付き定数:
- `MAX_TAGS_PER_RECORD` = 50（タグ共起の二重ループ前に slice、エッジを C(50,2) に有界化）
- `MAX_SENTENCES_FOR_TEXTRANK` = 200（minLength フィルタ後・TextRank 前に slice、先頭優先）
- `MAX_TAG_CLUSTER_TAGS` = 50（新関数 `narrowEntriesToTopTags` を `tagClusterPanel.load()` で共起計算前に適用、頻度上位へ絞り込み）
- 書き込み側防御: `browsingLogCodec.buildRecordFromPayload` の tags に `capTags`(50)（INSERT/INSERT_BATCH 両経路）

## テスト（TDD）
- 新規: `tagCooccurrenceCap.test.ts` / `sentenceExtractorCap.test.ts` / `tagClusterLayoutPerf.test.ts`
- RED: 5000文 TextRank = 21,572ms → GREEN: ~20ms。全 perf テストで「4x 入力 < 1x 時間 × 8」成立
- 通常規模（数十タグ/文）は結果不変

## ゲート
- `tsc --noEmit`: クリーン
- `npm test`: 10607 passing / 0 failures
- lint: 増分ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)