### PR TITLE
fix(security): CSPValidator の設定由来ドメイン自己許可を締め直す (PBI 29-19)

### DIFF
--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -33,7 +33,7 @@
 | [2026-08-29-12-fix-crypto-policy-ssot.md](2026-08-29-12-fix-crypto-policy-ssot.md) | 暗号・認証ポリシーSSOT化 ＋ HMAC先行化（VULN-010/034/035/037-040/052） | ⬜ | 🔧 | 🔴 | 🔴 | 453 |
 | [2026-08-29-13-fix-import-pipeline-safety.md](2026-08-29-13-fix-import-pipeline-safety.md) | インポート経路安全化 — 認証→上限→パース→検証（VULN-023/030/034/035/036） | 🔶 | 🔧 | 🟡 | 🟡 | 405 |
 | [2026-08-29-14-fix-security-hardening-code-quality.md](2026-08-29-14-fix-security-hardening-code-quality.md) | Code Qualityハードニング一括（将来攻撃面6件） | 🔶 | 🔧 | 🟢 | 🟡 | 170 |
-| [2026-08-29-19-fix-cspvalidator-self-allow.md](2026-08-29-19-fix-cspvalidator-self-allow.md) | CSPValidator の設定由来ドメイン自己許可の締め直し（29-14 の AC1 から分離） | ⬜ | 🔧 | 🟡 | 🟡 | 分離 |
+| [2026-08-29-19-fix-cspvalidator-self-allow.md](2026-08-29-19-fix-cspvalidator-self-allow.md) | CSPValidator の設定由来ドメイン自己許可の締め直し（29-14 の AC1 から分離） | 🔶 | 🔧 | 🟡 | 🟡 | 分離 |
 
 > **🔶 部分実装の内訳**（残タスクは別 PBI で完了 or 統合先へ）:
 > - 29-04: 2/6サイト着地（PR #74）。残 4 サイト（buffer/pending/logger の CAS + optimisticLock 直列化）は **29-16 で完了**（PR #79・アーカイブ済み）
@@ -44,6 +44,9 @@
 > 29-04/08/13/14 は「この PBI 自体の DoD は残タスクを含めて未達」だが、実装は分離先で完了済み。
 > VulnHunter 再スキャンでの最終確認待ちのため `pbi/` に残置。詳細は
 > [2026-08-29-00-backlog-vulnhunt-audit.md](2026-08-29-00-backlog-vulnhunt-audit.md) の「フォローアップ PBI」節。
+> - 29-19: 実装・テスト着地（`cspValidator.initializeFromSettings` に
+>   `isAllowedProviderBaseUrl` ガードを配線、`cspValidatorSelfAllow.test.ts` 8 ケース green）。
+>   VulnHunter 再スキャンで Code Quality 指摘の解消を確認したらアーカイブへ。
 
 ### クレンジング改善（2026-08-30）
 

