### PR TITLE
test(dashboard): B分離型ライトモード視認性の E2E を追加し PBI 31-01 をクローズ

### DIFF
--- a/dev-docs/archived/pbi/2026-08-31-01-fix-light-mode-visibility-dashboard.md
+++ b/dev-docs/archived/pbi/2026-08-31-01-fix-light-mode-visibility-dashboard.md
@@ -41,12 +41,27 @@ Scenario: エラーケース — ハードコード残存検出
 ```
 
 ## 受け入れ基準
-- [ ] ライトモード（prefers-color-scheme: light）で B分離型の Priority 3行と Provider Settings 7アコーディオンが白/紙色ベースで表示される（スクショで黒浮きが解消）
-- [ ] ダークモードで従来の暗色見た目が維持される（リグレッションなし）
-- [ ] 主要テキストのコントラスト比が WCAG 2.1 AA（4.5:1）を満たす（--color-text on --color-bg-white 等）
-- [ ] ハードコード色（#27272a, #18181b, #3f3f46, #a78bfa の直値）が dashboard.css の該当3クラスから除去され ymトークン / --color-* に置換
-- [ ] 既存のユニット/統合テストがグリーンを維持
-- [ ] `npm run type-check` と `npm run validate` がパス
+- [x] ライトモード（prefers-color-scheme: light）で B分離型の Priority 3行と Provider Settings 7アコーディオンが白/紙色ベースで表示される（スクショで黒浮きが解消）
+- [x] ダークモードで従来の暗色見た目が維持される（リグレッションなし）
+- [x] 主要テキストのコントラスト比が WCAG 2.1 AA（4.5:1）を満たす（--color-text on --color-bg-white 等）
+- [x] ハードコード色（#27272a, #18181b, #3f3f46, #a78bfa の直値）が dashboard.css の該当3クラスから除去され ymトークン / --color-* に置換
+- [x] 既存のユニット/統合テストがグリーンを維持
+- [x] `npm run type-check` と `npm run validate` がパス
+
+### 着地サマリ
+- CSS トークン置換: PR #84（`9e240f60`）。`.b-priority-row` / `.b-provider-details` /
+  `.b-provider-summary` / `.b-priority-handle` / `.ai-layout-toggle` を `--color-*` トークン化。
+  `--color-*` は dashboard.css:95 の `@media (prefers-color-scheme: dark)` で反転するため、
+  ライトは紙色（`#f8fafc` / `#ffffff`）、ダークは墨色（`#161b22` / `#0d1117`）を自動で使い分ける。
+  別途 `@media` ブロックは不要。
+- 単体テスト: `tests/dashboard/aiProviderBLightMode.test.ts`（PR #84）— CSS ソースの
+  トークン使用と暗色直値の不在をアサート。
+- E2E: `testDir/e2e/dashboard-light-mode.spec.ts` — ビルド後 options CSS を最小 DOM に適用し、
+  `page.emulateMedia({ colorScheme })` で light/dark の `.b-priority-row` / `.b-provider-details`
+  背景 computedStyle を検証（chromium + firefox で 6 ケース green）。
+- ハードコード検出（BDD「エラーケース」）: `grep "#27272a\|#18181b\|#3f3f46"
+  entrypoints/options/dashboard.css` → 0 件。ビルド後 `dist/**/options-*.css` の
+  該当ルールも全て `var(--color-*)`。
 
 ## テスト戦略（t_wadaスタイル）
 
@@ -143,9 +158,9 @@ grep -rn "b-priority-row\|b-provider-details\|ai-layout-toggle" src/ entrypoints
 - **ビルド後のCSSパス**: WXTビルドで `dist/chromium-mv3/assets/dashboard-*.css` にハッシュ付与されるため、grepは `dist/` 配下を再帰的に探す
 
 ## Definition of Done
-- [ ] 全BDDシナリオが自動テストとして実装されパスする（E2E light/dark + ハードコード検出）
-- [ ] テストカバレッジが基準を満たす（E2E/統合/単体すべて）
+- [x] 全BDDシナリオが自動テストとして実装されパスする（E2E light/dark + ハードコード検出）
+- [x] テストカバレッジが基準を満たす（E2E/統合/単体すべて）
 - [ ] コードレビュー完了（GitHub PR での approve を必須とする。セキュリティに関わる変更は CLAUDE.md「For Security Review Agents」節の観点確認をPR説明に明記 — 本PBIはCSSのみだがXSS/CSP観点で inline style 不使用を確認）
-- [ ] リファクタリング完了（グリーン後、トークン命名を DESIGN_TOKENS.md と整合）
-- [ ] ロールバック手段の検討（CSS変更のため即時リバート可能。ダーク見た目が崩れた場合は @media ブロックを削除して前版CSSに戻す。feature flag不要）
-- [ ] ドキュメント更新済み（必要なら DESIGN_TOKENS.md の「B分離型はライト対応済み」追記。不要なら省略）
+- [x] リファクタリング完了（グリーン後、トークン命名を DESIGN_TOKENS.md と整合。dashboard.css 内は `--color-*` で統一済み）
+- [x] ロールバック手段の検討（CSS変更のため即時リバート可能。`--color-*` トークン参照を旧直値に戻すだけ。feature flag不要）
+- [x] ドキュメント更新済み（DESIGN_TOKENS.md には B分離型固有の記載箇所がないため省略。本PBIの「着地サマリ」に集約）

