### PR TITLE
fix(lint): テストの未使用インポートを除去し main の validate を green にする

### DIFF
--- a/tests/dashboard/aiProviderB/priorityListView.test.ts
+++ b/tests/dashboard/aiProviderB/priorityListView.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { createBPriorityListView, collectBProviderPrioritySlots, validateBSlots } from '../../../src/dashboard/aiProviderB/priorityListView.js';
 import type { ProviderSlot } from '../../../src/utils/storage/types.js';
@@ -12,7 +12,7 @@ function setupDom() {
 describe('collectBProviderPrioritySlots', () => {
   it('3行のselect+inputからProviderSlot[]を収集（空は無視、trim）', () => {
     const container = setupDom();
-    const view = createBPriorityListView(container, [{ provider: 'openai', model: '  gpt  ' }, { provider: '' }, { provider: 'gemini' }]);
+    createBPriorityListView(container, [{ provider: 'openai', model: '  gpt  ' }, { provider: '' }, { provider: 'gemini' }]);
     const slots = collectBProviderPrioritySlots(container);
     expect(slots).toEqual([{ provider: 'openai', model: 'gpt' }, { provider: 'gemini' }]);
   });

--- a/tests/dashboard/aiProviderLayoutToggle.test.ts
+++ b/tests/dashboard/aiProviderLayoutToggle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 // InMemoryStoragePort を使った簡易テスト
 import { InMemoryStoragePort } from '../../src/utils/storage/InMemoryStoragePort.js';


### PR DESCRIPTION
## 問題

`main` の CI `validate` ジョブ（`validate:json && lint && type-check && test`）が **lint エラー4件で失敗**している。オープン中の全 PR（#67–#79）がこれを継承し、`validate` fail のためマージできない状態。

```
tests/dashboard/aiProviderB/priorityListView.test.ts
   1:32  error  'beforeEach' is defined but never used
  15:11  error  'view' is assigned a value but never used
tests/dashboard/aiProviderLayoutToggle.test.ts
  1:32  error  'vi' is defined but never used
  1:36  error  'beforeEach' is defined but never used
```

## 修正

- `priorityListView.test.ts`: 未使用 import `beforeEach` を除去。副作用（DOM レンダリング）のみ利用する `createBPriorityListView(...)` 呼び出しの未使用代入 `const view =` を除去（別テストの line 48 の `view` は `moveSlot` で使われているので維持）
- `aiProviderLayoutToggle.test.ts`: 未使用 import `vi` / `beforeEach` を除去

挙動変更なし。`npm run lint` が exit 0、`type-check` クリーン、該当テスト green。

**このPRを最初にマージすることで #67–#79 の `validate` が通るようになる。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)