### PR TITLE
fix(security): VulnHunter 残タスク Wave 3 — 29-02/03/07/10/14（統合）

### DIFF
--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -43,9 +43,10 @@
 | [2026-08-29-16-fix-cas-verify-write-serialization.md](2026-08-29-16-fix-cas-verify-write-serialization.md) | CAS verify→write 区間の直列化（fake-timer 互換 Mutex・29-04 の残4サイト） | ⬜ | 🔧 | 🔴 | 🟡 | 分離 |
 | [2026-08-29-17-fix-local-export-retention.md](2026-08-29-17-fix-local-export-retention.md) | ローカル Markdown エクスポートの retention（VULN-004・29-08 から分離） | ⬜ | 🔧 | 🟡 | 🟡 | 分離 |
 | [2026-08-29-18-fix-secondary-compute-input-caps.md](2026-08-29-18-fix-secondary-compute-input-caps.md) | 二次計算の入力上限（O(n²) タグ共起/TextRank/クラスタ配置・29-08 から分離） | ⬜ | 🔧 | 🟡 | 🟢 | 分離 |
+| [2026-08-29-19-fix-cspvalidator-self-allow.md](2026-08-29-19-fix-cspvalidator-self-allow.md) | CSPValidator の設定由来ドメイン自己許可の締め直し（29-14 の AC1 から分離） | ⬜ | 🔧 | 🟡 | 🟡 | 分離 |
 
-> 29-04 / 29-08 / 29-13 は Wave 2（PR #73–#76）で部分着地。残タスクは 16/17/18 に分離、
-> HMAC 先行化（29-13/29-04）は 29-12 に統合。詳細は
+> 29-04 / 29-08 / 29-13 は Wave 2（PR #73–#76）で、29-14 は Wave 3 で部分着地。
+> 残タスクは 16/17/18/19 に分離、HMAC 先行化（29-13/29-04）は 29-12 に統合。詳細は
 > [2026-08-29-00-backlog-vulnhunt-audit.md](2026-08-29-00-backlog-vulnhunt-audit.md) の「フォローアップ PBI」節。
 
 ### クレンジング改善（2026-08-30）

--- a/pbi/2026-08-29-00-backlog-vulnhunt-audit.md
+++ b/pbi/2026-08-29-00-backlog-vulnhunt-audit.md
@@ -113,13 +113,14 @@ VulnHunter 2026-08-29 スキャンで確認された **48件の脆弱性（Mediu
 14. `2026-08-29-14-fix-security-hardening-code-quality.md`（170 — ハードニングのみ）
 15. `2026-08-29-15-fix-pending-whitelist-orphan-key.md`（2280 — C14 から分離。着手は Wave 1）
 
-### フォローアップ PBI（Wave 2 の部分完了分から分離）
+### フォローアップ PBI（部分完了分から分離）
 
-Wave 2（PR #73–#76）で着地しきれなかった残タスクを新規 PBI として切り出した。
+Wave 2 / Wave 3 で着地しきれなかった残タスクを新規 PBI として切り出した。
 
 - `2026-08-29-16-fix-cas-verify-write-serialization.md` — 29-04 の残 4 サイト（buffer/pending/logger の CAS + `optimisticLock` の verify→write 直列化）。fake-timer 互換の key 粒度 Mutex 設計が主眼。VULN-003/005/012/050
 - `2026-08-29-17-fix-local-export-retention.md` — 29-08 の VULN-004。ローカル Markdown 自動エクスポートの retention（download 記録の purge + 日次バッファのエントリ上限）
 - `2026-08-29-18-fix-secondary-compute-input-caps.md` — 29-08 の VULN-041/051/053。タグ共起・TextRank・タグクラスタ配置の O(n²) 計算への入力 cap
+- `2026-08-29-19-fix-cspvalidator-self-allow.md` — 29-14 の AC1。`CSPValidator.initializeFromSettings` の設定由来 hostname 無条件許可を `isAllowedProviderBaseUrl` 相当のガード（private IP・metadata・非 https）で締め直す。「何を正当なカスタム API エンドポイントとみなすか」の設計判断を含む
 
 **29-13 / 29-04 の HMAC 先行化（VULN-034）と log 署名（VULN-035）** は暗号エクスポート形式の変更
 （平文 JSON 署名 → ciphertext 署名）を伴うため、独立 PBI にせず `2026-08-29-12-fix-crypto-policy-ssot.md`

--- a/pbi/2026-08-29-19-fix-cspvalidator-self-allow.md
+++ b/pbi/2026-08-29-19-fix-cspvalidator-self-allow.md
@@ -1,0 +1,117 @@
+# PBI: CSPValidator の設定由来ドメイン自己許可を締め直す（VULN Code Quality）
+
+> `2026-08-29-14-fix-security-hardening-code-quality.md` の AC1 から分離。
+> 29-14（PR: Wave 3 統合）では AC2–AC6 の 5 件が着地したが、
+> AC1（CSPValidator 自己許可）は「どのドメインを正当なカスタム API
+> エンドポイントとみなすか」の設計判断が必要なため単独 PBI とした。
+
+## ユーザーストーリー
+開発者として、`CSPValidator.initializeFromSettings` が設定値の hostname を無条件に条件付き CSP 許可リストへ追加しないようにしたい、なぜなら設定が汚染された場合（インポート経由の悪意ある設定ファイル等）に任意ドメインへの接続が許可され、条件付き CSP の意味が無くなるから
+
+## 背景
+
+### 現状
+`src/utils/cspValidator.ts` の `initializeFromSettings`:
+- `settings.provider_base_url` の hostname を **無条件で** `allowedDomains` に追加（`:144-154`）
+- `settings['{openai|openai2|lm-studio|ollama}_base_url']` の hostname も同様に無条件追加（`:156-170`）
+
+これらはユーザーがカスタム AI エンドポイントを設定するための正当な機能だが、
+値が「信頼できる定数」ではなく「設定由来」であるため、VulnHunter は
+Code Quality（自己許可構造）として指摘した。
+
+### なぜ 29-14 で見送ったか
+既存テスト（`cspValidator.test.ts` の "Provider Base URL Domains" ブロック）が
+`custom-openai.example.com` 等の**任意カスタムエンドポイント許可を明示的に前提**
+としている。締め直すには「何を正当とみなすか」の設計判断が要る:
+- https のみ許可（http は localhost/loopback を除き拒否）？
+- private IP / metadata endpoint（169.254.169.254 等）を明示的に拒否？
+- ユーザーが設定 UI で明示的にオプトインした場合のみ許可（暗黙の追加を廃止）？
+
+### 現行コードの他のガード（参考）
+- `src/utils/ssrfGuard.ts` に private IP / localhost 判定あり
+- `src/utils/cspDomains.ts` の `LOCAL_PORTS` / `aiConnectSrc` に localhost ポート許可リスト
+- `src/utils/allowedUrls.ts` の `isAllowedProviderBaseUrl(url, isLocal)` — 別 PBI で追加された同種のガード（169.254.169.254 / metadata.google.internal / private IP を拒否）
+
+## BDD受け入れシナリオ
+
+```gherkin
+Scenario: private IP / metadata エンドポイントは条件付き CSP に追加されない
+  Given provider_base_url が "http://169.254.169.254/" である
+  When CSPValidator.initializeFromSettings が走る
+  Then 169.254.169.254 は allowedDomains に追加されない
+
+Scenario: 非 https のカスタムエンドポイントは localhost 以外拒否される
+  Given openai_base_url が "http://evil.example/" である
+  When initializeFromSettings が走る
+  Then evil.example は追加されない（http は localhost/loopback のみ許可）
+
+Scenario: 正当なカスタム https エンドポイントは引き続き許可される（回帰防止）
+  Given provider_base_url が "https://custom-openai.example.com/v1" である
+  When initializeFromSettings が走る
+  Then custom-openai.example.com は allowedDomains に追加される
+
+Scenario: localhost のカスタムエンドポイント（Ollama/LM Studio）は許可される
+  Given ollama_base_url が "http://localhost:11434" である
+  When initializeFromSettings が走る
+  Then localhost は許可される（LOCAL_PORTS の既存挙動を踏襲）
+```
+
+## 受け入れ基準
+- [ ] `CSPValidator.initializeFromSettings` の `provider_base_url` / `*_base_url` の hostname 追加が、`src/utils/allowedUrls.ts` の `isAllowedProviderBaseUrl` 相当のガードを通る（private IP・metadata endpoint・非 https の非 localhost を拒否）
+- [ ] ガードは 1 箇所に集約（`isAllowedProviderBaseUrl` を再利用するか、共有ヘルパーに抽出）
+- [ ] 正当な https カスタムエンドポイントと localhost エンドポイントの許可挙動は不変（既存 `cspValidator.test.ts` の該当テストは新ガードに合わせて期待値更新）
+- [ ] 設定 UI で暗黙に追加される挙動を維持するか、明示オプトインに変えるかを決定しコメント化
+- [ ] `npm run type-check` と `npm run validate` が成功する
+
+## テスト戦略（t_wadaスタイル）
+
+### E2Eテスト
+- 対象なし
+
+### 統合テスト
+- `initializeFromSettings` × 汚染設定（private IP / metadata / http evil）: 追加されないこと
+- `initializeFromSettings` × 正当設定（https custom / localhost）: 追加されること
+
+### 単体テスト
+- 更新: `src/utils/__tests__/cspValidator.test.ts` の "Provider Base URL Domains" ブロック（CRLF 注意 — CRLF なら別 LF ファイルへ）
+- 新規（別 LF ファイル）: private IP / metadata / 非 https 拒否の境界テスト
+
+## 実装アプローチ
+- **Outside-In**: 汚染設定の RED テスト（現行は追加される）→ `isAllowedProviderBaseUrl` ガード適用で GREEN
+- **Red-Green-Refactor**: ガードを 1 箇所に集約（`allowedUrls.ts` の既存関数を再利用）
+
+## 見積もり
+1pt（要チームでの見積もり — ガード適用 + 既存テスト更新 + 境界テスト）
+
+## 技術的考慮事項
+- 依存関係: なし
+- `cspValidator.test.ts` は CRLF の可能性 — 着手時に `file` で確認
+- `isAllowedProviderBaseUrl` の `isLocal` 引数の判定（provider type から localhost 期待かどうか）を CSPValidator 側でどう渡すか
+- 行番号は監査時点（2026-08-29）のもの。着手時に該当シンボルで再確認すること
+
+## 実装者向け注記
+
+### 現状コードの確認
+```bash
+rg -n "provider_base_url|_base_url|allowedDomains\.add|initializeFromSettings" src/utils/cspValidator.ts
+rg -n "isAllowedProviderBaseUrl|isPrivateIpAddress|metadata" src/utils/allowedUrls.ts src/utils/ssrfGuard.ts
+rg -n "Provider Base URL Domains|custom-openai" src/utils/__tests__/cspValidator.test.ts
+```
+
+### 実装手順
+1. `isAllowedProviderBaseUrl`（`allowedUrls.ts`）を CSPValidator から import
+2. `:144-170` の 2 箇所（`provider_base_url` と `*_base_url` ループ）で、hostname 追加前にガードを通す
+3. `cspValidator.test.ts` の該当テストを新挙動に合わせて更新
+4. private IP / metadata / 非 https 拒否の境界テストを追加
+5. `npm run validate`
+
+### 落とし穴
+- 既存ユーザーが private IP の Ollama を設定している場合、締め直しで動かなくなる可能性 — localhost/loopback は許可、private IP（10.x/192.168.x/172.16-31.x）の扱いを慎重に（Ollama を LAN 上の別マシンで動かすケース）
+- `isLocal` の判定: `ollama_base_url` / `lm-studio_base_url` は localhost 期待、`provider_base_url` / `openai*_base_url` はリモート期待
+
+## Definition of Done
+- [ ] 全 BDD シナリオが自動テストとして実装されパスする
+- [ ] テストカバレッジが基準を満たす
+- [ ] コードレビュー完了
+- [ ] リファクタリング完了（グリーン後）
+- [ ] VulnHunter 再スキャンで該当 Code Quality 指摘が解消されること

--- a/src/background/__tests__/gistSyncTarget.test.ts
+++ b/src/background/__tests__/gistSyncTarget.test.ts
@@ -288,6 +288,33 @@ describe('GistSyncTarget', () => {
     expect(mockSqliteClient.mutate).toHaveBeenCalled();
   });
 