--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -74,7 +74,9 @@ VulnHunter セキュリティ修正（29 系）や クレンジング改善（30
 | ファイル | タイトル | 状態 | 種別 | 難易度 | 副作用 | RICE |
 |---|---|---|---|---|---|---|
 | [2026-08-31-00-backlog-ui-visibility.md](2026-08-31-00-backlog-ui-visibility.md) | UI/デザイン視認性のバックログ（候補列挙＋RICE＋推奨実行順＋トレーサビリティ） | ⬜ | 🔧 | - | - | 索引 |
-| [2026-08-31-01-fix-light-mode-visibility-dashboard.md](2026-08-31-01-fix-light-mode-visibility-dashboard.md) | ライトモード視認性改善 — Dashboard AIプロバイダー設定のトークン準拠化 | ⬜ | 🔧 | 🟢 | 🟢 | 32.4 |
+
+> 31-01（ライトモード視認性改善）は完了しアーカイブ済み（`dev-docs/archived/pbi/`）。
+> 新規候補はバックログ索引を参照。
 
 ---
 
@@ -117,6 +119,10 @@ VulnHunter セキュリティ修正（29 系）や クレンジング改善（30
 - 2026-08-30-15-feat-llm-output-quality-guard.md（PR #72 — `llmOutputGuard.ts` を新設（`isDegenerateOutput` — repetition / lowDiversity / highlyCompressible のいずれかで縮退判定、notSentence は補助のみ、名前付き閾値定数）。`privacyPipeline._processCloudResult` の `parseTagsFromSummary` 後に単一チェックポイントとして組込み、縮退時はフォールバック文字列 + `addLog(WARN)`。`historyEntryRow.ts` で表示時マスク）
 
 **部分着地で `pbi/` に残置**: 29-04（2/6サイト・PR #74）、29-08（3/7指摘・PR #75）、29-13（AC1/4/5/6・PR #76）、29-14（AC2–6・PR #81）。付随して lint 修正（PR #80）、PBI 索引整備（PR #67）もマージ。
+
+### 2026-08-31 ライトモード視認性改善 完了
+
+- 2026-08-31-01-fix-light-mode-visibility-dashboard.md（RICE 32.4 — B分離型 AIプロバイダー設定（`.b-priority-row` / `.b-provider-details` / `.b-provider-summary` / `.b-priority-handle` / `.ai-layout-toggle`）のハードコード暗色（`#27272a` / `#18181b` / `#3f3f46` / `#a78bfa` / `#e4e4e7`）を `--color-*` トークンに置換（CSS は PR #84 `9e240f60` で着地）。`--color-*` は `dashboard.css:95` の `@media (prefers-color-scheme: dark)` で反転するため、別 `@media` ブロック不要でライト＝紙色 `#f8fafc`/`#ffffff`、ダーク＝墨色 `#161b22`/`#0d1117` を自動で使い分ける。`.ai-layout-toggle` の未定義 `--color-surface` フォールバックで常時 `#27272a` を描画していたバグも解消。単体テスト `tests/dashboard/aiProviderBLightMode.test.ts`（CSS ソースのトークン使用と暗色直値の不在をアサート）、E2E `testDir/e2e/dashboard-light-mode.spec.ts`（ビルド後 options CSS を最小 DOM に適用し `page.emulateMedia({ colorScheme })` で light/dark の背景 computedStyle を検証、chromium + firefox で 6 ケース green）。BDD「ハードコード残存検出」: `grep "#27272a\|#18181b\|#3f3f46" entrypoints/options/dashboard.css` → 0 件、ビルド後 `dist/**/options-*.css` の該当ルールも全て `var(--color-*)`。type-check / validate（10839 tests）PASS）
 
 ### 2026-08-29 リリース前チェックのブロッカー解消 完了
 

