### PR TITLE
fix(dashboard): B分離型 AIプロバイダー設定をライトモードで視認可能にする

### DIFF
--- a/entrypoints/options/dashboard.css
+++ b/entrypoints/options/dashboard.css
@@ -4559,7 +4559,7 @@ details[open] > .priority-details-summary {
 .ai-layout-toggle {
   display: inline-flex;
   gap: 4px;
-  background: var(--color-surface, #27272a);
+  background: var(--color-bg-subtle);
   border-radius: 16px;
   padding: 2px;
   margin-left: 8px;
@@ -4570,35 +4570,36 @@ details[open] > .priority-details-summary {
   border-radius: 12px;
   border: none;
   background: transparent;
-  color: var(--color-text-muted, #71717a);
+  color: var(--color-text-muted);
   cursor: pointer;
 }
 .ai-layout-toggle-btn.active {
-  background: var(--color-primary, #7c3aed);
+  background: var(--color-primary);
   color: #fff;
 }
 .b-priority-row {
   display: flex;
   align-items: center;
   gap: 8px;
-  background: #27272a;
-  border: 1px solid #3f3f46;
+  /* Row uses subtle paper tone so white select/input children stay distinct. */
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 6px 8px;
   margin-bottom: 6px;
 }
 .b-priority-row.has-error {
-  border-color: #ef4444;
+  border-color: var(--color-danger);
 }
-.b-priority-handle { cursor: grab; color: #a78bfa; }
+.b-priority-handle { cursor: grab; color: var(--color-primary); }
 .b-provider-details {
-  border: 1px solid #3f3f46;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   margin-bottom: 6px;
-  background: #18181b;
+  background: var(--color-bg-white);
 }
 .b-provider-summary {
   padding: 8px 10px;
   cursor: pointer;
-  color: #e4e4e7;
+  color: var(--color-text-secondary);
 }

--- a/tests/dashboard/aiProviderBLightMode.test.ts
+++ b/tests/dashboard/aiProviderBLightMode.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CSS_PATH = path.resolve(__dirname, '../../entrypoints/options/dashboard.css');
+
+/**
+ * B分離型 AIプロバイダー設定パネルのライトモード視認性。
+ * ハードコードされた暗色 (#27272a / #18181b / #3f3f46 / #a78bfa) が
+ * `prefers-color-scheme` を無視して常時適用されると、OS ライトモードで
+ * 紙色 UI に黒背景が浮く。ベース規則はテーマトークンを使い、暗色は
+ * dark メディアクエリ側だけに置く。
+ */
+function readBlock(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`);
+  const m = css.match(re);
+  if (!m) throw new Error(`selector not found: ${selector}`);
+  return m[1];
+}
+
+describe('B分離型パネルのライトモード対応 (dashboard.css)', () => {
+  const css = readFileSync(CSS_PATH, 'utf8');
+
+  it('.b-priority-row のベース規則が暗色を直値で持たない', () => {
+    const block = readBlock(css, '.b-priority-row');
+    expect(block).not.toMatch(/#27272a/i);
+    expect(block).not.toMatch(/#3f3f46/i);
+    // 行は薄い紙色。白い select/input の子要素と境界が付くようにする
+    expect(block).toMatch(/var\(--color-bg-subtle\)/);
+    expect(block).toMatch(/var\(--color-border\)/);
+  });
+
+  it('.b-provider-details のベース規則が暗色を直値で持たない', () => {
+    const block = readBlock(css, '.b-provider-details');
+    expect(block).not.toMatch(/#18181b/i);
+    expect(block).not.toMatch(/#3f3f46/i);
+    expect(block).toMatch(/var\(--color-bg-white\)/);
+    expect(block).toMatch(/var\(--color-border\)/);
+  });
+
+  it('.b-provider-summary のベース規則がライトで読めるトークン色を使う', () => {
+    const block = readBlock(css, '.b-provider-summary');
+    expect(block).not.toMatch(/#e4e4e7/i);
+    expect(block).toMatch(/var\(--color-text-secondary\)/);
+  });
+
+  it('.b-priority-handle のベース規則が薄すぎる #a78bfa を直値で持たない', () => {
+    const block = readBlock(css, '.b-priority-handle');
+    expect(block).not.toMatch(/#a78bfa/i);
+    expect(block).toMatch(/var\(--color-primary\)/);
+  });
+
+  it('.b-priority-row.has-error がトークンの danger 色を使う', () => {
+    const block = readBlock(css, '.b-priority-row.has-error');
+    expect(block).not.toMatch(/#ef4444/i);
+    expect(block).toMatch(/var\(--color-danger\)/);
+  });
+
+  it('B分離型セレクタのブロック外に暗色直値が残っていない', () => {
+    // .b-priority-row 以降 EOF までの範囲に生の暗色が無いこと
+    const start = css.indexOf('.ai-layout-toggle {');
+    const tail = css.slice(start);
+    expect(tail).not.toMatch(/#27272a/i);
+    expect(tail).not.toMatch(/#18181b/i);
+    expect(tail).not.toMatch(/#3f3f46/i);
+    expect(tail).not.toMatch(/#a78bfa/i);
+  });
+});


### PR DESCRIPTION
## 概要

OS がライトモードのとき、Dashboard 初期設定タブの B分離型 AIプロバイダー設定パネル（Priority 3行 / Provider Settings アコーディオン / A・B レイアウトトグル）がハードコードされた暗色でレンダリングされ、紙色 UI に黒背景が浮いていた。

`pbi/2026-08-30-16-fix-light-mode-visibility-dashboard.md` の実装。

## 変更内容

`entrypoints/options/dashboard.css` の以下セレクタからハードコード暗色を除去し、`prefers-color-scheme` で反転する既存テーマトークンに置換:

| セレクタ | 旧（直値・常時適用） | 新（トークン） |
|---|---|---|
| `.b-priority-row` | `#27272a` / `#3f3f46` | `--color-bg-subtle` / `--color-border` |
| `.b-priority-row.has-error` | `#ef4444` | `--color-danger` |
| `.b-priority-handle` | `#a78bfa` | `--color-primary` |
| `.b-provider-details` | `#18181b` / `#3f3f46` | `--color-bg-white` / `--color-border` |
| `.b-provider-summary` | `#e4e4e7` | `--color-text-secondary` |
| `.ai-layout-toggle` | `var(--color-surface, #27272a)` ※未定義トークンで常時 `#27272a` | `--color-bg-subtle` |
| `.ai-layout-toggle-btn` | `#71717a` フォールバック | `--color-text-muted` |

- ライト時: 行は薄い紙色 `#f8fafc`、詳細パネルは白、白い select/input の子要素と境界が付く
- ダーク時: トークンが `#161b22` / `#0d1117` / `#30363d` / `#b1bac4` / `#c084fc` に反転し、ダッシュボード全体の墨色系（ink トークン）と統一される

## テスト

- 新規 `tests/dashboard/aiProviderBLightMode.test.ts`（6 ケース）— `dashboard.css` をパースし、対象セレクタのベース規則から暗色直値が消えテーマトークンを使うことを検証（PBI の「ハードコード検出テスト」）
- `npm run type-check` / `lint` / `test`（10839 passed）すべてグリーン

## セキュリティ観点（CLAUDE.md「For Security Review Agents」）

CSS のみの変更。inline style は不使用。XSS / CSP への影響なし。

## ロールバック

CSS 変更のみのため即時リバート可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)