### PR TITLE
feat(sqlite): InMemoryTransport を追加し PBI 05 を完了

### DIFF
--- a/dev-docs/DESIGN_SPECIFICATIONS.md
+++ b/dev-docs/DESIGN_SPECIFICATIONS.md
@@ -106,6 +106,7 @@ A local SQLite database acts as a **secondary store for browsing/search**, indep
   - The Dashboard hop passes failure-response reasons through **verbatim** (the Service Worker already classified them); it only runs `categorizeError` on its own transport-level exceptions. Re-classifying a already-classified reason would double-wrap it.
 - **Query plan** (`src/offscreen/queryPlan.ts`): `buildQuerySpec` / `clampLimit` / `buildExtraWhereSql` are the single source of truth for WHERE-clause generation and limit clamping. `IdbVfsBackend` and `opfsWorker/searchHandlers` consume them rather than re-deriving the same date/domain/starred/gist/ids filter.
 - **Backend facets** (`src/offscreen/StorageBackend.ts`): the storage backend interface is split into `Queryable` (read) and `Mutable` (write) so callers import only the facet they need.
+- **Transport adapters** (`OffscreenTransport` interface): `ChromeOffscreenTransport` manages the real offscreen-document lifecycle in production; `InMemoryTransport` (`src/background/inMemoryTransport.ts`) is a stateful in-memory store so `SqliteGateway` can be exercised in tests (insert → query → count → status all round-trip) without an offscreen document or any `chrome.*` API.
 
 ### 5.5 Trust DB
 

--- a/dev-docs/archived/pbi/2026-08-31-05-feat-sqlite-gateway-unification.md
+++ b/dev-docs/archived/pbi/2026-08-31-05-feat-sqlite-gateway-unification.md
@@ -56,8 +56,8 @@ Scenario: Transport が Adapter として差し替え可能
 - [x] `SqliteClient` と `dashboardSqliteService` の二重 RPC 実装が Gateway に統合され、呼び出し元が Gateway（`SqliteGateway` / `DashboardSqliteGateway`）に委譲する shim に縮小
 - [x] `buildExtraWhereSql` / `clampLimit` / `buildQuerySpec` が `queryPlan.ts` 1 ファイルに集約され、`IdbVfsBackend` / `opfsWorker/searchHandlers` の個別実装が削除される
 - [x] `StorageBackend` が `Queryable` と `Mutable` の 2 facet に分割される
-- [x] `categorizeError` が Gateway 経由で一元化（dashboard 失敗レスポンスの二重 categorize を修正）。`isServiceError` の重複は未解消（`dashboardSqliteService.ts` / `BrowsingLogRepository.ts` の 2 箇所）
-- [ ] Transport の `InMemoryTransport` adapter は未実装（`OffscreenTransport` interface + `ChromeOffscreenTransport` のみ）
+- [x] `categorizeError` が Gateway 経由で一元化され、dashboard/SW の 2 hop が同一分類（dashboard 失敗レスポンスの二重 categorize を修正）。live な `isServiceError` は `dashboardSqliteService.ts` の 1 箇所。`BrowsingLogRepository.ts` の同名定義は PR #87 由来の未接続コード（consumer / test なし）で、本 PBI の対象外 → 別途「dead code 整理」として扱う
+- [x] Transport は `OffscreenTransport` interface として抽出済み。adapter は `ChromeOffscreenTransport`（本番）と `InMemoryTransport`（`src/background/inMemoryTransport.ts` — stateful な in-memory store。offscreen / chrome.* を起動せず insert→query→count→status が round-trip する）の 2 実装
 - [x] `sqliteClient` / `dashboardSqliteService` / `IdbVfsBackend` のテストが Gateway 経由で green
 
 ## テスト戦略
@@ -74,9 +74,8 @@ Scenario: Transport が Adapter として差し替え可能
 - [x] ドキュメント更新済み（DESIGN_SPECIFICATIONS.md §5.4 に Unified gateway / Query plan / Backend facets を追記。ADR 2026-06-17 opfs-fts5-coexistence は VFS/FTS5 エンジン選定の ADR で RPC 層は対象外のため追記せず）
 - [x] `npm run validate` が green
 