+  it('createGist caps an oversized chunked response body', async () => {
+    mockGetAll.mockResolvedValue({ github_pat: 'ghp_test123' } as any);
+    mockSqliteClient.mutate.mockResolvedValue({ success: true, data: undefined });
+
+    const huge = new Uint8Array(11 * 1024 * 1024); // 11MB, over the 10MB cap
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      body: {
+        getReader: () => {
+          let sent = false;
+          return {
+            read: () => {
+              if (sent) return Promise.resolve({ done: true, value: undefined });
+              sent = true;
+              return Promise.resolve({ done: false, value: huge });
+            },
+            cancel: () => Promise.resolve(),
+          };
+        },
+      },
+    } as unknown as Response);
+
+    const result = await target.sync(1, 'https://example.com', 'Test', 'Summary');
+    expect(result.success).toBe(false);
+  });
+
   it('testConnection returns false when not configured', async () => {
     mockGetAll.mockResolvedValue({} as any);
     const result = await target.testConnection();

--- a/src/background/__tests__/markdownJoinSafety.test.ts
+++ b/src/background/__tests__/markdownJoinSafety.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ObsidianSyncService } from '../obsidianSyncService.js';
+import { GistSyncTarget } from '../syncTargets/gistSyncTarget.js';
+import { formatEntryToMarkdown } from '../../utils/markdownFormatter.js';
+import { formatMarkdownStep } from '../pipeline/steps/formatMarkdownStep.js';
+import type { RecordingContext } from '../pipeline/types.js';
+import type { BrowsingLogEntry } from '../../utils/sqlite-types.js';
+
+const EVIL = 'https://evil.example';
+
+/**
+ * A "balanced markdown link" to the attacker destination is `](EVIL)` preceded
+ * somewhere by an unescaped `[`. If every breakout `[` `]` `(` `)` is escaped
+ * with a backslash, no such link can render.
+ */
+function hasUnescapedEvilLink(md: string): boolean {
+  const idx = md.indexOf(`](${EVIL})`);
+  if (idx === -1) return false;
+  // the `]` at idx must be unescaped (not preceded by backslash)
+  return md[idx - 1] !== '\\';
+}
+
+describe('markdown join safety - tag fragments cannot reassemble a link', () => {
+  it('formatMarkdownStep: tag fragments "foo [" + "bar](EVIL)" do not form a link', async () => {
+    const ctx: Partial<RecordingContext> = {
+      data: { url: 'https://example.com', title: 'Example' },
+      sanitizedSummary: 'clean summary',
+      privacyResult: { summary: 'clean summary', tags: ['foo [', `bar](${EVIL})`] },
+    } as unknown as RecordingContext;
+
+    const result = await formatMarkdownStep(ctx as RecordingContext);
+    const md = result.markdown as string;
+    expect(hasUnescapedEvilLink(md)).toBe(false);
+  });
+
+  it('markdownFormatter legacy formatEntryToMarkdown: tag fragments do not form a link', () => {
+    const entry = {
+      url: 'https://example.com',
+      title: 'Example',
+      summary: 'clean',
+      tags: `foo [,bar](${EVIL})`,
+      created_at: Date.now(),
+    } as unknown as BrowsingLogEntry;
+    const md = formatEntryToMarkdown(entry);
+    expect(hasUnescapedEvilLink(md)).toBe(false);
+  });
+});
+
+describe('markdown join safety - title `](url)` suffix cannot break out', () => {
+  const EVIL_TITLE = `Doc](${EVIL})`;
+
+  it('markdownFormatter legacy: title suffix does not break out', () => {
+    const entry = {
+      url: 'https://example.com',
+      title: EVIL_TITLE,
+      summary: 'clean',
+      tags: '',
+      created_at: Date.now(),
+    } as unknown as BrowsingLogEntry;
+    const md = formatEntryToMarkdown(entry);
+    expect(hasUnescapedEvilLink(md)).toBe(false);
+  });
+
+  it('ObsidianSyncService: title suffix does not break out', async () => {
+    const appended: string[] = [];
+    const mockObsidianClient = {
+      appendToDailyNote: vi.fn(async (m: string) => { appended.push(m); }),
+      testConnection: vi.fn().mockResolvedValue({ success: true }),
+    };
+    const mockSqliteClient = {
+      mutate: vi.fn().mockResolvedValue({ success: true }),
+      query: vi.fn().mockResolvedValue({ success: true, data: { rows: [], total: 0 } }),
+      getStatus: vi.fn().mockResolvedValue({ initialized: true }),
+    };
+    const mockSettingsReader = {
+      getMany: vi.fn().mockResolvedValue({ obsidian_api_key: 'test-api-key-1234567' }),
+      getAll: vi.fn(),
+    };
+    const service = new ObsidianSyncService(
+      mockObsidianClient as never,
+      mockSqliteClient as never,
+      mockSettingsReader as never,
+    );
+    await service.sync(1, 'https://example.com', EVIL_TITLE, 'clean summary');
+    expect(appended).toHaveLength(1);
+    expect(hasUnescapedEvilLink(appended[0])).toBe(false);
+  });
+
+  it('GistSyncTarget: title suffix does not break out', async () => {
+    const captured: string[] = [];
+    const createSpy = vi
+      .spyOn(GistSyncTarget.prototype as unknown as { createGist: (c: string, p: string) => Promise<string> }, 'createGist')
+      .mockImplementation(async (content: string) => { captured.push(content); return 'gist-id'; });
+
+    const mockSqliteClient = { mutate: vi.fn().mockResolvedValue({ success: true }) };
+    const mockSettingsReader = {
+      getMany: vi.fn().mockResolvedValue({ github_pat: 'x' }),
+      getAll: vi.fn().mockResolvedValue({ github_pat: 'x' }),
+    };
+    // SettingsRepository is constructed internally for getAll/set; stub globally.
+    const { SettingsRepository } = await import('../../utils/storage/SettingsRepository.js');
+    vi.spyOn(SettingsRepository.prototype, 'getAll').mockResolvedValue({ github_pat: 'x' } as never);
+    vi.spyOn(SettingsRepository.prototype, 'set').mockResolvedValue(undefined as never);
+
+    const target = new GistSyncTarget(mockSqliteClient as never, mockSettingsReader as never);
+    await target.sync(1, 'https://example.com', EVIL_TITLE, 'clean summary');
+    createSpy.mockRestore();
+    expect(captured).toHaveLength(1);
+    expect(hasUnescapedEvilLink(captured[0])).toBe(false);
+  });
+});

--- a/src/background/__tests__/obsidianClient-body-timeout.test.ts
+++ b/src/background/__tests__/obsidianClient-body-timeout.test.ts
@@ -9,6 +9,31 @@ import * as storage from '../../utils/storage/types.js';
 import * as storageSettings from '../../utils/storage/settingsStore.js';
 import { addLog, LogType } from '../../utils/logger.js';
 
+/** Response body that resolves with the given text (as one chunk). */
+function bodyOf(text: string): { getReader: () => { read: () => Promise<{ done: boolean; value?: Uint8Array }>; cancel: () => Promise<void> } } {
+  let sent = false;
+  return {
+    getReader: () => ({
+      read: () => {
+        if (sent) return Promise.resolve({ done: true, value: undefined });
+        sent = true;
+        return Promise.resolve({ done: false, value: new TextEncoder().encode(text) });
+      },
+      cancel: () => Promise.resolve(),
+    }),
+  };
+}
+
+/** Response body whose read() never resolves. */
+function bodyNever(): { getReader: () => { read: () => Promise<never>; cancel: () => Promise<void> } } {
+  return {
+    getReader: () => ({
+      read: () => new Promise<never>(() => {}),
+      cancel: () => Promise.resolve(),
+    }),
+  };
+}
+
 vi.mock('../../utils/storage/types.js');
 vi.mock('../../utils/storage/defaults.js');
 vi.mock('../../utils/storage/encryptionSession.js');
@@ -62,7 +87,7 @@ describe('ObsidianClient: レスポンスボディ読み込みタイムアウト
       vi.useFakeTimers();
       mockFetch.mockResolvedValue({
         ok: true,
-        text: () => new Promise(() => {}) // ボディが永遠に返らない
+        body: bodyNever()
       });
 
       const promise = client._fetchExistingContent(
@@ -83,7 +108,7 @@ describe('ObsidianClient: レスポンスボディ読み込みタイムアウト
       vi.useFakeTimers();
       mockFetch.mockResolvedValue({
         ok: true,
-        text: () => new Promise(() => {})
+        body: bodyNever()
       });
 
       const promise = client._fetchExistingContent(
@@ -105,7 +130,7 @@ describe('ObsidianClient: レスポンスボディ読み込みタイムアウト
       vi.useFakeTimers();
       mockFetch.mockResolvedValue({
         ok: true,
-        text: () => new Promise(() => {})
+        body: bodyNever()
       });
 
       const mutex = client._globalWriteMutex;
@@ -127,7 +152,7 @@ describe('ObsidianClient: レスポンスボディ読み込みタイムアウト
     it('タイムアウトが発生せずコンテンツを返すこと', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        text: () => Promise.resolve('Existing content')
+        body: bodyOf("Existing content")
       });
 
       const result = await client._fetchExistingContent(
@@ -136,6 +161,34 @@ describe('ObsidianClient: レスポンスボディ読み込みタイムアウト
       );
 
       expect(result).toBe('Existing content');
+    });
+  });
+
+  describe('_fetchExistingContent - バイト上限', () => {
+    it('Content-Length なしで 10MB を超える chunked 応答は打ち切られエラー分類に乗ること', async () => {
+      const chunk = new Uint8Array(1024 * 1024); // 1MB
+      let count = 0;
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: { get: () => null },
+        body: {
+          getReader: () => ({
+            read: () => {
+              count += 1;
+              return Promise.resolve({ done: false, value: chunk });
+            },
+            cancel: () => Promise.resolve(),
+          }),
+        },
+      });
+
+      const err = await client._fetchExistingContent(
+        'http://127.0.0.1:27123/vault/test.md',
+        { 'Authorization': 'Bearer test_key' },
+      ).catch((e: Error) => e);
+
+      expect(err).toBeInstanceOf(Error);
+      expect(count).toBeLessThan(20); // aborted well before buffering everything
     });
   });
 

--- a/src/background/__tests__/obsidianClientLogIntegrity.test.ts
+++ b/src/background/__tests__/obsidianClientLogIntegrity.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Integration: an Obsidian error body containing newlines / control chars is
+ * single-lined by the logger persistence boundary before it is stored
+ * (VULN-044, transitive fix via logger neutralization).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ObsidianClient } from '../obsidianClient.js';
+import { getLogs, clearLogs, flushLogs } from '../../utils/logger/core.js';
+import { fetchWithTimeout } from '../../utils/fetch.js';
+
+vi.mock('../../utils/fetch.js', () => ({
+  fetchWithTimeout: vi.fn(),
+  CONNECTION_TEST_CACHE_MODE: 'no-cache',
+}));
+
+const NUL = String.fromCharCode(0x00);
+const originalNodeEnv = process.env.NODE_ENV;
+
+beforeEach(async () => {
+  process.env.NODE_ENV = 'test';
+  await clearLogs();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
+describe('ObsidianClient error path × logger', () => {
+  it('persists a forged multi-line error body as a single log line', async () => {
+    const client = new ObsidianClient();
+    const forgedBody = `500 Internal Error\n[Logger:ERROR] fake entry injected${NUL}`;
+
+    const response = {
+      ok: false,
+      status: 500,
+      text: async () => forgedBody,
+      headers: { get: () => null },
+    } as unknown as Response;
+    vi.mocked(fetchWithTimeout).mockResolvedValue(response);
+
+    await expect(
+      client._writeContent('https://127.0.0.1:27124/note.md', {}, 'body', 'trace-1'),
+    ).rejects.toThrow();
+    await flushLogs(true);
+
+    const entry = (await getLogs()).find((l) => l.message.includes('Obsidian API Error'));
+    expect(entry).toBeDefined();
+    expect(entry?.message).not.toContain('\n');
+    expect(entry?.message).not.toContain(NUL);
+    expect(entry?.message).toContain('[Logger:ERROR] fake entry injected');
+  });
+});

--- a/src/background/ai/providers/GeminiProvider.ts
+++ b/src/background/ai/providers/GeminiProvider.ts
@@ -12,6 +12,10 @@ import { Settings, StorageKeys } from '../../../utils/storage/types.js';
 import { errorMessage } from '../../../utils/errorUtils.js';
 import { applyCustomPrompt, getDefaultSystemPrompt } from '../../../utils/customPromptUtils.js';
 import { pickDefined } from '../../../utils/objectUtils.js';
+import { readJsonCapped } from '../../../utils/readBodyCapped.js';
+
+/** Default byte cap for AI provider JSON responses. */
+const MAX_AI_RESPONSE_BYTES = 10 * 1024 * 1024; // 10MB
 
 
 interface GeminiApiResponse {
@@ -131,7 +135,7 @@ export class GeminiProvider extends AIProviderStrategy {
                 return this._handleError(response);
             }
 
-            const data = await response.json();
+            const data = await readJsonCapped(response, MAX_AI_RESPONSE_BYTES) as GeminiApiResponse;
             return await this._extractSummary(data, traceId);
         } catch (error: unknown) {
             const msg = errorMessage(error);
@@ -229,7 +233,7 @@ export class GeminiProvider extends AIProviderStrategy {
                 };
             }
 
-            const data = await response.json() as GeminiApiResponse;
+            const data = await readJsonCapped(response, MAX_AI_RESPONSE_BYTES) as GeminiApiResponse;
             const candidate = data.candidates?.[0];
             // 応答が複数 parts に分かれる場合があるため全て結合する
             const text = (candidate?.content?.parts ?? [])

--- a/src/background/ai/providers/GeminiProvider.ts
+++ b/src/background/ai/providers/GeminiProvider.ts
@@ -53,6 +53,21 @@ export class GeminiProvider extends AIProviderStrategy {
     }
 
     /**
+     * Normalize the configured model into a single safe URL path segment.
+     * The model name is interpolated into the API URL path; without encoding a
+     * value containing `/` or `..` could escape the `/models/` segment
+     * (path traversal). Strips a leading `models/` prefix, rejects any
+     * remaining slashes or dot-segments, then percent-encodes the result.
+     */
+    private buildModelPathSegment(): string {
+        const raw = this.model.replace(/^models\//, '');
+        if (raw.includes('/') || raw.includes('\\') || raw === '..' || raw === '.') {
+            throw new Error(`Invalid Gemini model name: ${raw}`);
+        }
+        return encodeURIComponent(raw);
+    }
+
+    /**
      * 要約を生成する
      * @param {string} content - 要約対象のコンテンツ
      * @param {boolean} [tagSummaryMode=false] - タグ付き要約モード
@@ -68,9 +83,14 @@ export class GeminiProvider extends AIProviderStrategy {
             return { success: false, summary: preFlight.message! };
         }
 
-        const cleanModelName = this.model.replace(/^models\//, '');
+        let modelSegment: string;
+        try {
+            modelSegment = this.buildModelPathSegment();
+        } catch {
+            return { success: false, summary: "Error: Invalid AI model name. Please check your AI model settings." };
+        }
         const apiVersion = this._getApiVersion();
-        const url = `https://generativelanguage.googleapis.com/${apiVersion}/models/${cleanModelName}:generateContent`;
+        const url = `https://generativelanguage.googleapis.com/${apiVersion}/models/${modelSegment}:generateContent`;
         const maxContentChars = this.getMaxContentChars(30_000, StorageKeys.GEMINI_CONTENT_CHARS);
         const truncatedContent = content.substring(0, maxContentChars);
 
@@ -164,7 +184,17 @@ export class GeminiProvider extends AIProviderStrategy {
         // モデル一覧(GET /models)ではなく実際に推論を走らせる。メタデータ取得では
         // APIキーの有効性やモデル名の妥当性、実際の応答内容が検証できないため。
         const cleanModelName = this.model.replace(/^models\//, '');
-        const testUrl = `https://generativelanguage.googleapis.com/${this._getApiVersion()}/models/${cleanModelName}:generateContent`;
+        let modelSegment: string;
+        try {
+            modelSegment = this.buildModelPathSegment();
+        } catch (error: unknown) {
+            return {
+                success: false,
+                message: `Invalid model name: ${errorMessage(error)}`,
+                debug: { error: errorMessage(error) },
+            };
+        }
+        const testUrl = `https://generativelanguage.googleapis.com/${this._getApiVersion()}/models/${modelSegment}:generateContent`;
 
         // BaseUrl SSRF対策 - テストURLの検証
         try {

--- a/src/background/ai/providers/OpenAIProvider.ts
+++ b/src/background/ai/providers/OpenAIProvider.ts
@@ -13,6 +13,10 @@ import { applyCustomPrompt } from '../../../utils/customPromptUtils.js';
 
 import { getRegistryEntry, isAllowedProviderBaseUrl } from '../providerRegistry.js';
 import { pickDefined } from '../../../utils/objectUtils.js';
+import { readJsonCapped } from '../../../utils/readBodyCapped.js';
+
+/** Default byte cap for AI provider JSON responses. */
+const MAX_AI_RESPONSE_BYTES = 10 * 1024 * 1024; // 10MB
 
 interface OpenAIApiResponse {
     choices?: Array<{ message?: { content: string } }>;
@@ -180,7 +184,7 @@ export class GenericOpenAICompatibleProvider extends AIProviderStrategy {
                 return { success: false, summary: "Error: Failed to generate summary. Please check your API settings." };
             }
 
-            const data = await response.json();
+            const data = await readJsonCapped(response, MAX_AI_RESPONSE_BYTES) as OpenAIApiResponse;
             return this._extractSummary(data, traceId);
         } catch (error: unknown) {
             const msg = errorMessage(error);
@@ -248,7 +252,7 @@ export class GenericOpenAICompatibleProvider extends AIProviderStrategy {
                 };
             }
 
-            const data = await response.json() as OpenAIApiResponse;
+            const data = await readJsonCapped(response, MAX_AI_RESPONSE_BYTES) as OpenAIApiResponse;
             const text = data.choices?.[0]?.message?.content ?? '';
             const hasContent = text.trim().length > 0;
 

--- a/src/background/ai/providers/__tests__/GeminiProvider.test.ts
+++ b/src/background/ai/providers/__tests__/GeminiProvider.test.ts
@@ -67,6 +67,35 @@ describe('GeminiProvider: エラーハンドリング', () => {
     expect(result.summary).not.toContain('Invalid request');
   });
 
+  it('model 名に / を含む場合、パストラバーサルを許さずエラーを返す', async () => {
+    const provider = new GeminiProvider({
+      ...baseSettings,
+      gemini_model: '../../../etc/passwd',
+    } as Settings);
+    const result = await provider.generateSummary('content', false, '');
+
+    expect(result.summary).toContain('Error:');
+    expect(result.summary).toContain('Invalid AI model name');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('model 名の特殊文字は URL パスセグメントとしてエンコードされる', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] }),
+    });
+
+    const provider = new GeminiProvider({
+      ...baseSettings,
+      gemini_model: 'weird model:v1',
+    } as Settings);
+    await provider.generateSummary('content', false, '');
+
+    const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('/models/weird%20model%3Av1:generateContent');
+  });
+
   it('ネットワークエラー時、内部エラー詳細を含まない', async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error('Failed to fetch: Network request failed'),

--- a/src/background/handlers/__tests__/systemHandlers.test.ts
+++ b/src/background/handlers/__tests__/systemHandlers.test.ts
@@ -424,9 +424,33 @@ describe('createLogForwardHandler', () => {
     const handler = createLogForwardHandler();
     const sendResponse = vi.fn();
 
-    await handler({ payload: { level: 'error', message: 'Oops', details: { x: 1 }, source: 'offscreen' } } as any, {} as any, sendResponse);
-    expect(logError).toHaveBeenCalledWith('Oops', { x: 1 }, expect.anything(), 'offscreen');
+    const sender = { url: 'chrome-extension://abc/offscreen.html' } as chrome.runtime.MessageSender;
+    await handler({ payload: { level: 'error', message: 'Oops', details: { x: 1 }, source: 'offscreen' } } as any, sender, sendResponse);
+    expect(logError).toHaveBeenCalledWith(
+      'Oops',
+      { x: 1, _sourceHintUntrusted: 'offscreen' },
+      expect.anything(),
+      'chrome-extension://abc/offscreen.html',
+    );
     expect(sendResponse).toHaveBeenCalledWith({ success: true });
+  });
+
+  it('derives _source from the sender, not the payload (VULN-019)', async () => {
+    const handler = createLogForwardHandler();
+    const sendResponse = vi.fn();
+    const sender = { url: 'chrome-extension://abc/dashboard.html' } as chrome.runtime.MessageSender;
+
+    await handler(
+      { payload: { level: 'error', message: 'forged', details: {}, source: 'service-worker' } } as any,
+      sender,
+      sendResponse,
+    );
+    expect(logError).toHaveBeenCalledWith(
+      'forged',
+      { _sourceHintUntrusted: 'service-worker' },
+      expect.anything(),
+      'chrome-extension://abc/dashboard.html',
+    );
   });
 
   it('forwards warn level logs', async () => {

--- a/src/background/handlers/__tests__/systemHandlers.test.ts
+++ b/src/background/handlers/__tests__/systemHandlers.test.ts
@@ -85,16 +85,25 @@ describe('createFetchUrlHandler', () => {
     expect(logError).toHaveBeenCalled();
   });
 
-  it('rejects when Content-Length exceeds limit', async () => {
+  it('rejects an oversized body even when Content-Length lies about a small size', async () => {
+    const oneMb = new Uint8Array(1024 * 1024);
+    let reads = 0;
     vi.mocked(fetchWithTimeout).mockResolvedValue({
       ok: true,
       status: 200,
       headers: {
-        get: vi.fn((name: string) =>
-          name === 'content-length' ? String(11 * 1024 * 1024) : null,
-        ),
+        // Lying header: claims 1 byte, streams far more.
+        get: vi.fn((name: string) => (name === 'content-length' ? '1' : null)),
       },
-      text: vi.fn().mockResolvedValue(''),
+      body: {
+        getReader: () => ({
+          read: () => {
+            reads += 1;
+            return Promise.resolve({ done: false, value: oneMb });
+          },
+          cancel: () => Promise.resolve(),
+        }),
+      },
     } as any);
 
     const handler = createFetchUrlHandler(deps);
@@ -102,6 +111,7 @@ describe('createFetchUrlHandler', () => {
     await handler({ payload: { url: 'https://example.com/list.txt' } } as any, {} as any, sendResponse);
 
     expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    expect(reads).toBeLessThan(20); // aborted before buffering the whole stream
   });
 
   it('rejects when actual text size exceeds limit', async () => {

--- a/src/background/handlers/systemHandlers.ts
+++ b/src/background/handlers/systemHandlers.ts
@@ -265,6 +265,28 @@ export function createConsentStateChangedHandler(deps: ConsentStateChangedHandle
   };
 }
 
+/**
+ * VULN-019 (CWE-290): derive the log attribution from the message sender, never
+ * from the payload. A `chrome-extension://` page (dashboard, popup, offscreen)
+ * could otherwise set `payload.source` to `service-worker` and forge the origin
+ * of a persisted log entry. Extension pages and the offscreen document share the
+ * same extension origin, so this yields the extension id, optionally narrowed by
+ * the page path when available.
+ */
+export function deriveLogSource(sender: chrome.runtime.MessageSender): string {
+  const raw = sender.url || sender.origin || '';
+  if (!raw) {
+    return 'unknown';
+  }
+  try {
+    const parsed = new URL(raw);
+    const page = parsed.pathname.split('/').pop();
+    return page ? `${parsed.protocol}//${parsed.host}/${page}` : `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return raw;
+  }
+}
+
 export function createLogForwardHandler() {
   return async (
     message: LogForwardMessage,
@@ -274,12 +296,21 @@ export function createLogForwardHandler() {
     // Sender authorization is enforced by the registry ('extension-only'); the
     // offscreen document is the expected caller.
     const { level, message: logMessage, details, source } = message.payload;
+    const derivedSource = deriveLogSource(sender);
+    // payload.source is an untrusted display hint only; it must not decide
+    // attribution. The neutralization boundary in logger/core.ts strips control
+    // chars / ANSI / newlines from logMessage and every string in details
+    // (VULN-044 co-parameter).
+    const enrichedDetails = {
+      ...(details ?? {}),
+      _sourceHintUntrusted: source,
+    };
     if (level === 'error') {
-      await logError(logMessage, details ?? {}, ErrorCode.INTERNAL_ERROR, source);
+      await logError(logMessage, enrichedDetails, ErrorCode.INTERNAL_ERROR, derivedSource);
     } else if (level === 'warn') {
-      await logWarn(logMessage, details ?? {}, undefined, source);
+      await logWarn(logMessage, enrichedDetails, undefined, derivedSource);
     } else {
-      await logDebug(logMessage, details ?? {}, source);
+      await logDebug(logMessage, enrichedDetails, derivedSource);
     }
     sendResponse({ success: true });
   };

--- a/src/background/handlers/systemHandlers.ts
+++ b/src/background/handlers/systemHandlers.ts
@@ -4,6 +4,7 @@ import { BADGE_COLORS } from '../../constants/appConstants.js';
 import { logDebug, logWarn, logError, ErrorCode } from '../../utils/logger.js';
 import { errorMessage } from '../../utils/errorUtils.js';
 import { createErrorResponse } from '../../utils/errorClassification.js';
+import { readBodyCapped } from '../../utils/readBodyCapped.js';
 import { updateSavedUrlEntry } from '../../utils/storage/savedUrlRepository.js';
 import type { PrivacyInfo } from '../../utils/privacyChecker.js';
 
@@ -112,16 +113,12 @@ export function createFetchUrlHandler(deps: FetchUrlHandlerDeps) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      // VULN-012 fix: check Content-Length header first
-      const contentLength = response.headers.get('content-length');
-      if (contentLength && parseInt(contentLength, 10) > MAX_FILTER_LIST_SIZE) {
-        throw new Error(`Filter list too large: ${Math.round(parseInt(contentLength, 10) / 1024 / 1024)}MB exceeds ${MAX_FILTER_LIST_SIZE / 1024 / 1024}MB limit`);
-      }
-
       const contentType = response.headers.get('content-type');
-      const text = await response.text();
+      // Cap the streamed body on actual bytes; Content-Length is not trusted
+      // (attacker can omit it via chunked transfer-encoding).
+      const text = await readBodyCapped(response, MAX_FILTER_LIST_SIZE);
 
-      // VULN-012 fix: also check actual text size after reading
+      // Defense in depth: keep the post-read size check.
       if (text.length > MAX_FILTER_LIST_SIZE) {
         throw new Error(`Filter list too large: ${Math.round(text.length / 1024 / 1024)}MB exceeds ${MAX_FILTER_LIST_SIZE / 1024 / 1024}MB limit`);
       }

--- a/src/background/obsidianClient.ts
+++ b/src/background/obsidianClient.ts
@@ -16,6 +16,7 @@ import {
     type ObsidianProtocol,
 } from '../utils/obsidianConfigValidator.js';
 import { buildObsidianConfig, type ObsidianConfig } from '../utils/obsidianConfigBuilder.js';
+import { readBodyCapped } from '../utils/readBodyCapped.js';
 
 /**
  * Problem #1: Fetchタイムアウト設定
@@ -189,14 +190,15 @@ export class ObsidianClient {
         }, FETCH_TIMEOUT_MS);
 
         if (!response.ok) {
-            // Guard against unbounded reads of potentially huge error responses
-            const contentLength = response.headers?.get('content-length');
+            // Cap the error body on actual bytes; Content-Length is not trusted.
             const MAX_ERROR_BODY_SIZE = 1024 * 1024; // 1MB
-            if (contentLength && parseInt(contentLength, 10) > MAX_ERROR_BODY_SIZE) {
-                addLog(LogType.ERROR, `Obsidian API Error: ${response.status} (response body too large: ${contentLength} bytes)`, { traceId });
+            let errorText: string;
+            try {
+                errorText = await readBodyCapped(response, MAX_ERROR_BODY_SIZE);
+            } catch {
+                addLog(LogType.ERROR, `Obsidian API Error: ${response.status} (response body too large or unreadable)`, { traceId });
                 throw new Error('Error: Failed to write to daily note. Please check your Obsidian connection.');
             }
-            const errorText = await response.text();
             addLog(LogType.ERROR, `Obsidian API Error: ${response.status} ${errorText}`, { traceId });
             throw new Error('Error: Failed to write to daily note. Please check your Obsidian connection.');
         }

--- a/src/background/obsidianSyncService.ts
+++ b/src/background/obsidianSyncService.ts
@@ -11,7 +11,7 @@ import { addLog, LogType } from '../utils/logger.js';
 import { errorMessage } from '../utils/errorUtils.js';
 import { StorageKeys } from '../utils/storage/types.js';
 import { settingsRepository, type SettingsReader } from '../utils/storage/SettingsRepository.js';
-import { sanitizeForObsidian, sanitizeUrlForMarkdownTarget } from '../utils/markdownSanitizer.js';
+import { sanitizeForObsidian, sanitizeForMarkdownLinkText, sanitizeUrlForMarkdownTarget } from '../utils/markdownSanitizer.js';
 import type { SyncTarget } from './syncTargets/SyncTarget.js';
 import { isCredentialConfigured } from './syncTargets/settingsConfiguredCheck.js';
 import { SyncBatchRunner, type PendingSyncRow } from './syncTargets/SyncBatchRunner.js';
@@ -59,7 +59,7 @@ export class ObsidianSyncService implements SyncTarget {
 
     try {
       // Use the existing ObsidianClient to append to daily note
-      const sanitizedTitle = sanitizeForObsidian(title || url || 'Untitled');
+      const sanitizedTitle = sanitizeForMarkdownLinkText(title || url || 'Untitled');
       const sanitizedUrl = sanitizeUrlForMarkdownTarget(url);
       const sanitizedSummary = summary ? sanitizeForObsidian(summary) : null;
       const markdown = `- [${sanitizedTitle}](${sanitizedUrl})${sanitizedSummary ? `: ${sanitizedSummary}` : ''}`;

--- a/src/background/pipeline/steps/formatMarkdownStep.ts
+++ b/src/background/pipeline/steps/formatMarkdownStep.ts
@@ -50,7 +50,7 @@ export const formatMarkdownStep: PipelineStepFunction = async (
   // Tags come from the AI summary (prompt-injection surface) — sanitize each one
   // before interpolating as `#${tag}` (VULN-008) to stop link/wikilink injection.
   const tags = privacyResult?.tags;
-  const tagPrefix = tags && tags.length > 0 ? tags.map(t => `#${sanitizeForObsidian(t)}`).join(' ') + ' ' : '';
+  const tagPrefix = tags && tags.length > 0 ? tags.map(t => `#${sanitizeForMarkdownLinkText(sanitizeForObsidian(t))}`).join(' ') + ' ' : '';
 
   // Create markdown
   const markdown = `- ${timestamp} [${sanitizedTitle}](${sanitizedUrl})\n    - ${tagPrefix}${finalSanitizedSummary}`;

--- a/src/background/syncTargets/gistSyncTarget.ts
+++ b/src/background/syncTargets/gistSyncTarget.ts
@@ -10,7 +10,7 @@ import { addLog, LogType } from '../../utils/logger.js';
 import { errorMessage } from '../../utils/errorUtils.js';
 import { SettingsRepository, settingsRepository, type SettingsReader } from '../../utils/storage/SettingsRepository.js';
 import { StorageKeys } from '../../utils/storage/types.js';
-import { sanitizeForObsidian, sanitizeUrlForMarkdownTarget } from '../../utils/markdownSanitizer.js';
+import { sanitizeForObsidian, sanitizeForMarkdownLinkText, sanitizeUrlForMarkdownTarget } from '../../utils/markdownSanitizer.js';
 import { CONNECTION_TEST_CACHE_MODE } from '../../utils/fetch.js';
 import { isCredentialConfigured } from './settingsConfiguredCheck.js';
 import { SyncBatchRunner, type PendingSyncRow } from './SyncBatchRunner.js';
@@ -46,7 +46,7 @@ export class GistSyncTarget implements SyncTarget {
       const pat = settings[StorageKeys.GITHUB_PAT] as string;
       const gistId = settings[StorageKeys.GIST_ID] as string | undefined;
       const defaultEntry = () => {
-        const safeTitle = sanitizeForObsidian(title || url || 'Untitled');
+        const safeTitle = sanitizeForMarkdownLinkText(title || url || 'Untitled');
         const safeUrl = sanitizeUrlForMarkdownTarget(url);
         const safeSummary = summary ? sanitizeForObsidian(summary) : null;
         return `- [${safeTitle}](${safeUrl})${safeSummary ? `: ${safeSummary}` : ''}`;

--- a/src/background/syncTargets/gistSyncTarget.ts
+++ b/src/background/syncTargets/gistSyncTarget.ts
@@ -11,7 +11,8 @@ import { errorMessage } from '../../utils/errorUtils.js';
 import { SettingsRepository, settingsRepository, type SettingsReader } from '../../utils/storage/SettingsRepository.js';
 import { StorageKeys } from '../../utils/storage/types.js';
 import { sanitizeForObsidian, sanitizeUrlForMarkdownTarget } from '../../utils/markdownSanitizer.js';
-import { CONNECTION_TEST_CACHE_MODE } from '../../utils/fetch.js';
+import { CONNECTION_TEST_CACHE_MODE, fetchWithTimeout } from '../../utils/fetch.js';
+import { readJsonCapped } from '../../utils/readBodyCapped.js';
 import { isCredentialConfigured } from './settingsConfiguredCheck.js';
 import { SyncBatchRunner, type PendingSyncRow } from './SyncBatchRunner.js';
 
@@ -117,13 +118,14 @@ export class GistSyncTarget implements SyncTarget {
       const settings = await new SettingsRepository().getAll();
       const pat = settings[StorageKeys.GITHUB_PAT] as string;
 
-      const response = await fetch(`${GIST_API_BASE}/user`, {
+      const response = await fetchWithTimeout(`${GIST_API_BASE}/user`, {
         headers: {
           Authorization: `token ${pat}`,
           'User-Agent': 'yasumaro-extension',
           Accept: 'application/vnd.github.v3+json',
         },
         cache: CONNECTION_TEST_CACHE_MODE,
+        skipCspValidation: true,
       });
 
       if (response.ok) {
@@ -144,8 +146,9 @@ export class GistSyncTarget implements SyncTarget {
   }
 
   private async createGist(content: string, pat: string): Promise<string> {
-    const response = await fetch(`${GIST_API_BASE}/gists`, {
+    const response = await fetchWithTimeout(`${GIST_API_BASE}/gists`, {
       method: 'POST',
+      skipCspValidation: true,
       headers: {
         Authorization: `token ${pat}`,
         'User-Agent': 'yasumaro-extension',
@@ -167,13 +170,14 @@ export class GistSyncTarget implements SyncTarget {
       throw new Error(`GitHub Gist creation failed: ${response.status}`);
     }
 
-    const data = await response.json() as { id: string };
+    const data = await readJsonCapped(response, 10 * 1024 * 1024) as { id: string };
     return data.id;
   }
 
   private async updateGist(gistId: string, content: string, pat: string): Promise<void> {
-    const response = await fetch(`${GIST_API_BASE}/gists/${gistId}`, {
+    const response = await fetchWithTimeout(`${GIST_API_BASE}/gists/${gistId}`, {
       method: 'PATCH',
+      skipCspValidation: true,
       headers: {
         Authorization: `token ${pat}`,
         'User-Agent': 'yasumaro-extension',

--- a/src/dashboard/__tests__/auditLogTsv.test.ts
+++ b/src/dashboard/__tests__/auditLogTsv.test.ts
@@ -22,6 +22,16 @@ describe('toTsvString', () => {
     expect(tsv).toContain('"open\tai"');
   });
 
+  it('neutralizes formula-trigger characters in fields', () => {
+    const rows = [
+      { id: 1, provider: '=1+1', url: '@SUM(A1)', created_at: 1721203200000 },
+      { id: 2, provider: '+cmd', url: '-2+3', created_at: 1721203200000 },
+    ];
+    const tsv = toTsvString(rows);
+    expect(tsv).toContain("1\t'=1+1\t'@SUM(A1)\t");
+    expect(tsv).toContain("2\t'+cmd\t'-2+3\t");
+  });
+
   it('handles empty rows', () => {
     const tsv = toTsvString([]);
     const lines = tsv.split('\n');

--- a/src/dashboard/__tests__/historyEntryRow.test.ts
+++ b/src/dashboard/__tests__/historyEntryRow.test.ts
@@ -130,6 +130,24 @@ describe('URL & Timestamp', () => {
     expect(urlEl.rel).toBe('noopener noreferrer');
   });
 
+  it('javascript: URL is rendered as text, not wired as an href', () => {
+    const row = makeHistoryEntryRow(
+      createMinimalEntry({ url: 'javascript:alert(1)' }), 0, 0, createMockState(), createMockElements(), vi.fn(), vi.fn(),
+    );
+    const urlEl = row.querySelector('.history-entry-url') as HTMLAnchorElement;
+    expect(urlEl).not.toBeNull();
+    expect(urlEl.getAttribute('href')).toBeNull();
+    expect(urlEl.textContent).toBe('javascript:alert(1)');
+  });
+
+  it('http: URL is still wired as an href', () => {
+    const row = makeHistoryEntryRow(
+      createMinimalEntry({ url: 'http://example.com/page' }), 0, 0, createMockState(), createMockElements(), vi.fn(), vi.fn(),
+    );
+    const urlEl = row.querySelector('.history-entry-url') as HTMLAnchorElement;
+    expect(urlEl.getAttribute('href')).toBe('http://example.com/page');
+  });
+
   it('timestamp matches toLocaleString format', () => {
     const ts = 1705300000000;
     const row = makeHistoryEntryRow(

--- a/src/dashboard/__tests__/historyPendingPanel.test.ts
+++ b/src/dashboard/__tests__/historyPendingPanel.test.ts
@@ -958,6 +958,48 @@ describe('historyPendingPanel', () => {
       });
     });
   });
+
+  describe('isSecureUrl gate on links', () => {
+    it('renderPendingPage: javascript: URL is not wired as an href', async () => {
+      const { renderPendingPage } = await import('../historyPendingPanel.js');
+      const pages = [createMockPage({ url: 'javascript:alert(1)' })];
+      const state = createMockState(pages);
+      const sortedPending = [...pages];
+      const { pendingSection, pendingList, pendingCurrentPageRef } = createPendingFixture();
+
+      renderPendingPage(state, {} as any, pendingSection, pendingList, sortedPending, pendingCurrentPageRef, vi.fn());
+
+      const anchor = pendingList.querySelector('a.history-entry-url') as HTMLAnchorElement;
+      expect(anchor).not.toBeNull();
+      expect(anchor.getAttribute('href')).toBeNull();
+    });
+
+    it('renderPendingPage: http: URL is still wired as an href', async () => {
+      const { renderPendingPage } = await import('../historyPendingPanel.js');
+      const pages = [createMockPage({ url: 'http://example.com/page' })];
+      const state = createMockState(pages);
+      const sortedPending = [...pages];
+      const { pendingSection, pendingList, pendingCurrentPageRef } = createPendingFixture();
+
+      renderPendingPage(state, {} as any, pendingSection, pendingList, sortedPending, pendingCurrentPageRef, vi.fn());
+
+      const anchor = pendingList.querySelector('a.history-entry-url') as HTMLAnchorElement;
+      expect(anchor.getAttribute('href')).toBe('http://example.com/page');
+    });
+
+    it('renderSkippedMode: javascript: URL is not wired as an href', async () => {
+      const { renderSkippedMode } = await import('../historyPendingPanel.js');
+      const pages = [createMockPage({ url: 'javascript:alert(1)' })];
+      const state = createMockState(pages);
+      const elements = { historyList: document.createElement('div'), historyStats: document.createElement('div') };
+
+      renderSkippedMode(state, elements as any, '', vi.fn());
+
+      const anchor = elements.historyList.querySelector('a.history-entry-url') as HTMLAnchorElement;
+      expect(anchor).not.toBeNull();
+      expect(anchor.getAttribute('href')).toBeNull();
+    });
+  });
 });
 
 function createMockState(pages: any[] = []): any {

--- a/src/dashboard/__tests__/models-dev-dialog.test.ts
+++ b/src/dashboard/__tests__/models-dev-dialog.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../utils/modelsDevApi.js', () => ({
   formatContextLimit: vi.fn().mockReturnValue('8K'),
   getApiKeyEnvName: vi.fn().mockImplementation((id: string) => `MOCK_${id.toUpperCase()}_KEY`),
   getApiKeyUrl: vi.fn().mockReturnValue(null),
+  isHttpsUrl: (v: unknown) => typeof v === 'string' && v.startsWith('https://'),
 }));
 
 vi.mock('../../utils/storage/types.js', async (importOriginal) => {
@@ -641,6 +642,27 @@ describe('ModelsDevDialog', () => {
       await vi.waitFor(() => {
         expect(document.getElementById('models-dev-dialog')!.classList.contains('hidden')).toBe(true);
       });
+    });
+
+    it('should reject a provider whose api is not https', async () => {
+      const { loadModelsDevData } = await import('../../utils/modelsDevApi.js');
+      (loadModelsDevData as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        providers: [
+          { id: 'evil', name: 'Evil', api: 'javascript:alert(1)', models: [{ id: 'm', isFreeTier: false, inputPrice: 0.01 }], isAggregator: false },
+        ],
+      });
+      const onSave = vi.fn();
+      const dialog = new ModelsDevDialog({ onSave });
+      await dialog.show();
+      (document.querySelector('.provider-item') as HTMLElement).click();
+      const apiKeyInput = document.getElementById('api-key-input') as HTMLInputElement;
+      apiKeyInput.value = 'test-key';
+      document.getElementById('dialog-save')?.click();
+      await vi.waitFor(() => {
+        const errorEl = document.getElementById('dialog-error');
+        expect(errorEl!.classList.contains('hidden')).toBe(false);
+      });
+      expect(onSave).not.toHaveBeenCalled();
     });
 
     it('should show error on saveSettings rejection', async () => {

--- a/src/dashboard/historyEntryRow.ts
+++ b/src/dashboard/historyEntryRow.ts
@@ -7,6 +7,7 @@ import { makeRecordTypeBadge, makeMaskBadge, makeCleansedBadge, makePrivacyModeB
 import { openTagEditModal } from './historyTagEditModal.js';
 import { getCachedMessage } from './historyState.js';
 import { isDegenerateOutput } from '../utils/llmOutputGuard.js';
+import { isSecureUrl } from '../utils/urlUtils.js';
 
 /** Shown in place of a stored summary that the guard flags as degenerate. */
 const DEGENERATE_SUMMARY_FALLBACK = '要約に失敗しました（AI出力が不自然なため）';
@@ -115,9 +116,13 @@ export function makeHistoryEntryRow(
 
   const urlEl = document.createElement('a');
   urlEl.className = 'history-entry-url';
-  urlEl.href = url;
-  urlEl.target = '_blank';
-  urlEl.rel = 'noopener noreferrer';
+  // Only wire an href for http/https. A stored entry with a javascript: (or
+  // other dangerous) scheme is shown as plain text, never as a clickable link.
+  if (isSecureUrl(url)) {
+    urlEl.href = url;
+    urlEl.target = '_blank';
+    urlEl.rel = 'noopener noreferrer';
+  }
   urlEl.textContent = url;
 
   topRow.appendChild(makeRecordTypeBadge(recordType));

--- a/src/dashboard/historyPendingPanel.ts
+++ b/src/dashboard/historyPendingPanel.ts
@@ -4,6 +4,7 @@ import type { PendingPage } from '../utils/pendingStorage.js';
 import { renderPendingReason } from './historyFilters.js';
 import { showRecordError, checkServiceWorkerAlive, sendMessageWithTimeout, createPaginationControls } from './historyUtils.js';
 import type { HistoryPanelState, HistoryElements } from './historyState.js';
+import { isSecureUrl } from '../utils/urlUtils.js';
 
 const PENDING_PAGE_SIZE = 10;
 
@@ -91,9 +92,13 @@ export function renderSkippedMode(
 
     const urlEl = document.createElement('a');
     urlEl.className = 'history-entry-url';
-    urlEl.href = page.url;
-    urlEl.target = '_blank';
-    urlEl.rel = 'noopener noreferrer';
+    // Re-opening a pending page is by design, but only for http/https — a
+    // dangerous scheme is shown as plain text, never as a clickable link.
+    if (isSecureUrl(page.url)) {
+      urlEl.href = page.url;
+      urlEl.target = '_blank';
+      urlEl.rel = 'noopener noreferrer';
+    }
     urlEl.textContent = page.title || page.url;
     topRow.appendChild(urlEl);
 
@@ -174,9 +179,11 @@ export function renderPendingPage(
 
     const urlEl = document.createElement('a');
     urlEl.className = 'history-entry-url';
-    urlEl.href = page.url;
-    urlEl.target = '_blank';
-    urlEl.rel = 'noopener noreferrer';
+    if (isSecureUrl(page.url)) {
+      urlEl.href = page.url;
+      urlEl.target = '_blank';
+      urlEl.rel = 'noopener noreferrer';
+    }
     urlEl.textContent = page.title || page.url;
 
     const metaEl = document.createElement('div');

--- a/src/dashboard/models-dev-dialog.ts
+++ b/src/dashboard/models-dev-dialog.ts
@@ -8,6 +8,7 @@ import {
     loadModelsDevData,
     getApiKeyEnvName,
     getApiKeyUrl,
+    isHttpsUrl,
 } from '../utils/modelsDevApi.js';
 import { saveSettings, getSettings } from '../utils/storage/settingsStore.js';
 import { StorageKeys } from '../utils/storage/types.js';
@@ -447,6 +448,13 @@ export class ModelsDevDialog {
         // Validation
         if (!apiKey) {
             this.showError('Please enter your API key');
+            return;
+        }
+
+        // The provider base URL is written to settings and later used to build
+        // request URLs — reject anything that is not an absolute https: URL.
+        if (!isHttpsUrl(this.selectedProvider.api)) {
+            this.showError('Selected provider has an invalid API endpoint');
             return;
         }
 

--- a/src/dashboard/utils/auditLogTsv.ts
+++ b/src/dashboard/utils/auditLogTsv.ts
@@ -19,10 +19,17 @@ function toIsoDate(ms: number): string {
 }
 
 function escapeTsvField(value: string): string {
-  if (value.includes('\t') || value.includes('\n') || value.includes('"')) {
-    return '"' + value.replace(/"/g, '""') + '"';
+  let str = value;
+  // CWE-1236: neutralize a leading formula-trigger character so a spreadsheet
+  // treats the cell as text instead of evaluating it. Mirrors escapeCsv in
+  // exportLogsService.ts.
+  if (/^[=+\-@]/.test(str)) {
+    str = `'${str}`;
   }
-  return value;
+  if (str.includes('\t') || str.includes('\n') || str.includes('"')) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
 }
 
 export function toTsvString(rows: AuditLogEntry[]): string {

--- a/src/utils/__tests__/markdownFormatter.test.ts
+++ b/src/utils/__tests__/markdownFormatter.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { formatEntryToMarkdown, formatEntriesToGenericMarkdown } from '../markdownFormatter.js';
-import { sanitizeForObsidian } from '../markdownSanitizer.js';
 import type { BrowsingLogEntry } from '../sqlite-types.js';
 
 const baseEntry: BrowsingLogEntry = {
@@ -88,16 +87,17 @@ describe('markdownFormatter', () => {
     expect(md).toContain('- URL: https://example.com/\\[click\\]\\(https://evil.com\\)');
   });
 
-  it('escapes markdown links in tags via sanitizeForObsidian', () => {
+  it('escapes markdown links in tags via link-text + obsidian sanitizers', () => {
     const entry = { ...baseEntry, tags: '[promo](https://evil.com),ai' };
     const md = formatEntryToMarkdown(entry);
-    expect(md).toContain('- Tags: #\\[promo\\]\\(https://evil.com\\) #ai');
+    // sanitizeForObsidian escapes the link, sanitizeForMarkdownLinkText escapes
+    // the resulting brackets/parens a second time (join-boundary safety).
+    expect(md).toContain('- Tags: #\\\\[promo\\\\]\\\\(https://evil.com\\\\) #ai');
   });
 
-  it('leaves standalone ] and # characters unchanged', () => {
+  it('escapes standalone ] in the title (link-text boundary safety)', () => {
     const title = 'Title with ] and #';
-    expect(sanitizeForObsidian(title)).toBe(title);
     const md = formatEntryToMarkdown({ ...baseEntry, title });
-    expect(md).toContain('# Title with ] and #');
+    expect(md).toContain('# Title with \\] and #');
   });
 });

--- a/src/utils/__tests__/markdownSanitizerBoundary.test.ts
+++ b/src/utils/__tests__/markdownSanitizerBoundary.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeForObsidian,
+  sanitizeForMarkdownLinkText,
+} from '../markdownSanitizer.js';
+
+describe('sanitizeForObsidian - HTML entity encoding (VULN-001)', () => {
+  it('encodes raw HTML tags into entities', () => {
+    const out = sanitizeForObsidian('<img src=x onerror=alert(1)>');
+    expect(out).toBe('&lt;img src=x onerror=alert(1)&gt;');
+    expect(out).not.toContain('<img');
+    expect(out).not.toContain('>');
+  });
+
+  it('encodes ampersand first to avoid double-encoding', () => {
+    expect(sanitizeForObsidian('a & b < c')).toBe('a &amp; b &lt; c');
+  });
+
+  it('does not double-encode an existing entity', () => {
+    // Given "&amp;", "&" -> "&amp;" produces "&amp;amp;" only if not careful.
+    // Spec requires "&"->"&amp;" first (single pass), so "&amp;" becomes "&amp;amp;".
+    // We assert the deterministic single-pass behaviour: every raw & is encoded.
+    expect(sanitizeForObsidian('&amp;')).toBe('&amp;amp;');
+  });
+
+  it('handles empty string', () => {
+    expect(sanitizeForObsidian('')).toBe('');
+  });
+
+  it('handles symbols-only input', () => {
+    expect(sanitizeForObsidian('<<>>&&')).toBe('&lt;&lt;&gt;&gt;&amp;&amp;');
+  });
+
+  it('preserves unicode text', () => {
+    expect(sanitizeForObsidian('日本語 テスト <b>')).toBe('日本語 テスト &lt;b&gt;');
+  });
+
+  it('does not touch markdown syntax chars', () => {
+    expect(sanitizeForObsidian('a *b* _c_ # d')).toBe('a *b* _c_ # d');
+  });
+
+  it('does not break Obsidian wikilinks structurally', () => {
+    // wikilink escaping already turns [[x]] into \[\[x\]\]; no HTML chars involved
+    expect(sanitizeForObsidian('[[Note]]')).toBe('\\[\\[Note\\]\\]');
+  });
+
+  it('guards non-string input', () => {
+    // @ts-expect-error testing runtime guard
+    expect(sanitizeForObsidian(null)).toBeNull();
+    // @ts-expect-error testing runtime guard
+    expect(sanitizeForObsidian(undefined)).toBeUndefined();
+    // @ts-expect-error testing runtime guard
+    expect(sanitizeForObsidian(123)).toBe(123);
+  });
+});
+
+describe('sanitizeForMarkdownLinkText - tag fragment safety', () => {
+  it('escapes bracket/paren fragments so links cannot reassemble', () => {
+    expect(sanitizeForMarkdownLinkText('bar](https://evil.example)')).toBe(
+      'bar\\]\\(https://evil.example\\)',
+    );
+  });
+});

--- a/src/utils/__tests__/modelsDevApi.test.ts
+++ b/src/utils/__tests__/modelsDevApi.test.ts
@@ -9,6 +9,9 @@ import {
   findProviderById,
   loadModelsDevData,
   getApiKeyEnvName,
+  getApiKeyUrl,
+  isHttpsUrl,
+  parseModelsDevData,
   type ModelsDevProvider,
   type ModelsDevModel,
   type ModelsDevData,
@@ -163,6 +166,69 @@ describe('modelsDevApi', () => {
 
       const result = await loadModelsDevData();
       expect(result).toBeNull();
+    });
+
+    it('should drop provider entries with a non-https api/doc', async () => {
+      const raw = {
+        generatedAt: 'x',
+        providers: [
+          {
+            id: 'good', name: 'Good', api: 'https://api.good.com',
+            doc: 'https://good.com/docs', env: [], isAggregator: false, models: [],
+          },
+          {
+            id: 'evil', name: 'Evil', api: 'javascript:alert(1)',
+            doc: 'https://evil.com/docs', env: [], isAggregator: false, models: [],
+          },
+          {
+            id: 'httpdoc', name: 'HttpDoc', api: 'https://api.httpdoc.com',
+            doc: 'http://httpdoc.com/docs', env: [], isAggregator: false, models: [],
+          },
+        ],
+        stats: {},
+      };
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(raw),
+      } as unknown as Response);
+
+      const result = await loadModelsDevData();
+      expect(result).not.toBeNull();
+      expect(result!.providers.map(p => p.id)).toEqual(['good']);
+    });
+
+    it('should return null when top-level shape is wrong', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ nope: true }),
+      } as unknown as Response);
+
+      expect(await loadModelsDevData()).toBeNull();
+    });
+  });
+
+  describe('isHttpsUrl', () => {
+    it('accepts absolute https URLs only', () => {
+      expect(isHttpsUrl('https://example.com')).toBe(true);
+      expect(isHttpsUrl('http://example.com')).toBe(false);
+      expect(isHttpsUrl('javascript:alert(1)')).toBe(false);
+      expect(isHttpsUrl('/relative')).toBe(false);
+      expect(isHttpsUrl('')).toBe(false);
+      expect(isHttpsUrl(undefined)).toBe(false);
+    });
+  });
+
+  describe('parseModelsDevData', () => {
+    it('returns null for non-object / missing providers', () => {
+      expect(parseModelsDevData(null)).toBeNull();
+      expect(parseModelsDevData({})).toBeNull();
+    });
+  });
+
+  describe('getApiKeyUrl', () => {
+    it('returns undefined for a non-https doc fallback', () => {
+      expect(getApiKeyUrl('unknown-provider', 'javascript:alert(1)')).toBeUndefined();
+      expect(getApiKeyUrl('unknown-provider', 'https://ok.com/keys')).toBe('https://ok.com/keys');
     });
   });
 });

--- a/src/utils/__tests__/readBodyCapped.test.ts
+++ b/src/utils/__tests__/readBodyCapped.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { readBodyCapped, ResponseBodyTooLargeError } from '../readBodyCapped.js';
+
+/**
+ * Build a Response-like object whose body streams the given chunks.
+ * Content-Length header is intentionally controllable (and may lie).
+ */
+function makeStreamingResponse(
+  chunks: Uint8Array[],
+  opts: { contentLength?: string; failAfter?: number } = {},
+): Response {
+  let index = 0;
+  const reader = {
+    read(): Promise<{ done: boolean; value?: Uint8Array }> {
+      if (opts.failAfter !== undefined && index >= opts.failAfter) {
+        return Promise.reject(new Error('network read aborted'));
+      }
+      if (index >= chunks.length) {
+        return Promise.resolve({ done: true, value: undefined });
+      }
+      const value = chunks[index];
+      index += 1;
+      return Promise.resolve({ done: false, value });
+    },
+    cancel(): Promise<void> {
+      return Promise.resolve();
+    },
+  };
+  const headers = new Map<string, string>();
+  if (opts.contentLength !== undefined) {
+    headers.set('content-length', opts.contentLength);
+  }
+  return {
+    body: { getReader: () => reader },
+    headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+  } as unknown as Response;
+}
+
+const enc = new TextEncoder();
+
+describe('readBodyCapped', () => {
+  it('reads a body that is under the cap', async () => {
+    const res = makeStreamingResponse([enc.encode('hello world')]);
+    await expect(readBodyCapped(res, 100)).resolves.toBe('hello world');
+  });
+
+  it('reads an empty body', async () => {
+    const res = makeStreamingResponse([]);
+    await expect(readBodyCapped(res, 10)).resolves.toBe('');
+  });
+
+  it('accepts a body exactly at the cap', async () => {
+    const res = makeStreamingResponse([enc.encode('abcde')]);
+    await expect(readBodyCapped(res, 5)).resolves.toBe('abcde');
+  });
+
+  it('rejects a body one byte over the cap', async () => {
+    const res = makeStreamingResponse([enc.encode('abcdef')]);
+    await expect(readBodyCapped(res, 5)).rejects.toBeInstanceOf(ResponseBodyTooLargeError);
+  });
+
+  it('rejects when many 1-byte chunks exceed the cap', async () => {
+    const chunks = Array.from({ length: 20 }, (_, i) => enc.encode(String(i % 10)));
+    const res = makeStreamingResponse(chunks);
+    await expect(readBodyCapped(res, 10)).rejects.toBeInstanceOf(ResponseBodyTooLargeError);
+  });
+
+  it('ignores a lying Content-Length and caps on actual bytes', async () => {
+    const big = enc.encode('x'.repeat(50));
+    const res = makeStreamingResponse([big], { contentLength: '10' });
+    await expect(readBodyCapped(res, 20)).rejects.toBeInstanceOf(ResponseBodyTooLargeError);
+  });
+
+  it('does not rely on Content-Length to allow an under-cap body', async () => {
+    const res = makeStreamingResponse([enc.encode('short')], { contentLength: '999999999' });
+    await expect(readBodyCapped(res, 100)).resolves.toBe('short');
+  });
+
+  it('propagates a reader abnormal termination as an Error', async () => {
+    const res = makeStreamingResponse([enc.encode('a'), enc.encode('b')], { failAfter: 1 });
+    await expect(readBodyCapped(res, 100)).rejects.toThrow(/aborted/);
+  });
+
+  it('throws a classifiable Error (not null) when body is missing', async () => {
+    const res = { body: null, headers: { get: () => null } } as unknown as Response;
+    await expect(readBodyCapped(res, 100)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('the too-large error message mentions the limit', async () => {
+    const res = makeStreamingResponse([enc.encode('abcdef')]);
+    await expect(readBodyCapped(res, 5)).rejects.toThrow(/too large/i);
+  });
+});

--- a/src/utils/__tests__/storage-buildAllowedUrls.test.ts
+++ b/src/utils/__tests__/storage-buildAllowedUrls.test.ts
@@ -143,6 +143,18 @@ describe('storage - buildAllowedUrls', () => {
             expect(allowedUrls.has('https://raw.githubusercontent.com')).toBe(true);
         });
 
+        it('should not add non-whitelisted uBlock source origins (no self-allow)', () => {
+            const settings = {
+                [StorageKeys.UBLOCK_SOURCES]: [
+                    { url: 'https://evil.example.com/filters.txt' },
+                ]
+            };
+
+            const allowedUrls = buildAllowedUrls(settings);
+
+            expect(allowedUrls.has('https://evil.example.com')).toBe(false);
+        });
+
         it('should handle empty settings', () => {
             const allowedUrls = buildAllowedUrls({});
             

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -349,15 +349,29 @@ describe('buildAllowedUrls - edge cases', () => {
       whitelist_mode: true,
       ublock_sources: [
         { url: 'not-a-valid-url', name: 'Test' },
-        { url: 'https://example.com/list.txt', name: 'Valid' },
+        { url: 'https://raw.githubusercontent.com/u/r/list.txt', name: 'Valid' },
       ],
     } as unknown as Settings;
 
     const allowedUrls = await buildAllowedUrls(settings);
 
-    // Fixed 8 + 1 valid uBlock origin = 9 total
-    expect(allowedUrls.size).toBe(9);
-    expect(allowedUrls.has('https://example.com')).toBe(true);
+    // The whitelisted origin is already in the fixed set, so the size is
+    // unchanged; the non-whitelisted / invalid entries add nothing.
+    expect(allowedUrls.size).toBe(8);
+    expect(allowedUrls.has('https://raw.githubusercontent.com')).toBe(true);
+  });
+
+  it('does not add non-whitelisted uBlock source origins (no self-allow)', async () => {
+    const settings = {
+      whitelist_mode: true,
+      ublock_sources: [
+        { url: 'https://example.com/list.txt', name: 'NotWhitelisted' },
+      ],
+    } as unknown as Settings;
+
+    const allowedUrls = await buildAllowedUrls(settings);
+
+    expect(allowedUrls.has('https://example.com')).toBe(false);
   });
 });
 

--- a/src/utils/allowedUrls.ts
+++ b/src/utils/allowedUrls.ts
@@ -87,7 +87,13 @@ export function buildAllowedUrls(
         if (source.url && source.url !== 'manual') {
             try {
                 const parsed = new URL(source.url);
-                allowedUrls.add(normalizeUrl(parsed.origin));
+                // Gate on the whitelist: a stored ublock source must not be able
+                // to add an arbitrary origin to the allow list on its own.
+                if (isDomainInWhitelistFunc(source.url)) {
+                    allowedUrls.add(normalizeUrl(parsed.origin));
+                } else {
+                    console.warn(`uBlock source origin not in whitelist, skipped: ${parsed.origin}`);
+                }
             } catch (_e) {
                 // 無効なURLは無視
             }

--- a/src/utils/logger/__tests__/logNeutralization.test.ts
+++ b/src/utils/logger/__tests__/logNeutralization.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { neutralizeLogText, LINE_BREAK_REPLACEMENT } from '../neutralize.js';
+
+const ESC = String.fromCharCode(0x1b);
+const NUL = String.fromCharCode(0x00);
+const DEL = String.fromCharCode(0x7f);
+
+describe('neutralizeLogText', () => {
+  it('replaces LF with a visible separator (not removal)', () => {
+    expect(neutralizeLogText('a\nb')).toBe(`a${LINE_BREAK_REPLACEMENT}b`);
+  });
+
+  it('replaces CRLF and lone CR with a single separator each', () => {
+    expect(neutralizeLogText('a\r\nb\rc')).toBe(
+      `a${LINE_BREAK_REPLACEMENT}b${LINE_BREAK_REPLACEMENT}c`,
+    );
+  });
+
+  it('handles empty string', () => {
+    expect(neutralizeLogText('')).toBe('');
+  });
+
+  it('collapses consecutive newlines into consecutive separators', () => {
+    expect(neutralizeLogText('a\n\n\nb')).toBe(
+      `a${LINE_BREAK_REPLACEMENT}${LINE_BREAK_REPLACEMENT}${LINE_BREAK_REPLACEMENT}b`,
+    );
+  });
+
+  it('removes ANSI CSI colour sequences but keeps the wrapped text', () => {
+    expect(neutralizeLogText(`${ESC}[31mred${ESC}[0m`)).toBe('red');
+  });
+
+  it('removes NUL and DEL control characters', () => {
+    expect(neutralizeLogText(`a${NUL}b${DEL}c`)).toBe('abc');
+  });
+
+  it('handles mixed ANSI, control chars and newlines together', () => {
+    const forged = `${ESC}[32mok${NUL}\n[Logger:fake] forged${ESC}[0m`;
+    const out = neutralizeLogText(forged);
+    expect(out).not.toContain('\n');
+    expect(out).not.toContain(ESC);
+    expect(out).not.toContain(NUL);
+    expect(out).toBe(`ok${LINE_BREAK_REPLACEMENT}[Logger:fake] forged`);
+  });
+
+  it('preserves emoji and other multi-byte characters', () => {
+    expect(neutralizeLogText('done 🎉 完了')).toBe('done 🎉 完了');
+  });
+
+  it('leaves a lone ESC without a CSI intro (removed as a control char, no over-eating)', () => {
+    expect(neutralizeLogText(`press ${ESC} then A`)).toBe('press  then A');
+  });
+
+  it('is a pure function over a huge body without throwing', () => {
+    const huge = ('x\n'.repeat(100_000));
+    const out = neutralizeLogText(huge);
+    expect(out).not.toContain('\n');
+    expect(out.startsWith(`x${LINE_BREAK_REPLACEMENT}x`)).toBe(true);
+  });
+});

--- a/src/utils/logger/__tests__/logNeutralizationIntegration.test.ts
+++ b/src/utils/logger/__tests__/logNeutralizationIntegration.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Integration: the logger persistence boundary neutralizes untrusted text.
+ * Covers VULN-044 (multi-line / ANSI / control-char injection into the log) and
+ * the PII-mask ordering contract (mask first, neutralize second).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { addLog, flushLogs, getLogs, clearLogs } from '../core.js';
+
+const ESC = String.fromCharCode(0x1b);
+const NUL = String.fromCharCode(0x00);
+const originalNodeEnv = process.env.NODE_ENV;
+
+beforeEach(async () => {
+  process.env.NODE_ENV = 'test';
+  await clearLogs();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
+describe('logger persistence boundary neutralization', () => {
+  it('single-lines a multi-line Obsidian-style error body (VULN-044)', async () => {
+    const obsidianBody = `Obsidian API Error: 500\n[Logger:fake] forged entry\n${NUL}`;
+    await addLog('ERROR', obsidianBody, {});
+    await flushLogs(true);
+
+    const [entry] = await getLogs();
+    expect(entry.message).not.toContain('\n');
+    expect(entry.message).not.toContain(NUL);
+    expect(entry.message).toContain('[Logger:fake] forged entry');
+  });
+
+  it('strips ANSI escape sequences from a persisted message', async () => {
+    await addLog('ERROR', `${ESC}[31mObsidian API Error: 401${ESC}[0m`, {});
+    await flushLogs(true);
+
+    const [entry] = await getLogs();
+    expect(entry.message).not.toContain(ESC);
+    expect(entry.message).toBe('Obsidian API Error: 401');
+  });
+
+  it('neutralizes multi-line strings nested in details', async () => {
+    await addLog('ERROR', 'Obsidian API Error', { errorText: `line1\nline2` });
+    await flushLogs(true);
+
+    const [entry] = await getLogs();
+    expect(String(entry.details?.errorText)).not.toContain('\n');
+  });
+
+  it('PII regression: a PII string is still masked identically when combined with neutralization (mask before neutralize)', async () => {
+    await addLog('ERROR', 'auth failed for user@example.com\nretrying', {});
+    await addLog('INFO', 'plain user@example.com', {});
+    await flushLogs(true);
+
+    const logs = await getLogs();
+    const combined = logs.find((l) => l.type === 'ERROR');
+    const plain = logs.find((l) => l.type === 'INFO');
+    expect(combined?.message).not.toContain('user@example.com');
+    expect(combined?.message).not.toContain('\n');
+    // The mask runs before neutralization, so the masked token is identical to
+    // the newline-free case.
+    expect(plain?.message).not.toContain('user@example.com');
+    const maskedToken = plain?.message.replace('plain ', '');
+    expect(combined?.message).toContain(maskedToken as string);
+  });
+});

--- a/src/utils/logger/core.ts
+++ b/src/utils/logger/core.ts
@@ -6,6 +6,7 @@
  * External interface (addLog / getLogs / clearLogs / flushLogs) is unchanged.
  */
 import { sanitizeRegex } from '../piiSanitizer.js';
+import { neutralizeLogText } from './neutralize.js';
 import { LogBuffer } from './buffer.js';
 import { sanitizeLogDetails } from './sanitize.js';
 import { ChromeStorageLogAdapter, type LogStorageAdapter } from './storageAdapter.js';
@@ -62,6 +63,8 @@ export async function addLog<T extends object = Record<string, unknown>>(
       return;
     }
 
+    // Order: PII mask first (matches on original text), then neutralize control
+    // bytes / ANSI / line breaks in the persisted result. See neutralize.ts.
     const sanitizedMessage = await sanitizeRegex(message);
     const { traceId: traceIdValue, ...restDetails } = details as Record<string, unknown>;
     const traceId = typeof traceIdValue === 'string' ? traceIdValue : undefined;
@@ -77,7 +80,9 @@ export async function addLog<T extends object = Record<string, unknown>>(
             })(),
       timestamp: Date.now(),
       type,
-      message: sanitizedMessage.maskedItems.length > 0 ? sanitizedMessage.text : message,
+      message: neutralizeLogText(
+        sanitizedMessage.maskedItems.length > 0 ? sanitizedMessage.text : message,
+      ),
       details: await sanitizeLogDetails(restDetails),
       ...pickDefined({ traceId }),
     };

--- a/src/utils/logger/neutralize.ts
+++ b/src/utils/logger/neutralize.ts
@@ -1,0 +1,40 @@
+/**
+ * logger/neutralize.ts
+ * Pure neutralization of untrusted text before it is persisted into the log.
+ *
+ * The persisted log is the primary forensic record. External strings (Obsidian
+ * error bodies, forwarded messages) must not be able to break the line
+ * structure, inject fake entries, or smuggle terminal escape sequences.
+ *
+ * Order contract: this runs AFTER the PII mask (sanitizeRegex). The PII mask
+ * matches on the original text; neutralization only rewrites control bytes in
+ * the already-masked result, so mask coverage is unaffected.
+ */
+
+/** Visible replacement for a neutralized line break; keeps the text readable. */
+export const LINE_BREAK_REPLACEMENT = ' ⏎ ';
+
+// ANSI CSI sequences: ESC "[" params/intermediates, final byte in 0x40-0x7E.
+// Only CSI is targeted so a lone ESC (e.g. a literal "esc key" mention) in
+// legitimate prose is handled by the generic control-char pass instead, rather
+// than eating the characters that follow it.
+const ANSI_CSI = new RegExp('\\u001b\\[[0-?]*[ -/]*[@-~]', 'g');
+
+const LINE_BREAKS = /\r\n|\r|\n/g;
+
+// C0 control chars (U+0000-U+001F) and DEL (U+007F), excluding \n and \r which
+// are handled by LINE_BREAKS above.
+const OTHER_CONTROLS = new RegExp('[\\u0000-\\u0009\\u000b\\u000c\\u000e-\\u001f\\u007f]', 'g');
+
+/**
+ * Neutralize a single string for safe persistence.
+ * - CR/LF (any combination) -> a visible separator
+ * - ANSI CSI escape sequences -> removed
+ * - other C0 control chars + DEL -> removed
+ */
+export function neutralizeLogText(input: string): string {
+  return input
+    .replace(ANSI_CSI, '')
+    .replace(LINE_BREAKS, LINE_BREAK_REPLACEMENT)
+    .replace(OTHER_CONTROLS, '');
+}

--- a/src/utils/logger/sanitize.ts
+++ b/src/utils/logger/sanitize.ts
@@ -1,4 +1,5 @@
 import { sanitizeRegex } from '../piiSanitizer.js';
+import { neutralizeLogText } from './neutralize.js';
 
 // セキュリティ強化: log sanitization への深度制限と循環参照保護
 // redaction.ts と整合
@@ -63,12 +64,13 @@ async function sanitizeLogDetails(
     }
 
     if (typeof value === 'string') {
+      // Order: PII mask first, then neutralize control bytes / ANSI / newlines.
       const result = await sanitizeRegex(value);
       if (result.maskedItems.length > 0) {
-        sanitized[key] = result.text;
+        sanitized[key] = neutralizeLogText(result.text);
         sanitized[`${key}_maskedTypes`] = result.maskedItems.map((m) => (typeof m === 'string' ? m : m.type));
       } else {
-        sanitized[key] = value;
+        sanitized[key] = neutralizeLogText(value);
       }
     } else if (typeof value === 'object') {
       if (Array.isArray(value)) {
@@ -115,9 +117,9 @@ async function sanitizeArray(
     if (typeof item === 'string') {
       const result = await sanitizeRegex(item);
       if (result.maskedItems.length > 0) {
-        sanitized.push(result.text);
+        sanitized.push(neutralizeLogText(result.text));
       } else {
-        sanitized.push(item);
+        sanitized.push(neutralizeLogText(item));
       }
     } else if (typeof item === 'object') {
       if (Array.isArray(item)) {

--- a/src/utils/markdownFormatter.ts
+++ b/src/utils/markdownFormatter.ts
@@ -2,11 +2,11 @@ import { sanitizeForObsidian, sanitizeForMarkdownLinkText, sanitizeUrlForMarkdow
 import type { BrowsingLogEntry } from './sqlite-types.js';
 
 export function formatEntryToMarkdown(entry: BrowsingLogEntry): string {
-  const title = sanitizeForObsidian(entry.title || entry.url || 'Untitled');
+  const title = sanitizeForMarkdownLinkText(entry.title || entry.url || 'Untitled');
   const url = sanitizeForObsidian(entry.url);
   const summary = sanitizeForObsidian((entry.summary || 'Summary not available.').replace(/\n+/g, ' ').replace(/  +/g, ' ').trim());
   const tags = entry.tags
-    ? entry.tags.split(',').map(t => t.trim()).filter(Boolean).map(t => `#${sanitizeForObsidian(t)}`).join(' ')
+    ? entry.tags.split(',').map(t => t.trim()).filter(Boolean).map(t => `#${sanitizeForMarkdownLinkText(sanitizeForObsidian(t))}`).join(' ')
     : '';
   const date = new Date(entry.created_at).toLocaleString();
 

--- a/src/utils/markdownSanitizer.ts
+++ b/src/utils/markdownSanitizer.ts
@@ -103,6 +103,8 @@ export function sanitizeUrlForMarkdownTarget(url: string): string {
  * 【処理内容】:
  * 1. スキーム非依存のMarkdownリンクエスケープ（sanitizeAllMarkdownLinks）
  * 2. Obsidian wikilink/embed 構文のエスケープ（escapeObsidianWikilinks）
+ * 3. HTML エンティティ化（&, <, >）— 生 HTML がノートに verbatim で
+ *    到達するのを防ぐ（VULN-001）
  *
  * @param {string} content - サニタイズするコンテンツ
  * @returns {string} サニタイズされたコンテンツ
@@ -117,6 +119,14 @@ export function sanitizeForObsidian(content: string): string {
 
     // Escape Obsidian wikilink/embed syntax (VULN-002/005 fix)
     sanitized = escapeObsidianWikilinks(sanitized);
+
+    // HTML entity encoding (VULN-001). `&` must be encoded first so the `;` of
+    // the subsequent `&lt;` / `&gt;` entities is not itself re-encoded.
+    // Markdown syntax characters are deliberately left untouched.
+    sanitized = sanitized
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
 
     return sanitized;
 }

--- a/src/utils/modelsDevApi.ts
+++ b/src/utils/modelsDevApi.ts
@@ -54,6 +54,52 @@ export function findProviderById(providers: ModelsDevProvider[], providerId: str
 }
 
 /**
+ * True only for an absolute https: URL. `doc`/`api` from the provider asset
+ * are used as link hrefs and as the stored provider base URL, so anything that
+ * is not https: (javascript:, http:, data:, relative) is rejected.
+ */
+export function isHttpsUrl(value: unknown): value is string {
+    if (typeof value !== 'string' || value === '') return false;
+    try {
+        return new URL(value).protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Runtime schema check for one provider entry. The asset is bundled today
+ * (chrome.runtime.getURL), so this is defense-in-depth against a tampered or
+ * malformed file; it becomes load-bearing if the source ever moves to a
+ * remote fetch.
+ */
+export function isValidModelsDevProvider(p: unknown): p is ModelsDevProvider {
+    if (typeof p !== 'object' || p === null) return false;
+    const o = p as Record<string, unknown>;
+    return (
+        typeof o.id === 'string' &&
+        typeof o.name === 'string' &&
+        isHttpsUrl(o.api) &&
+        isHttpsUrl(o.doc) &&
+        typeof o.isAggregator === 'boolean' &&
+        Array.isArray(o.models) &&
+        Array.isArray(o.env)
+    );
+}
+
+/**
+ * Validates and narrows raw asset JSON. Returns null if the top-level shape is
+ * wrong; otherwise keeps only the provider entries that pass the schema check.
+ */
+export function parseModelsDevData(raw: unknown): ModelsDevData | null {
+    if (typeof raw !== 'object' || raw === null) return null;
+    const o = raw as Record<string, unknown>;
+    if (!Array.isArray(o.providers)) return null;
+    const providers = o.providers.filter(isValidModelsDevProvider);
+    return { ...(o as unknown as ModelsDevData), providers };
+}
+
+/**
  * Load models.dev data from extension assets
  */
 export async function loadModelsDevData(): Promise<ModelsDevData | null> {
@@ -63,7 +109,12 @@ export async function loadModelsDevData(): Promise<ModelsDevData | null> {
             console.warn('[ModelsDev] Failed to load provider data:', response.status);
             return null;
         }
-        return await response.json() as ModelsDevData;
+        const parsed = parseModelsDevData(await response.json());
+        if (!parsed) {
+            console.warn('[ModelsDev] Provider data failed schema validation');
+            return null;
+        }
+        return parsed;
     } catch (error) {
         console.warn('[ModelsDev] Error loading provider data:', error);
         return null;
@@ -146,5 +197,6 @@ const API_KEY_URLS: Record<string, string> = {
  * Returns the known URL if available, falls back to the provider's doc URL.
  */
 export function getApiKeyUrl(providerId: string, docUrl?: string): string | undefined {
-    return API_KEY_URLS[providerId] ?? docUrl;
+    const candidate = API_KEY_URLS[providerId] ?? docUrl;
+    return isHttpsUrl(candidate) ? candidate : undefined;
 }

--- a/src/utils/obsidianConfigValidator.ts
+++ b/src/utils/obsidianConfigValidator.ts
@@ -5,6 +5,7 @@
  */
 
 import { addLog, LogType } from './logger.js';
+import { readBodyCapped } from './readBodyCapped.js';
 
 /** Protocol type used by Obsidian Local REST API. */
 export type ObsidianProtocol = 'http' | 'https';
@@ -141,14 +142,10 @@ export function validateObsidianPort(port: string | number | undefined | null): 
  * @throws Error with name='AbortError' if body read times out
  */
 export async function readBodyWithTimeout(response: Response): Promise<string> {
-    // Guard against unbounded reads of potentially huge responses
-    const contentLength = response.headers?.get('content-length');
+    // Cap the streamed body on actual bytes (Content-Length can be omitted or lie).
     const MAX_BODY_SIZE = 10 * 1024 * 1024; // 10MB
-    if (contentLength && parseInt(contentLength, 10) > MAX_BODY_SIZE) {
-        throw new Error(`Response body too large: ${Math.round(parseInt(contentLength, 10) / 1024 / 1024)}MB exceeds ${MAX_BODY_SIZE / 1024 / 1024}MB limit`);
-    }
 
-    const textPromise = response.text();
+    const textPromise = readBodyCapped(response, MAX_BODY_SIZE);
     // Suppress unhandled rejection when timeout wins the race
     textPromise.catch(() => {});
 

--- a/src/utils/readBodyCapped.ts
+++ b/src/utils/readBodyCapped.ts
@@ -1,0 +1,129 @@
+/**
+ * readBodyCapped.ts
+ *
+ * Streaming response-body reader with a hard byte cap.
+ *
+ * Why not response.text()/json() directly: those buffer the entire response
+ * into Service Worker memory before returning (measured 64-200MB for hostile
+ * responses), and the size guards that precede them trust the Content-Length
+ * header, which an attacker omits trivially via chunked transfer-encoding
+ * (CWE-400). This reader pulls the body one chunk at a time through
+ * response.body.getReader(), keeps a running byte counter, and aborts the read
+ * as soon as the counter exceeds maxBytes -- independent of any header.
+ */
+
+/**
+ * Thrown when the streamed body exceeds the caller's byte cap.
+ * A concrete Error subclass (never a null return) so callers stay on the
+ * existing errorUtils / error-classification path instead of hitting a
+ * TypeError on a null.
+ */
+export class ResponseBodyTooLargeError extends Error {
+  readonly maxBytes: number;
+
+  constructor(maxBytes: number) {
+    super(
+      `Response body too large: exceeds ${Math.round(maxBytes / 1024 / 1024)}MB limit`,
+    );
+    this.name = 'ResponseBodyTooLargeError';
+    this.maxBytes = maxBytes;
+  }
+}
+
+/**
+ * Read a response body as text, aborting if it exceeds maxBytes.
+ *
+ * @param response - fetch Response (or a compatible object exposing
+ *   `body.getReader()`)
+ * @param maxBytes - hard cap on the number of body bytes to buffer
+ * @returns the decoded body text
+ * @throws ResponseBodyTooLargeError when the running byte count exceeds maxBytes
+ * @throws Error when the response exposes no readable body, or the underlying
+ *   reader terminates abnormally
+ */
+function byteLength(text: string): number {
+  return new TextEncoder().encode(text).byteLength;
+}
+
+function hasReadableStream(response: Response): boolean {
+  const body: unknown = response.body;
+  return (
+    body !== null &&
+    typeof body === 'object' &&
+    typeof (body as { getReader?: unknown }).getReader === 'function'
+  );
+}
+
+/**
+ * Read and JSON-parse a response body under a byte cap.
+ *
+ * When the response exposes a readable stream (every real fetch Response does),
+ * the body is streamed through readBodyCapped and then JSON.parse'd. Callers
+ * keep their existing type assertions on the returned value.
+ *
+ * @throws ResponseBodyTooLargeError when the body exceeds maxBytes
+ * @throws SyntaxError when the capped body is not valid JSON
+ */
+export async function readJsonCapped(response: Response, maxBytes: number): Promise<unknown> {
+  if (hasReadableStream(response)) {
+    return JSON.parse(await readBodyCapped(response, maxBytes));
+  }
+  // Host/mock without a readable stream: fall back to Response.json(), still
+  // guarding the buffered result would require re-serializing; callers here are
+  // test doubles and non-streaming runtimes, not an attack surface.
+  if (typeof response.json === 'function') {
+    return response.json();
+  }
+  return JSON.parse(await readBodyCapped(response, maxBytes));
+}
+
+export async function readBodyCapped(response: Response, maxBytes: number): Promise<string> {
+  const body = response.body;
+  if (!body || typeof body.getReader !== 'function') {
+    // Real fetch Responses always expose a readable stream; this branch is for
+    // hosts/mocks that only implement Response.text(). Still enforce the cap on
+    // the buffered result so callers never receive an oversized string.
+    if (typeof response.text === 'function') {
+      // Size limit guard: the buffered text is rejected if it exceeds this.
+      const sizeLimit = maxBytes;
+      const text = await response.text();
+      if (byteLength(text) > sizeLimit) {
+        throw new ResponseBodyTooLargeError(sizeLimit);
+      }
+      return text;
+    }
+    throw new Error('Response has no readable body stream');
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  const parts: string[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+      total += value.byteLength;
+      if (total > maxBytes) {
+        throw new ResponseBodyTooLargeError(maxBytes);
+      }
+      parts.push(decoder.decode(value, { stream: true }));
+    }
+  } finally {
+    // Release the underlying connection promptly on both success and abort.
+    try {
+      await reader.cancel();
+    } catch {
+      // best effort
+    }
+  }
+
+  parts.push(decoder.decode());
+  return parts.join('');
+}

--- a/src/utils/storage/urlWhitelist.ts
+++ b/src/utils/storage/urlWhitelist.ts
@@ -136,7 +136,13 @@ export function buildAllowedUrls(settings: Settings): Set<string> {
         if (source.url && source.url !== 'manual') {
             try {
                 const parsed = new URL(source.url);
-                allowedUrls.add(normalizeUrl(parsed.origin));
+                // Gate on the whitelist: a stored ublock source must not be able
+                // to add an arbitrary origin to the allow list on its own.
+                if (isDomainInWhitelist(source.url)) {
+                    allowedUrls.add(normalizeUrl(parsed.origin));
+                } else {
+                    console.warn(`uBlock source origin not in whitelist, skipped: ${parsed.origin}`);
+                }
             } catch (_e) {
                 // ignore invalid URL
             }

--- a/src/utils/trustDb/__tests__/lockContract.test.ts
+++ b/src/utils/trustDb/__tests__/lockContract.test.ts
@@ -1,0 +1,177 @@
+/**
+ * lockContract.test.ts
+ * Lock / CAS API contract tests (VULN-028 / VULN-029, CWE-667 / CWE-362).
+ *
+ * Two invariants every lock-guarded update site must uphold:
+ *  1. finally-coverage: an in-flight lock/flag is released even when the
+ *     guarded work throws.
+ *  2. current-consumption: a CAS updateFn derives its result from the
+ *     `current` value it is handed, never from a stale captured snapshot.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TrustDatabase } from '../trustDbSchema.js';
+import { mergeTrustDatabase } from '../mergeTrustDatabase.js';
+
+function makeDb(overrides: Partial<TrustDatabase> = {}): TrustDatabase {
+  return {
+    version: '1',
+    lastUpdated: '2026-01-01T00:00:00.000Z',
+    tranco: { tier: 'top1k', domains: [], count: 0, sizeBytes: 0 },
+    jpAnchor: { tlds: ['.go.jp'], userTlds: [] },
+    sensitive: {
+      presets: { finance: [], gaming: [], sns: [] },
+      userBlacklist: [],
+      whitelist: [],
+    },
+    bloomFilter: {
+      data: '',
+      hashCount: 1,
+      bitCount: 1,
+      expectedDomainCount: 0,
+      hash: '',
+    },
+    ...overrides,
+  };
+}
+
+describe('lock contract: finally-coverage (trancoUpdater)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('releases updateInProgress when the update throws mid-flight', async () => {
+    vi.doMock('../trustDb.js', () => ({
+      getTrustDb: () => ({
+        initialize: vi.fn().mockResolvedValue(undefined),
+        updateTranco: vi.fn().mockRejectedValue(new Error('db exploded')),
+      }),
+    }));
+
+    const globalFetch = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', globalFetch);
+
+    const { TrancoUpdater } = await import('../trancoUpdater.js');
+    const updater = new TrancoUpdater();
+
+    const result = await updater.updateTrancoList('top1k');
+    expect(result.success).toBe(false);
+    // The bug (post-loop reset only) leaves this true after the retry loop
+    // returns on the exception path.
+    expect(updater.isUpdateInProgress()).toBe(false);
+
+    // A subsequent update must not be rejected as "already in progress".
+    const second = await updater.updateTrancoList('top1k');
+    expect(second.error).not.toBe('Update already in progress');
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('lock contract: current-consumption (mergeTrustDatabase)', () => {
+  it('derives its result from `current`, not from a captured snapshot', () => {
+    const current = makeDb({
+      sensitive: {
+        presets: { finance: [], gaming: [], sns: [] },
+        userBlacklist: ['writer-a.example'],
+        whitelist: [],
+      },
+    });
+    const local = makeDb({
+      sensitive: {
+        presets: { finance: [], gaming: [], sns: [] },
+        userBlacklist: ['writer-b.example'],
+        whitelist: [],
+      },
+    });
+
+    const merged = mergeTrustDatabase(current, local);
+
+    // Writer A's delta (only present in `current`) survives.
+    expect(merged.sensitive.userBlacklist).toContain('writer-a.example');
+    // Writer B's own delta survives too.
+    expect(merged.sensitive.userBlacklist).toContain('writer-b.example');
+  });
+
+  it('does not mutate either argument', () => {
+    const current = makeDb();
+    const local = makeDb({ jpAnchor: { tlds: ['.go.jp'], userTlds: ['.x'] } });
+    const currentCopy = structuredClone(current);
+    const localCopy = structuredClone(local);
+
+    mergeTrustDatabase(current, local);
+
+    expect(current).toEqual(currentCopy);
+    expect(local).toEqual(localCopy);
+  });
+
+  it('returns a fresh object on first write (current undefined)', () => {
+    const local = makeDb();
+    const merged = mergeTrustDatabase(undefined, local);
+    expect(merged).not.toBe(local);
+    expect(merged).toEqual(local);
+  });
+
+  it('keeps the more recent tranco snapshot', () => {
+    const current = makeDb({
+      lastUpdated: '2026-05-01T00:00:00.000Z',
+      tranco: { tier: 'top10k', domains: ['new.example'], count: 1, sizeBytes: 10 },
+    });
+    const local = makeDb({
+      lastUpdated: '2026-01-01T00:00:00.000Z',
+      tranco: { tier: 'top1k', domains: ['old.example'], count: 1, sizeBytes: 10 },
+    });
+
+    const merged = mergeTrustDatabase(current, local);
+    expect(merged.tranco.domains).toEqual(['new.example']);
+    expect(merged.lastUpdated).toBe('2026-05-01T00:00:00.000Z');
+  });
+});
+
+describe('lock contract: 2-writer CAS integration (trustDb.save)', () => {
+  it('preserves both writers deltas through withOptimisticLock', async () => {
+    vi.resetModules();
+
+    const store: Record<string, unknown> = {};
+    // Serialized fake: updateFn is applied against the live stored value.
+    vi.doMock('../../optimisticLock.js', () => ({
+      withOptimisticLock: vi.fn(
+        async (key: string, fn: (cur: unknown) => unknown) => {
+          const next = fn(store[key]);
+          store[key] = next;
+          return next;
+        }
+      ),
+      ConflictError: class ConflictError extends Error {},
+    }));
+
+    const { mergeTrustDatabase: merge } = await import('../mergeTrustDatabase.js');
+    const { withOptimisticLock } = await import('../../optimisticLock.js');
+
+    const KEY = 'trust_db:json';
+    const writerA = makeDb({
+      sensitive: {
+        presets: { finance: [], gaming: [], sns: [] },
+        userBlacklist: ['a.example'],
+        whitelist: [],
+      },
+    });
+    const writerB = makeDb({
+      sensitive: {
+        presets: { finance: [], gaming: [], sns: [] },
+        userBlacklist: ['b.example'],
+        whitelist: [],
+      },
+    });
+
+    await withOptimisticLock(KEY, (cur: unknown) => merge(cur as TrustDatabase | undefined, writerA));
+    await withOptimisticLock(KEY, (cur: unknown) => merge(cur as TrustDatabase | undefined, writerB));
+
+    const final = store[KEY] as TrustDatabase;
+    // RED without the merge fix: writer B's snapshot overwrites writer A's.
+    expect(final.sensitive.userBlacklist).toEqual(
+      expect.arrayContaining(['a.example', 'b.example'])
+    );
+  });
+});

--- a/src/utils/trustDb/__tests__/trancoUpdater.test.ts
+++ b/src/utils/trustDb/__tests__/trancoUpdater.test.ts
@@ -120,6 +120,40 @@ describe('trancoUpdater', () => {
                 expect(result.sizeBytes).toBeGreaterThan(0);
             });
 
+            test('Content-Length なしで 50MB を超える chunked CSV は打ち切られエラーを返す', async () => {
+                const huge = new Uint8Array(51 * 1024 * 1024); // 51MB in one chunk
+                let reads = 0;
+                (fetchWithTimeout as vi.Mock).mockResolvedValue({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ list_id: 'test-list-id' }),
+                    headers: { get: () => null },
+                    body: {
+                        getReader: () => {
+                            let sent = false;
+                            return {
+                                read: () => {
+                                    reads += 1;
+                                    if (sent) return Promise.resolve({ done: true, value: undefined });
+                                    sent = true;
+                                    return Promise.resolve({ done: false, value: huge });
+                                },
+                                cancel: () => Promise.resolve(),
+                            };
+                        },
+                    },
+                });
+
+                const resultPromise = updater.updateTrancoList('top1k');
+                await vi.advanceTimersByTimeAsync(1000);
+                await vi.advanceTimersByTimeAsync(2000);
+                await vi.advanceTimersByTimeAsync(4000);
+                const result = await resultPromise;
+
+                expect(result.success).toBe(false);
+                expect(reads).toBeGreaterThan(0);
+            });
+
             test('API失敗時にリトライして最終的にエラーを返す', async () => {
                 (fetchWithTimeout as vi.Mock).mockResolvedValue({
                     ok: false,

--- a/src/utils/trustDb/mergeTrustDatabase.ts
+++ b/src/utils/trustDb/mergeTrustDatabase.ts
@@ -1,0 +1,60 @@
+/**
+ * mergeTrustDatabase.ts
+ * CAS-safe merge of a locally-mutated Trust Database snapshot onto the
+ * database currently in storage.
+ *
+ * withOptimisticLock passes the current stored value to the updateFn. A
+ * writer that ignores it and returns its own captured snapshot silently
+ * discards any delta another writer committed in between (CAS degrades to
+ * last-writer-wins, VULN-029 / CWE-362). This helper takes `current` as
+ * the base and overlays only the fields this writer owns, unioning the
+ * user-editable lists so concurrent additions from both writers survive.
+ */
+
+import type { TrustDatabase } from './trustDbSchema.js';
+
+function union(a: readonly string[] | undefined, b: readonly string[] | undefined): string[] {
+  return Array.from(new Set([...(a ?? []), ...(b ?? [])]));
+}
+
+/**
+ * Merge `local` (this writer's intended state) onto `current` (the value
+ * just read from storage inside the CAS critical section).
+ *
+ * Never mutates either argument; always returns a new object.
+ */
+export function mergeTrustDatabase(
+  current: TrustDatabase | undefined,
+  local: TrustDatabase
+): TrustDatabase {
+  // First write for this key: nothing to merge against.
+  if (!current) {
+    return structuredClone(local);
+  }
+
+  // Tranco data and the bloom filter are bulk-replaced snapshots, not
+  // incremental lists: keep whichever side was updated more recently.
+  const localNewer =
+    Date.parse(local.lastUpdated || '') >= Date.parse(current.lastUpdated || '');
+  const trancoSource = localNewer ? local : current;
+
+  return {
+    version: local.version,
+    lastUpdated: localNewer ? local.lastUpdated : current.lastUpdated,
+    tranco: structuredClone(trancoSource.tranco),
+    bloomFilter: structuredClone(trancoSource.bloomFilter),
+    jpAnchor: {
+      tlds: local.jpAnchor.tlds,
+      userTlds: union(current.jpAnchor.userTlds, local.jpAnchor.userTlds),
+    },
+    sensitive: {
+      presets: {
+        finance: union(current.sensitive.presets.finance, local.sensitive.presets.finance),
+        gaming: union(current.sensitive.presets.gaming, local.sensitive.presets.gaming),
+        sns: union(current.sensitive.presets.sns, local.sensitive.presets.sns),
+      },
+      userBlacklist: union(current.sensitive.userBlacklist, local.sensitive.userBlacklist),
+      whitelist: union(current.sensitive.whitelist, local.sensitive.whitelist),
+    },
+  };
+}

--- a/src/utils/trustDb/trancoUpdater.ts
+++ b/src/utils/trustDb/trancoUpdater.ts
@@ -12,6 +12,7 @@ import { getTrustDb } from './trustDb.js';
 import { logInfo, logError, logWarn, ErrorCode } from '../logger.js';
 import { errorMessage } from '../errorUtils.js';
 import { fetchWithTimeout } from '../fetch.js';
+import { readBodyCapped } from '../readBodyCapped.js';
 
 // ===== 定数 =====
 
@@ -144,14 +145,9 @@ export class TrancoUpdater {
       throw new Error(`Tranco CSV returned status ${response.status}: ${response.statusText}`);
     }
 
-    // Guard against unbounded reads of potentially huge responses
-    const contentLength = response.headers?.get('content-length');
+    // Cap the streamed body on actual bytes; Content-Length is not trusted.
     const MAX_TRANCO_SIZE = 50 * 1024 * 1024; // 50MB
-    if (contentLength && parseInt(contentLength, 10) > MAX_TRANCO_SIZE) {
-      throw new Error(`Tranco CSV too large: ${Math.round(parseInt(contentLength, 10) / 1024 / 1024)}MB exceeds ${MAX_TRANCO_SIZE / 1024 / 1024}MB limit`);
-    }
-
-    const text = await response.text();
+    const text = await readBodyCapped(response, MAX_TRANCO_SIZE);
     const domains = this.parseTrancoCSV(text, tier);
 
     logInfo('TrancoUpdater', { tier, count: domains.length }, `Parsed ${domains.length} domains for tier: ${tier}`);

--- a/src/utils/trustDb/trancoUpdater.ts
+++ b/src/utils/trustDb/trancoUpdater.ts
@@ -65,6 +65,7 @@ export class TrancoUpdater {
     const maxRetries = 3;
     const baseDelay = 1000; // 1秒
 
+    try {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         logInfo('TrancoUpdater', { tier, attempt, maxRetries }, `Starting Tranco update for tier: ${tier}`);
@@ -107,8 +108,6 @@ export class TrancoUpdater {
       }
     }
 
-    this.updateInProgress = false;
-
     // 通常到達しないが、型安全性のため
     return {
       success: false,
@@ -116,6 +115,13 @@ export class TrancoUpdater {
       sizeBytes: 0,
       error: 'Unexpected error'
     };
+    } finally {
+      // Guarantee the lock is released on every exit path, including a
+      // thrown exception from fetch/DB code that never reaches the
+      // loop-exit return. Without this a single failed update would keep
+      // updateInProgress = true forever (VULN-028 / CWE-667).
+      this.updateInProgress = false;
+    }
   }
 
   /**

--- a/src/utils/trustDb/trustDb.ts
+++ b/src/utils/trustDb/trustDb.ts
@@ -15,6 +15,7 @@ import { DomainTrustLevel } from './trustDbSchema.js';
 import { TrustBloomFilter, bloomFilterFromData } from './bloomFilter.js';
 import { logDebug, logInfo, logWarn, logError, ErrorCode } from '../logger.js';
 import { withOptimisticLock } from '../optimisticLock.js';
+import { mergeTrustDatabase } from './mergeTrustDatabase.js';
 import { TRANCO_VERSION as CURRENT_TRANCO_VERSION } from './presetDomains.js';
 import { SENSITIVE_DOMAINS_PRESETS as PRESETS, JP_ANCHOR_TLDS } from './presets.js';
 
@@ -312,11 +313,15 @@ class TrustDb {
     this.state.database.bloomFilter = bloomData;
     this.state.database.lastUpdated = new Date().toISOString();
 
-    // Save the entire database atomically via optimistic lock
-    await withOptimisticLock(STORAGE_KEY, async (_currentDb) => {
-      // Return the current database state; the lock handler persists it
-      return this.state.database;
-    });
+    // Save the entire database atomically via optimistic lock.
+    // The updateFn must consume `currentDb` (the value read inside the CAS
+    // critical section) and merge this writer's intended state onto it, so
+    // a concurrent writer's delta is not silently dropped (VULN-029).
+    const localSnapshot = this.state.database;
+    await withOptimisticLock<TrustDatabase>(
+      STORAGE_KEY,
+      (currentDb) => mergeTrustDatabase(currentDb, localSnapshot)
+    );
 
     logDebug('TrustDb', {}, 'Database saved with optimistic lock');
   }


### PR DESCRIPTION
VulnHunter 2026-08-29 監査の残 PBI のうち、低〜中リスクの 5 件を 1 本にまとめた統合 PR。
各 PBI は独立ブランチで TDD 実装し、`vulnhunt/wave3-remaining` に集約（`gistSyncTarget.ts` の import 競合のみ手動解消）。

## 含まれる修正

### 29-02 Markdown/Obsidian 出力サニタイズ境界（VULN-001/008/047, CWE-79）
- `sanitizeForObsidian` に HTML エンティティ化（`&`→`&amp;` 先行、`<`→`&lt;`、`>`→`&gt;`）を追加。生 HTML がノートに verbatim 到達する問題を解消
- 既存 `sanitizeForMarkdownLinkText` の適用漏れ 4 箇所を解消: legacy `formatEntryToMarkdown`（タイトル）、`obsidianSyncService`（タイトル）、`gistSyncTarget`（タイトル）、タグ連結経路 2 箇所
- コミット `3ac1e585`

### 29-03 レスポンスボディのバイト上限（VULN-013/015/027/054/055, CWE-400）
- 新規 `src/utils/readBodyCapped.ts`（`readBodyCapped` / `readJsonCapped`）— ストリーミング読み取り + バイトカウンタ、超過時に `ResponseBodyTooLargeError`（null は返さない）。Content-Length に依存しない
- 8 シンクを置換: obsidianConfigValidator / obsidianClient（10MB + 1MB）/ FETCH_URL / trancoUpdater（50MB）/ Gemini×2 / OpenAI×2 / gistSyncTarget
- Gist の素 fetch 3 箇所を `fetchWithTimeout` 経由に統一
- コミット `69b98de5`

### 29-07 ロック/CAS 運用の正しさ（VULN-028/029, CWE-667/362）
- `trancoUpdater.ts` の更新ループを try/finally 化。1 回の失敗で `updateInProgress` が true のまま残る恒久ロックアウトを解消
- `trustDb.ts` の CAS を `(current) => mergeTrustDatabase(current, localSnapshot)` に。新規 `mergeTrustDatabase.ts`（ユーザー編集リストは和集合、tranco/bloom は `lastUpdated` が新しい側、非破壊）
- ロック API 契約テスト（finally カバレッジ・current 消費検証）を追加
- コミット `9f24f984`

### 29-10 ログ完全性（VULN-019/044, CWE-290/117）
- 新規 `src/utils/logger/neutralize.ts` — `\n` → 可視区切り `" ⏎ "`、ANSI CSI 除去、C0 制御文字除去。**PII マスクの後**に適用
- `LOG_FORWARD` ハンドラの `_source` を `deriveLogSource(sender)` で sender 由来に固定。payload の `source` は `_sourceHintUntrusted` として保持
- 変更は LOG_FORWARD ブロックに限局（29-03 の FETCH_URL と非競合）
- コミット `6cb255ff`

### 29-14 Code Quality ハードニング（5/6 着地）
- **AC4** `escapeTsvField` に数式トリガー（先頭 `= + - @`）の `'` プレフィックス無害化
- **AC3** Gemini model 名を `buildModelPathSegment()` で `/`・`\`・`..` 拒否 + `encodeURIComponent`
- **AC5** models-dev asset の読み込み時スキーマ検証、`doc`/`api` の https: 検証
- **AC6** 履歴/pending パネルの a.href に `isSecureUrl` ゲート（`javascript:` 拒否、`http:` 再オープンは維持）
- **AC2** `buildAllowedUrls` の ublock ソース origin を whitelist ゲート（無条件追加を廃止）
- **AC1（見送り→ 29-19）**: CSPValidator の `provider_base_url` / `*_base_url` 自己許可は「何を正当なカスタム API エンドポイントとみなすか」の設計判断が必要 → `pbi/2026-08-29-19-fix-cspvalidator-self-allow.md` に分離
- コミット `e9f7860b`

## ゲート
- `npx tsc --noEmit`: クリーン
- `npm run lint`: クリーン
- `npm test`: **614 files / 10833 tests passing / 0 failures**（統合マージ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)