--- a/testDir/e2e/dashboard-light-mode.spec.ts
+++ b/testDir/e2e/dashboard-light-mode.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DIST_ASSETS = path.join(__dirname, '../../dist/chromium-mv3/assets');
+
+/**
+ * PBI 2026-08-31-01: B分離型 AIプロバイダー設定のライトモード視認性。
+ *
+ * B分離型の行 (.b-priority-row 等) は JS で動的生成される。また options.html は
+ * `/assets/...css` を絶対パス参照するため file:// 単体ではスタイルが読めない。
+ * ここではビルド後の options CSS を直接読み込んだ最小 DOM にプローブ要素を置き、
+ * prefers-color-scheme に応じて背景トークンが反転することを検証する。
+ */
+
+function builtOptionsCss(): string {
+  const file = fs.readdirSync(DIST_ASSETS).find((f) => /^options-.*\.css$/.test(f));
+  if (!file) throw new Error('built options CSS not found — run `npm run build`');
+  return fs.readFileSync(path.join(DIST_ASSETS, file), 'utf8');
+}
+
+const PAGE_HTML = `<!doctype html><html><head></head><body>
+  <div id="e2e-probe">
+    <div class="b-priority-row"><span class="b-priority-handle">::</span></div>
+    <div class="b-provider-details"><div class="b-provider-summary">summary</div></div>
+    <div class="ai-layout-toggle">
+      <button class="ai-layout-toggle-btn">A</button>
+      <button class="ai-layout-toggle-btn active">B</button>
+    </div>
+  </div>
+</body></html>`;
+
+async function bg(page: import('@playwright/test').Page, selector: string): Promise<string> {
+  return page.locator(`#e2e-probe ${selector}`).evaluate(
+    (el) => getComputedStyle(el as HTMLElement).backgroundColor,
+  );
+}
+
+test.describe('Dashboard - B-separated AI provider light mode @ui', () => {
+  const css = builtOptionsCss();
+
+  test.beforeEach(async ({ page }) => {
+    await page.setContent(PAGE_HTML);
+    await page.addStyleTag({ content: css });
+  });
+
+  test('light mode: rows use paper-tone tokens, not hardcoded ink', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+
+    // --color-bg-subtle (#f8fafc) / --color-bg-white (#ffffff)
+    expect(await bg(page, '.b-priority-row')).toBe('rgb(248, 250, 252)');
+    expect(await bg(page, '.b-provider-details')).toBe('rgb(255, 255, 255)');
+
+    for (const sel of ['.b-priority-row', '.b-provider-details']) {
+      expect(await bg(page, sel)).not.toBe('rgb(39, 39, 42)'); // #27272a
+      expect(await bg(page, sel)).not.toBe('rgb(24, 24, 27)'); // #18181b
+    }
+  });
+
+  test('dark mode: rows keep ink-toned background', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+
+    // dark token overrides: --color-bg-subtle #161b22 / --color-bg-white #0d1117
+    expect(await bg(page, '.b-priority-row')).toBe('rgb(22, 27, 34)');
+    expect(await bg(page, '.b-provider-details')).toBe('rgb(13, 17, 23)');
+  });
+
+  test('active layout toggle button resolves to a real color in both schemes', async ({ page }) => {
+    for (const scheme of ['light', 'dark'] as const) {
+      await page.emulateMedia({ colorScheme: scheme });
+      const c = await bg(page, '.ai-layout-toggle-btn.active');
+      expect(c).not.toBe('rgba(0, 0, 0, 0)'); // resolved, not transparent
+      expect(c).not.toBe('rgb(39, 39, 42)'); // not the stale #27272a --color-surface bug
+    }
+  });
+});


### PR DESCRIPTION
## 概要

PBI [2026-08-31-01 ライトモード視認性改善](../blob/fix/light-mode-visibility-e2e/dev-docs/archived/pbi/2026-08-31-01-fix-light-mode-visibility-dashboard.md) の残 DoD（E2E・アーカイブ整理）を埋めてクローズする。

CSS のトークン置換自体は PR #84 (`9e240f60`) で着地済み。本 PR はその挙動を固定する E2E を追加し、PBI を `dev-docs/archived/pbi/` へ移動、INDEX を更新する。

## 変更内容

- **E2E 追加** `testDir/e2e/dashboard-light-mode.spec.ts`
  - ビルド後 options CSS を最小 DOM に `addStyleTag` で適用し、`page.emulateMedia({ colorScheme })` で light/dark を切り替えて `.b-priority-row` / `.b-provider-details` の背景 `computedStyle` を検証
  - light: `--color-bg-subtle` `#f8fafc` / `--color-bg-white` `#ffffff`
  - dark: `dashboard.css:95` の `@media (prefers-color-scheme: dark)` 反転で `#161b22` / `#0d1117`
  - chromium + firefox の 2 プロジェクトで計 6 ケース green
  - 補足: `options.html` は `/assets/*.css` を絶対パス参照するため `file://` 単体ではスタイルが読めず、既存の `dashboard-ui.spec.ts` は DOM 構造のみ検証している。B分離型の行は JS 動的生成のためプローブ要素で代替した
- **PBI アーカイブ** `pbi/2026-08-31-01-...md` → `dev-docs/archived/pbi/` へ `git mv`、受け入れ基準・DoD にチェックと着地サマリを追記
- **INDEX 更新** 進行中テーブルから 31-01 行を削除、アーカイブ履歴に 1 行追記

## テスト

- `npx playwright test --config testDir/playwright.config.ts dashboard-light-mode` → 6 passed（chromium + firefox）
- `npm run validate` → type-check PASS / 10839 tests PASS

## セキュリティ観点（CLAUDE.md「For Security Review Agents」）

CSS とテストのみの変更。inline style は不使用（`var(--color-*)` トークン参照のみ）。XSS/CSP への影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)