-## 残作業
-- `InMemoryTransport` adapter の実装（テスト seam の実在化。現状 `OffscreenTransport` interface は注入可能で機能的には充足）
-- `isServiceError` の重複解消（`dashboardSqliteService.ts` / `BrowsingLogRepository.ts` の 2 箇所。挙動は同一）
+## フォローアップ（本 PBI 対象外）
+- `src/dashboard/BrowsingLogRepository.ts`（PR #87 由来、consumer / test なし、296 行）を wire-up するか削除するかの判断。`ServiceResult` / `isServiceError` の重複はこの dead code に由来する
 
 ## 実装メモ（任意）
 - `SqliteClient` は互換 shim として一時残し、内部で Gateway に委譲。`getSharedSqliteClient()` は Gateway の singleton を返す形に段階移行

--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -18,9 +18,8 @@
 |-----|------|--------|--------|-----------|------|
 | [02-feat-recording-orchestrator](2026-08-31-02-feat-recording-orchestrator.md) | ✨ | 🔴 | 🟡 | 🔶 | demolition + facade 化完了。alias/shim 削除と pipeline docs が残る |
 | [04-feat-composition-manifest](2026-08-31-04-feat-composition-manifest.md) | 🔧 | 🔴 | 🟡 | 🔶 | boilerplate 削除のみ。compositionManifest 本体は未実装 |
-| [05-feat-sqlite-gateway-unification](2026-08-31-05-feat-sqlite-gateway-unification.md) | 🔧 | 🔴 | 🟡 | 🔶 | Gateway 統合完了。InMemoryTransport の実装のみ残る |
 
-`pbi/` には上記 3 件が残る。各 PBI の「残作業」節を参照。
+`pbi/` には上記 2 件が残る。各 PBI の「残作業」節を参照。
 
 ---
 
@@ -44,11 +43,12 @@
 完了済みPBIは [dev-docs/archived/pbi/](../dev-docs/archived/pbi/)、
 その実装計画は [dev-docs/archived/plans/](../dev-docs/archived/plans/) にある。
 
-### 2026-08-31 Architecture Deepening 0831a — 3件完了（PBI 01 / 03 / 06）
+### 2026-08-31 Architecture Deepening 0831a — 4件完了（PBI 01 / 03 / 05 / 06）
 
 - 2026-08-31-01-fix-settings-dual-truth.md（RICE 2160 — `SettingsRepository` への一本化。`settingsStore.legacy.ts` / `settingsStore.ts` を削除し、`storage.ts` barrel を SettingsRepository 委譲に切り替え。旧 re-export を settingsMigration / urlWhitelist / storageMaintenance / savedUrlRepository へ振り直し。34 call sites + 約 90 テストファイルの import を移行。`getAll()` の scattered fallback を `__getAllScatteredFallback` test 専用 seam に分離。ADR `2026-03-20-default-settings-single-source.md` に Phase 4 追記。type-check / lint / test / build green）
 - 2026-08-31-03-fix-trustdb-god-module.md（RICE — trustDb god module を `TrustDbKernel`（lifecycle + 単一 `chrome.storage` 読取 + 単一 `withOptimisticLock`）/ `TrustPolicy`（`isDomainTrusted` / `isTrancoDomain` seam）/ `ManagedCollections`（userTlds / sensitive / whitelist 束ね）に分割。`trustDb.ts` は re-export shim に。settings アクセスを注入可能な `settingsReader` port 化し、ADR 2026-08-20 の循環 1 を解消。dead code の `whitelistStore.ts` / `sensitiveDomainStore.ts` を削除。DESIGN_SPEC §5.5 新設 + ADR 2026-08-20 に解消記録。11109 tests green。残: 破損 DB 復旧の手動 e2e 確認のみ）
 - 2026-08-31-06-feat-provider-catalog.md（RICE — Speculative。`ProviderCatalog` を単一 seam として先行実装。csp / cspSettings / DiagnosticsCollector / getMaxContentChars を Catalog 駆動化。DESIGN_SPEC §11.3 新設。再評価トリガー（次 provider 追加時）を backlog に明記。11109 tests green）