--- a/pbi/2026-08-29-19-fix-cspvalidator-self-allow.md
+++ b/pbi/2026-08-29-19-fix-cspvalidator-self-allow.md
@@ -57,11 +57,28 @@ Scenario: localhost のカスタムエンドポイント（Ollama/LM Studio）�
 ```
 
 ## 受け入れ基準
-- [ ] `CSPValidator.initializeFromSettings` の `provider_base_url` / `*_base_url` の hostname 追加が、`src/utils/allowedUrls.ts` の `isAllowedProviderBaseUrl` 相当のガードを通る（private IP・metadata endpoint・非 https の非 localhost を拒否）
-- [ ] ガードは 1 箇所に集約（`isAllowedProviderBaseUrl` を再利用するか、共有ヘルパーに抽出）
-- [ ] 正当な https カスタムエンドポイントと localhost エンドポイントの許可挙動は不変（既存 `cspValidator.test.ts` の該当テストは新ガードに合わせて期待値更新）
-- [ ] 設定 UI で暗黙に追加される挙動を維持するか、明示オプトインに変えるかを決定しコメント化
-- [ ] `npm run type-check` と `npm run validate` が成功する
+- [x] `CSPValidator.initializeFromSettings` の `provider_base_url` / `*_base_url` の hostname 追加が、`src/background/ai/providerRegistry.ts` の `isAllowedProviderBaseUrl` ガードを通る（private IP・metadata endpoint・非 https の非 localhost を拒否）
+- [x] ガードは 1 箇所に集約（`initializeFromSettings` 内 `addBaseUrlDomain` ヘルパーが `isAllowedProviderBaseUrl` を再利用。ガード本体は `providerRegistry.ts` の既存関数のまま）
+- [x] 正当な https カスタムエンドポイントと localhost エンドポイントの許可挙動は不変（既存 `cspValidator.test.ts` 29 件は無改修で green。safe な値のみ使用していたため期待値更新不要だった）
+- [x] 設定 UI で暗黙に追加される挙動を維持するか、明示オプトインに変えるかを決定しコメント化（暗黙追加を維持。汚染設定はガードで弾くため CSP の意味は保たれる。判断理由を `cspValidator.ts` にコメント化）
+- [x] `npm run type-check` と `npm run validate` が成功する（10847 tests PASS）
+
+### 着地サマリ
+- `src/utils/cspValidator.ts` の `initializeFromSettings` で `provider_base_url` /
+  `{openai|openai2|lm-studio|ollama}_base_url` の hostname を `allowedDomains` へ
+  追加する前に `isAllowedProviderBaseUrl(rawUrl, isLocal)` を通す `addBaseUrlDomain`
+  ヘルパーを新設。`lm-studio` / `ollama` は `isLocal: true`、`openai` 系は `isLocal: false`。
+- ガードは既存の `src/background/ai/providerRegistry.ts` `isAllowedProviderBaseUrl`
+  を再利用（`OpenAIProvider` / `ollamaOriginRule` が実 fetch 層で使う同じ関数）。
+  CSP で許可しても fetch 層で弾かれるドメインを allowlist する無意味を解消し、
+  多層防御の 2 層を一致させる。
+- private IP は local provider でも拒否される（`isAllowedProviderBaseUrl` の仕様）。
+  LAN 上の Ollama（`192.168.x`）を CSP allowlist しなくなるが、実 fetch も同関数で
+  弾くため挙動は一貫。localhost / `127.0.0.1` は従来どおり許可。
+- テスト: `src/utils/__tests__/cspValidatorSelfAllow.test.ts`（LF 新規、8 ケース）—
+  metadata / private IP / 非 https evil / 非 http(s) スキームの拒否と、
+  正当な https・localhost・127.0.0.1 の許可（回帰防止）。
+- CRLF の既存 `cspValidator.test.ts` は無改修（29 件 green 維持）。
 
 ## テスト戦略（t_wadaスタイル）
 
@@ -110,8 +127,8 @@ rg -n "Provider Base URL Domains|custom-openai" src/utils/__tests__/cspValidator
 - `isLocal` の判定: `ollama_base_url` / `lm-studio_base_url` は localhost 期待、`provider_base_url` / `openai*_base_url` はリモート期待
 
 ## Definition of Done
-- [ ] 全 BDD シナリオが自動テストとして実装されパスする
-- [ ] テストカバレッジが基準を満たす
-- [ ] コードレビュー完了
-- [ ] リファクタリング完了（グリーン後）
-- [ ] VulnHunter 再スキャンで該当 Code Quality 指摘が解消されること
+- [x] 全 BDD シナリオが自動テストとして実装されパスする（`cspValidatorSelfAllow.test.ts` 8 ケース）
+- [x] テストカバレッジが基準を満たす（汚染系 5・正当系 3 で境界を網羅）
+- [ ] コードレビュー完了（GitHub PR approve）
+- [x] リファクタリング完了（グリーン後 — `addBaseUrlDomain` に集約、`providerTypes` を `{key, isLocal}` 配列化）
+- [ ] VulnHunter 再スキャンで該当 Code Quality 指摘が解消されること（29 系一括の再スキャン時に確認）

--- a/src/utils/__tests__/cspValidatorSelfAllow.test.ts
+++ b/src/utils/__tests__/cspValidatorSelfAllow.test.ts
@@ -1,0 +1,98 @@
+/**
+ * cspValidatorSelfAllow.test.ts
+ *
+ * PBI 2026-08-29-19: CSPValidator.initializeFromSettings が設定由来の
+ * base URL hostname を無条件で条件付き CSP 許可リストへ追加していた
+ * (self-allow) 構造を締め直す。汚染された設定 (インポート経由の悪意ある
+ * 設定ファイル等) で private IP / metadata endpoint / 非 https の非 localhost
+ * へ接続が許可されるのを防ぐ。
+ *
+ * ガードは src/background/ai/providerRegistry.ts の isAllowedProviderBaseUrl
+ * を再利用する。既存 cspValidator.test.ts は CRLF のため、新規ケースは
+ * この LF ファイルに置く。
+ */
+
+import { vi } from 'vitest';
+import { CSPValidator } from '../cspValidator.js';
+
+describe('CSPValidator - self-allow hardening (PBI 29-19)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    CSPValidator.reset();
+  });
+
+  describe('汚染設定は条件付き CSP に追加されない', () => {
+    it('provider_base_url が metadata endpoint (169.254.169.254) の場合は追加しない', () => {
+      CSPValidator.initializeFromSettings({
+        conditional_csp_providers: [],
+        provider_base_url: 'http://169.254.169.254/latest/meta-data/',
+      });
+      expect(CSPValidator.isUrlAllowed('http://169.254.169.254/latest/meta-data/')).toBe(false);
+    });
+
+    it('provider_base_url が metadata.google.internal の場合は追加しない', () => {
+      CSPValidator.initializeFromSettings({
+        conditional_csp_providers: [],
+        provider_base_url: 'http://metadata.google.internal/computeMetadata/v1/',
+      });
+      expect(CSPValidator.isUrlAllowed('http://metadata.google.internal/computeMetadata/v1/')).toBe(false);
+    });
+
+    it('provider_base_url が private IP (10.x/192.168.x/172.16-31.x) の場合は追加しない', () => {
+      CSPValidator.initializeFromSettings({
+        conditional_csp_providers: [],
+        provider_base_url: 'http://192.168.1.50:8080/v1',
+      });
+      expect(CSPValidator.isUrlAllowed('http://192.168.1.50:8080/v1/models')).toBe(false);
+
+      CSPValidator.reset();
+      CSPValidator.initializeFromSettings({
+        conditional_csp_providers: [],
+        provider_base_url: 'https://10.0.0.5/v1',
+      });
+      expect(CSPValidator.isUrlAllowed('https://10.0.0.5/v1/models')).toBe(false);
+    });
+
+    it('openai_base_url が非 https の非 localhost (http://evil.example) の場合は追加しない', () => {
+      CSPValidator.initializeFromSettings({
+        conditional_csp_providers: [],
+        openai_base_url: 'http://evil.example/v1',
+      });
+      expect(CSPValidator.isUrlAllowed('http://evil.example/v1/models')).toBe(false);
+    });
+
+    it('非 http(s) スキーム (file:, ftp:) は追加しない', () => {
+      CSPValidator.initializeFromSettings({
+        conditional_csp_providers: [],
+        provider_base_url: 'ftp://ftp.example.com/',
+      });
+      expect(CSPValidator.isUrlAllowed('ftp://ftp.example.com/models')).toBe(false);
+    });
+  });
+
+  describe('正当な設定は引き続き許可される (回帰防止)', () => {
+    it('正当な https カスタムエンドポイントは追加される', () => {
+      CSPValidator.initializeFromSettings({
+        conditional_csp_providers: [],
+        provider_base_url: 'https://custom-openai.example.com/v1',
+      });
+      expect(CSPValidator.isUrlAllowed('https://custom-openai.example.com/v1/chat/completions')).toBe(true);
+    });
+
+    it('localhost のカスタムエンドポイント (Ollama/LM Studio) は追加される', () => {
+      CSPValidator.initializeFromSettings({
+        conditional_csp_providers: [],
+        'ollama_base_url': 'http://localhost:11434/v1',
+      });
+      expect(CSPValidator.isUrlAllowed('http://localhost:11434/v1/models')).toBe(true);
+    });
+
+    it('127.0.0.1 のカスタムエンドポイントは追加される', () => {
+      CSPValidator.initializeFromSettings({
+        conditional_csp_providers: [],
+        'lm-studio_base_url': 'http://127.0.0.1:1234/v1',
+      });
+      expect(CSPValidator.isUrlAllowed('http://127.0.0.1:1234/v1/models')).toBe(true);
+    });
+  });
+});

--- a/src/utils/cspValidator.ts
+++ b/src/utils/cspValidator.ts
@@ -11,6 +11,7 @@ import { logWarn, ErrorCode } from './logger.js';
 import { errorMessage } from './errorUtils.js';
 import { ALLOWED_LOCALHOST_PORTS } from './ssrfGuard.js';
 import { pickDefined } from './objectUtils.js';
+import { isAllowedProviderBaseUrl } from '../background/ai/providerRegistry.js';
 
 class CspError extends Error {
     code: string;
@@ -140,32 +141,40 @@ export class CSPValidator {
       }
     }
 
-    // OpenAI互換プロバイダーのBase URLドメインを直接追加（PROVIDER_BASE_URL）
-    const providerBaseUrl = settings.provider_base_url as string | undefined;
-    if (providerBaseUrl) {
+    // 設定由来の Base URL は「信頼できる定数」ではないため、暗黙に許可リストへ
+    // 入れる前に isAllowedProviderBaseUrl で締め直す（private IP・metadata
+    // endpoint・非 localhost の http を拒否）。汚染設定でも条件付き CSP の
+    // 意味を保つ。挙動は暗黙追加のまま（明示オプトイン化はしない）。
+    const addBaseUrlDomain = (rawUrl: string, isLocal: boolean): void => {
+      if (!isAllowedProviderBaseUrl(rawUrl, isLocal)) return;
       try {
-        const domain = new URL(providerBaseUrl).hostname;
+        const domain = new URL(rawUrl).hostname;
         if (domain) {
           CSPValidator.allowedDomains.add(domain);
         }
       } catch {
         // 無効なURLは無視
       }
+    };
+
+    // OpenAI互換プロバイダーのBase URLドメインを直接追加（PROVIDER_BASE_URL）
+    const providerBaseUrl = settings.provider_base_url as string | undefined;
+    if (providerBaseUrl) {
+      addBaseUrlDomain(providerBaseUrl, false);
     }
 
     // All provider Base URL domains (openai, openai2, etc.)
-    const providerTypes = ['openai', 'openai2', 'lm-studio', 'ollama'];
-    for (const pt of providerTypes) {
-      const baseUrl = settings[`${pt}_base_url`] as string | undefined;
+    // lm-studio / ollama は localhost 期待、openai 系はリモート期待
+    const providerTypes: { key: string; isLocal: boolean }[] = [
+      { key: 'openai', isLocal: false },
+      { key: 'openai2', isLocal: false },
+      { key: 'lm-studio', isLocal: true },
+      { key: 'ollama', isLocal: true },
+    ];
+    for (const { key, isLocal } of providerTypes) {
+      const baseUrl = settings[`${key}_base_url`] as string | undefined;
       if (baseUrl) {
-        try {
-          const domain = new URL(baseUrl).hostname;
-          if (domain) {
-            CSPValidator.allowedDomains.add(domain);
-          }
-        } catch {
-          // 無効なURLは無視
-        }
+        addBaseUrlDomain(baseUrl, isLocal);
       }
     }
 


### PR DESCRIPTION
## 概要

PBI [2026-08-29-19](../blob/fix/cspvalidator-self-allow/pbi/2026-08-29-19-fix-cspvalidator-self-allow.md)（VulnHunter 2026-08-29 監査 Code Quality、29-14 の AC1 から分離）。

`CSPValidator.initializeFromSettings` が設定由来の base URL hostname を**無条件で**条件付き CSP 許可リストへ追加していた self-allow 構造を締め直す。

## 変更内容

- `src/utils/cspValidator.ts` — `provider_base_url` / `{openai|openai2|lm-studio|ollama}_base_url` の hostname を `allowedDomains` へ追加する前に `isAllowedProviderBaseUrl(rawUrl, isLocal)` を通す `addBaseUrlDomain` ヘルパーを新設
  - `lm-studio` / `ollama` → `isLocal: true`、`openai` 系 → `isLocal: false`
  - ガード本体は既存の `src/background/ai/providerRegistry.ts` `isAllowedProviderBaseUrl` を再利用（`OpenAIProvider` / `ollamaOriginRule` が実 fetch 層で使う同じ関数）
  - 拒否: private IP（10.x / 192.168.x / 172.16-31.x）、metadata endpoint（169.254.169.254 / metadata.google.internal）、非 localhost の http、非 http(s) スキーム
  - 暗黙追加の挙動自体は維持（明示オプトイン化はしない）— 理由をコメント化
- `src/utils/__tests__/cspValidatorSelfAllow.test.ts` — LF 新規、8 ケース（汚染系 5 / 正当系 3・回帰防止）

## 設計判断

CSP で許可しても fetch 層（`n()` = `isAllowedProviderBaseUrl`）で弾かれるドメインを allowlist する無意味を解消し、多層防御の 2 層を一致させる。private IP は local provider でも拒否されるため LAN 上の Ollama（`192.168.x`）を CSP allowlist しなくなるが、実 fetch も同関数で弾くため挙動は一貫。localhost / `127.0.0.1` は従来どおり許可。

## テスト

- `npx vitest run src/utils/__tests__/cspValidatorSelfAllow.test.ts src/utils/__tests__/cspValidator.test.ts` → 37 passed（新 8 + 既存 29 無改修）
- `npm run validate` → type-check PASS / 10847 tests PASS

## セキュリティ観点（CLAUDE.md「For Security Review Agents」）

SSRF / metadata endpoint 露出の緩和。既存ガードの再利用でロジック重複なし。import cycle なし（`providerRegistry` は `storage/types` のみ import）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)