+- 2026-08-31-05-feat-sqlite-gateway-unification.md（RICE — 2 つの RPC スタックを `SqliteGateway`（query/mutate/maintain/status + 統一 `SqliteResult<T>`）に統合。`SqliteClient` / `dashboardSqliteService` を委譲 shim に。`queryPlan.ts` に WHERE 生成を集約し `IdbVfsBackend` / `searchHandlers` の重複を削除。`StorageBackend` を `Queryable` / `Mutable` に分割。dashboard hop の二重 `categorizeError` を修正。`OffscreenTransport` の 2nd adapter として `InMemoryTransport`（stateful in-memory store、chrome.* 不要）を実装。DESIGN_SPEC §5.4 追記。11117 tests green。フォローアップ: 未接続の `BrowsingLogRepository.ts`（PR #87 由来）の整理）
 
 ### 2026-08-30 VulnHunter 2026-08-29 監査対応 — 13件完了（PR #67–#81）
 

--- a/src/background/__tests__/inMemoryTransport.test.ts
+++ b/src/background/__tests__/inMemoryTransport.test.ts
@@ -1,0 +1,111 @@
+/**
+ * inMemoryTransport.test.ts
+ * InMemoryTransport is a real (stateful) OffscreenTransport for tests:
+ * SqliteGateway round-trips through it without an offscreen document or
+ * any chrome.* API (PBI 2026-08-31-05, Scenario 5).
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../../utils/logger.js', () => ({
+  logError: vi.fn(),
+  ErrorCode: { STORAGE_READ_FAILURE: 'STRG_RD_001' },
+}));
+vi.mock('../sqliteAlert.js', () => ({
+  recordSqliteSuccess: vi.fn(),
+  recordSqliteFailure: vi.fn(),
+}));
+
+import { InMemoryTransport } from '../inMemoryTransport.js';
+import { SqliteGateway } from '../sqliteGateway.js';
+import type { BrowsingLogRecord } from '../../utils/sqlite-types.js';
+
+function rec(over: Partial<BrowsingLogRecord> = {}): BrowsingLogRecord {
+  return { url: 'https://example.com/', domain: 'example.com', created_at: 1000, ...over };
+}
+
+describe('InMemoryTransport + SqliteGateway', () => {
+  let transport: InMemoryTransport;
+  let gateway: SqliteGateway;
+
+  beforeEach(() => {
+    transport = new InMemoryTransport();
+    gateway = new SqliteGateway(transport);
+  });
+
+  it('status() returns without touching chrome APIs', async () => {
+    const res = await gateway.status();
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.initialized).toBe(true);
+      expect(res.data.path).toBe(':memory:');
+    }
+  });
+
+  it('insert then query round-trips the record', async () => {
+    const inserted = await gateway.mutate({ type: 'insert', record: rec({ title: 'Hello' }) });
+    expect(inserted.success).toBe(true);
+
+    const q = await gateway.query({});
+    expect(q.success).toBe(true);
+    if (q.success) {
+      expect(q.data.total).toBe(1);
+      expect(q.data.rows[0]?.title).toBe('Hello');
+    }
+  });
+
+  it('query filters by domain', async () => {
+    await gateway.mutate({ type: 'insert', record: rec({ domain: 'a.com', url: 'https://a.com/' }) });
+    await gateway.mutate({ type: 'insert', record: rec({ domain: 'b.com', url: 'https://b.com/' }) });
+
+    const q = await gateway.query({ domain: 'b.com' });
+    expect(q.success && q.data.total).toBe(1);
+    expect(q.success && q.data.rows[0]?.domain).toBe('b.com');
+  });
+
+  it('count reflects inserts and soft-deletes', async () => {
+    const a = await gateway.mutate({ type: 'insert', record: rec() });
+    await gateway.mutate({ type: 'insert', record: rec() });
+    const beforeDelete = await gateway.query({ kind: 'count' });
+    expect(beforeDelete.success && beforeDelete.data).toBe(2);
+
+    if (a.success) await gateway.mutate({ type: 'delete', id: a.data.id });
+    const afterDelete = await gateway.query({ kind: 'count' });
+    expect(afterDelete.success && afterDelete.data).toBe(1);
+  });
+
+  it('toggleStar flips is_starred', async () => {
+    const ins = await gateway.mutate({ type: 'insert', record: rec() });
+    const id = ins.success ? ins.data.id : 0;
+
+    const first = await gateway.mutate({ type: 'toggleStar', id });
+    expect(first.success && first.data.is_starred).toBe(1);
+    const second = await gateway.mutate({ type: 'toggleStar', id });
+    expect(second.success && second.data.is_starred).toBe(0);
+  });
+
+  it('seeded records are queryable immediately', async () => {
+    transport = new InMemoryTransport({ records: [rec({ title: 'seed-1' }), rec({ title: 'seed-2' })] });
+    gateway = new SqliteGateway(transport);
+
+    const q = await gateway.query({});
+    expect(q.success && q.data.total).toBe(2);
+  });
+
+  it('text search matches title substring', async () => {
+    await gateway.mutate({ type: 'insert', record: rec({ title: 'unique-token-here' }) });
+    await gateway.mutate({ type: 'insert', record: rec({ title: 'something else' }) });
+
+    const q = await gateway.query({ kind: 'search', text: 'unique-token' });
+    expect(q.success && q.data.total).toBe(1);
+  });
+
+  it('clearAll empties the store', async () => {
+    await gateway.mutate({ type: 'insert', record: rec() });
+    await gateway.maintain({ type: 'clearAll' });
+    expect(transport.wasCleared()).toBe(true);
+
+    const q = await gateway.query({ kind: 'count' });
+    expect(q.success && q.data).toBe(0);
+  });
+});

--- a/src/background/inMemoryTransport.ts
+++ b/src/background/inMemoryTransport.ts
@@ -1,0 +1,216 @@
+/**
+ * InMemoryTransport
+ * An OffscreenTransport backed by an in-memory record array.
+ *
+ * Lets SqliteGateway (and SqliteClient) be exercised in tests without an
+ * offscreen document or any chrome.* API: insert a record, query it back,
+ * count, toggle star, delete, and read status all round-trip through the
+ * same seam production uses.
+ *
+ * This is deliberately not a full SQL engine — it covers the operations the
+ * gateway issues, with a filter that mirrors buildExtraWhereSql's semantics
+ * (domain / starred / date range / ids) plus a substring match for `text`.
+ */
+
+import type { OffscreenTransport } from './offscreenTransport.js';
+import type { SqliteMessageType } from '../messaging/sqliteMessages.js';
+import type { OffscreenResponse } from '../messaging/sqliteMessages.js';
+import type { BrowsingLogRecord } from '../utils/sqlite-types.js';
+
+interface QueryPayload {
+  text?: string;
+  domain?: string;
+  starred?: boolean;
+  dateFrom?: number;
+  dateTo?: number;
+  gistSynced?: number;
+  ids?: number[];
+  limit?: number;
+  offset?: number;
+  orderBy?: string;
+  orderDir?: 'ASC' | 'DESC';
+}
+
+const FTS_CAP = 100_000;
+const PLAIN_CAP = 1_000;
+
+export interface InMemoryTransportOptions {
+  /** Seed records. Ids are assigned if absent. */
+  records?: BrowsingLogRecord[];
+  /** Overrides for the STATUS response. */
+  status?: Partial<Extract<OffscreenResponse, { initialized: boolean; path: string }>>;
+}
+
+export class InMemoryTransport implements OffscreenTransport {
+  private records: BrowsingLogRecord[] = [];
+  private nextId = 1;
+  private cleared = false;
+  private readonly statusOverrides: InMemoryTransportOptions['status'];
+
+  /** The last payload handled — handy for asserting what the gateway sent. */
+  lastPayload: Record<string, unknown> | null = null;
+
+  constructor(opts: InMemoryTransportOptions = {}) {
+    this.statusOverrides = opts.status;
+    for (const r of opts.records ?? []) this.insertRecord(r);
+  }
+
+  /** Current record snapshot (copy) for assertions. */
+  getRecords(): BrowsingLogRecord[] {
+    return this.records.map((r) => ({ ...r }));
+  }
+
+  async msgOffscreen(
+    type: SqliteMessageType,
+    payload: Record<string, unknown> = {},
+    _traceId?: string
+  ): Promise<OffscreenResponse> {
+    this.lastPayload = payload;
+    switch (type) {
+      case 'SQLITE_INIT':
+      case 'SQLITE_HEALTH_CHECK':
+        return { success: true, initialized: true };
+
+      case 'SQLITE_INSERT': {
+        const id = this.insertRecord(payload as unknown as BrowsingLogRecord);
+        return { success: true, id };
+      }
+      case 'SQLITE_INSERT_BATCH': {
+        const list = (payload.records as BrowsingLogRecord[] | undefined) ?? [];
+        for (const r of list) this.insertRecord(r);
+        return { success: true, count: list.length };
+      }
+      case 'SQLITE_AUDIT_LOG_INSERT':
+        return { success: true, id: this.nextId++ };
+
+      case 'SQLITE_QUERY':
+      case 'SQLITE_SEARCH': {
+        const { rows, total } = this.select(payload as QueryPayload);
+        return { success: true, rows, total };
+      }
+      case 'SQLITE_AUDIT_LOG_QUERY':
+        return { success: true, rows: [], total: 0 };
+
+      case 'SQLITE_COUNT': {
+        const { total } = this.select(payload as QueryPayload, { countOnly: true });
+        return { success: true, count: total };
+      }
+
+      case 'SQLITE_UPDATE': {
+        const { id, ...changes } = payload as { id: number } & Partial<BrowsingLogRecord>;
+        const row = this.records.find((r) => r.id === id);
+        if (row) Object.assign(row, changes);
+        return { success: true };
+      }
+      case 'SQLITE_DELETE': {
+        const id = payload.id as number;
+        const row = this.records.find((r) => r.id === id);
+        if (row) row.is_deleted = 1;
+        return { success: true };
+      }
+      case 'SQLITE_TOGGLE_STAR': {
+        const id = payload.id as number;
+        const row = this.records.find((r) => r.id === id);
+        const next = row?.is_starred ? 0 : 1;
+        if (row) row.is_starred = next;
+        return { success: true, is_starred: next };
+      }
+      case 'SQLITE_CLEAR_ALL':
+        this.records = [];
+        this.cleared = true;
+        return { success: true };
+      case 'SQLITE_RESTORE':
+        return { success: true };
+
+      case 'SQLITE_STATUS':
+        return {
+          success: true,
+          initialized: true,
+          path: ':memory:',
+          fallback: false,
+          fts5: true,
+          ...this.statusOverrides,
+        };
+
+      case 'SQLITE_PURGE':
+      case 'CONTENT_PURGE':
+        return { success: true, purged: 0 };
+
+      case 'SQLITE_BACKUP':
+      case 'SQLITE_EXPORT':
+        return { success: true, data: [] };
+
+      case 'SQLITE_OPFS_SPIKE':
+        return { success: false, error: 'OPFS spike is not supported by InMemoryTransport' };
+
+      default: {
+        const exhaustive: never = type;
+        return { success: false, error: `InMemoryTransport: unhandled message '${String(exhaustive)}'` };
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------------
+
+  private insertRecord(record: BrowsingLogRecord): number {
+    const id = record.id ?? this.nextId++;
+    if (id >= this.nextId) this.nextId = id + 1;
+    this.records.push({ ...record, id });
+    return id;
+  }
+
+  private select(
+    q: QueryPayload,
+    opts: { countOnly?: boolean } = {}
+  ): { rows: BrowsingLogRecord[]; total: number } {
+    let rows = this.records.filter((r) => !r.is_deleted);
+
+    if (q.domain) rows = rows.filter((r) => r.domain === q.domain);
+    if (q.starred != null) rows = rows.filter((r) => Boolean(r.is_starred) === q.starred);
+    if (q.gistSynced != null) rows = rows.filter((r) => (r.gist_synced ?? 0) === q.gistSynced);
+    if (q.dateFrom != null) rows = rows.filter((r) => r.created_at >= q.dateFrom!);
+    if (q.dateTo != null) rows = rows.filter((r) => r.created_at <= q.dateTo!);
+    if (q.ids?.length) {
+      const set = new Set(q.ids);
+      rows = rows.filter((r) => r.id != null && set.has(r.id));
+    }
+    if (q.text) {
+      const bare = q.text.trim().toLowerCase();
+      // trigram tokenizer needs >= 3 chars; shorter queries return nothing here
+      // (production falls back to LIKE — the gateway shortcuts before calling us).
+      if (bare.length > 0) {
+        rows = rows.filter((r) =>
+          [r.title, r.summary, r.content, r.url]
+            .some((f) => typeof f === 'string' && f.toLowerCase().includes(bare))
+        );
+      }
+    }
+
+    const total = rows.length;
+    if (opts.countOnly) return { rows: [], total };
+
+    const dir = q.orderDir === 'ASC' ? 1 : -1;
+    const key = (q.orderBy as keyof BrowsingLogRecord) || 'created_at';
+    rows = [...rows].sort((a, b) => {
+      const av = a[key] ?? 0;
+      const bv = b[key] ?? 0;
+      return av < bv ? -1 * dir : av > bv ? 1 * dir : 0;
+    });
+
+    const cap = q.text ? FTS_CAP : PLAIN_CAP;
+    const limit = clampPositive(q.limit, cap);
+    const offset = clampPositive(q.offset, Number.MAX_SAFE_INTEGER, 0);
+    return { rows: rows.slice(offset, offset + limit), total };
+  }
+
+  /** Test helper: whether SQLITE_CLEAR_ALL was received. */
+  wasCleared(): boolean {
+    return this.cleared;
+  }
+}
+
+function clampPositive(value: unknown, cap: number, fallback = cap): number {
+  const n = typeof value === 'number' && Number.isFinite(value) ? Math.floor(value) : NaN;
+  if (Number.isNaN(n) || n <= 0) return fallback;
+  return Math.min(n, cap);
+}


### PR DESCRIPTION
## 概要

PBI 05（SQLite Gateway 統一）の唯一の未完項目 `InMemoryTransport` adapter を実装し、PBI を完了して archive する。

前提 PR: #88（Gateway 統合本体）、#89（docs 残作業）— いずれもマージ済み。

## 変更

### `src/background/inMemoryTransport.ts`（新規）
`OffscreenTransport` の 2nd adapter。stateful な in-memory record store で、offscreen document も `chrome.*` API も起動せずに `SqliteGateway` の insert → query → count → toggleStar → delete → status が round-trip する。

- フィルタは `buildExtraWhereSql` のセマンティクス（domain / starred / date range / ids）＋ `text` の部分一致
- limit clamp は fts 100000 / plain 1000 を踏襲
- `getRecords()` / `wasCleared()` / `lastPayload` の assertion ヘルパ

### `src/background/__tests__/inMemoryTransport.test.ts`（新規）
`SqliteGateway` + `InMemoryTransport` の 8 シナリオ（PBI 05 Scenario 5 の自動テスト化）。

### docs
- DESIGN_SPEC §5.4 に Transport adapters を追記
- PBI 05 の全 DoD が checked → `dev-docs/archived/pbi/` へ移動、INDEX 更新（進行中は 02 / 04 の 2 件に）
- `BrowsingLogRepository.ts`（PR #87 由来の未接続コード、296 行、consumer / test なし）由来の `isServiceError` 重複は本 PBI 対象外とし、フォローアップに記録

## 検証

- `npm run type-check` / `npm run lint` / `npm run build` green
- `npm test` — 11117 passed / 20 skipped / 0 failed（+8）

🤖 Generated with [Claude Code](https://claude.com/claude-code)