### PR TITLE
docs(pbi): 0831a のフォローアップ 2 件を PBI 化

### DIFF
--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -14,12 +14,13 @@
 
 ## 進行中 ⬜ 未着手 / 🔶 部分実装
 
-**進行中の PBI は 0 件。** `pbi/` には INDEX と backlog のみが残る。
+| PBI | 種別 | 難易度 | 副作用 | ステータス | 備考 |
+|-----|------|--------|--------|-----------|------|
+| [2026-09-01-01-refactor-recording-pipeline-facade-removal](2026-09-01-01-refactor-recording-pipeline-facade-removal.md) | 🔧 | 🔴 | 🟡 | ⬜ | PBI 2026-08-31-02 の残余。facade クラス + `createRecordingPipeline` を撤去し全 caller を Orchestrator 直接利用へ（~12 テスト移行） |
+| [2026-09-01-02-refactor-browsinglog-repository-decision](2026-09-01-02-refactor-browsinglog-repository-decision.md) | 🔧 | 🟢 | 🟢 | ⬜ | PBI 2026-08-31-05 の残余。未接続の `BrowsingLogRepository.ts`（296 行）を接続 or 削除。`ServiceResult` / `isServiceError` の重複解消 |
 
-### フォローアップ候補（未 PBI 化）
-- `RecordingPipeline` facade（`execute` / `record` / `retryObsidianWriteOnly`）と `createRecordingPipeline` の完全撤去。~12 テストファイル + `offlineQueueProcessor` + `recordingHandlers` を `RecordingOrchestrator` 直接利用へ移行。PBI 02 の残余（blast radius 大）
-- `src/dashboard/BrowsingLogRepository.ts`（PR #87 由来、consumer / test なし、296 行）を wire-up するか削除するか。`ServiceResult` / `isServiceError` の重複はこの dead code に由来（PBI 05 のフォローアップ）
-- PBI 06 の効果確認（次に AI provider を追加するとき、`ProviderCatalog` 駆動化で追加が 1 箇所で済むか。詳細は `2026-08-31-00-backlog.md`）
+### 未 PBI 化のトリガー
+- PBI 06 の効果確認: 次に AI provider を追加するとき、`ProviderCatalog` 駆動化で追加が 1 箇所で済むか確認する（詳細は `2026-08-31-00-backlog.md` の「PBI 06 — Speculative の扱い」節）
 
 ---
 

--- a/pbi/2026-09-01-01-refactor-recording-pipeline-facade-removal.md
+++ b/pbi/2026-09-01-01-refactor-recording-pipeline-facade-removal.md
@@ -1,0 +1,36 @@
+# PBI: RecordingPipeline facade の完全撤去 — 全 caller を RecordingOrchestrator 直接利用へ
+
+## ユーザーストーリー
+開発者として、Recording の実行経路を `RecordingOrchestrator` 一つに統一したい。なぜなら現在は互換 facade の `RecordingPipeline`（`execute` / `record` / `retryObsidianWriteOnly` の 3 メソッド）と `createRecordingPipeline` が残っており、新しい経路を書くときに「facade を使うのか orchestrator を使うのか」を毎回判断させられ、facade → orchestrator の薄い委譲を追う往復が発生するから。
+
+## 背景
+PBI 2026-08-31-02（RecordingOrchestrator 単一 Seam 化）で orchestrator への集約と `perUrlMutexMap` の race 修正、`buildRecordingPipelineDeps` / `recordWithPreview` の削除まで完了した。残ったのは facade クラス本体と `createRecordingPipeline` の撤去で、これは blast radius が大きいため独立 PBI として切り出した。
+
+### 現状の caller
+- **production**
+  - `createBackgroundServices` / `compositionManifest.ts` — `createRecordingPipeline({...})` で生成し container に登録
+  - `recordingHandlers.ts:229,288` — `pipeline.execute(data)`（明示 settings 経由。orchestrator には `execute` がなく `record` が settings を再取得する）
+  - `offlineQueueProcessor.ts` — `RecordingPipelineLike` interface 経由で `record` と `retryObsidianWriteOnly`
+  - `MessageRouterDeps.recordingPipeline` — `Pick<RecordingPipeline, 'record'>`
+- **test**: 約 12 ファイル（`recordingPipeline-*.test.ts` / `RecordingPipeline*.test.ts` / `service-worker.test.ts` / `backgroundComposition.test.ts` / `createBackgroundServices.test.ts` / `helpers/makeRecordingLogic.ts` / `checkPrivacyHeadersStep.test.ts` 他）が `RecordingPipeline` / `createRecordingPipeline` を import またはモック
+
+## 受け入れ基準
+- [ ] `RecordingOrchestrator` に `execute(data, settings)` 相当の明示 settings 経路が用意されるか、`recordingHandlers` が `record(data)` + 事前 settings 注入に移行する
+- [ ] `offlineQueueProcessor` の `RecordingPipelineLike` が `RecordingOrchestrator` の公開 Interface（`record` + retryObsidian mode）で表現され、`retryObsidianWriteOnly` の呼び出しが `record(job, { mode: 'retryObsidian' })` に置換される
+- [ ] `compositionManifest.ts` の `recordingPipeline` エントリが `createRecordingOrchestrator` 直接生成になる
+- [ ] `RecordingPipeline.ts`（facade クラス + `createRecordingPipeline`）が削除される
+- [ ] 約 12 テストファイルが `RecordingOrchestrator` seam でパスする（`makeRecordingLogic` ヘルパを orchestrator 生成に書き換え）
+- [ ] `MessageRouterDeps.recordingPipeline` の `Pick` 型が orchestrator 由来になる
+
+## テスト戦略
+- 統合: 3 経路（VALID_VISIT / MANUAL_RECORD / SAVE_RECORD / PREVIEW_RECORD / offline retry）が orchestrator 経由で観測可能挙動を保つ
+- 単体: `recordingHandlers` の明示 settings 経路、offline retry の retryObsidian mode
+
+## 見積もり
+5 pt — orchestrator の `execute` 相当 API 追加 1pt + caller 3 経路の移行 2pt + テスト 12 ファイル移行 2pt
+
+## Definition of Done
+- [ ] 全 caller が `RecordingOrchestrator` 直接利用
+- [ ] `RecordingPipeline.ts` 削除
+- [ ] `npm run validate` が green
+- [ ] DESIGN_SPECIFICATIONS.md の pipeline 記述を facade 前提から orchestrator 前提に更新

--- a/pbi/2026-09-01-02-refactor-browsinglog-repository-decision.md
+++ b/pbi/2026-09-01-02-refactor-browsinglog-repository-decision.md
@@ -1,0 +1,27 @@
+# PBI: BrowsingLogRepository の接続または削除 — dashboard SQLite アクセスの deep module 化を完遂 or 撤回
+
+## ユーザーストーリー
+開発者として、dashboard から SQLite への読み書き経路を一つに絞りたい。なぜなら現在 `src/dashboard/dashboardSqliteService.ts`（live、20 弱の shallow 関数 + `DashboardSqliteGateway` 委譲）と `src/dashboard/BrowsingLogRepository.ts`（未接続、296 行の deep module、consumer / test ゼロ）が並存し、`ServiceResult` / `isServiceError` が両方に重複定義されているから。
+
+## 背景
+`BrowsingLogRepository.ts` は PR #87（plan/0830 backlog execution）で「20 shallow 関数 → 1 seam」を狙って実装されたが、caller の移行が行われず未接続のまま残った。その後 PBI 2026-08-31-05（SQLite Gateway 統一）で `dashboardSqliteService.ts` 側が `DashboardSqliteGateway` 委譲にリファクタされ、`BrowsingLogRepository` はそのリファクタにも追従していない（独自の `sendDashboardMessage` を持つ）。
+
+## 選択肢
+1. **接続**: PR #87 の当初意図どおり、dashboard の query/search/toggleStar/delete/getCount/getStatus 呼出しを `BrowsingLogRepository` に移し、`dashboardSqliteService` の該当 shallow 関数を削除。`BrowsingLogRepository` を Gateway 委譲にリファクタして PBI 05 と整合させる
+2. **削除**: `BrowsingLogRepository.ts` を削除。`dashboardSqliteService.ts`（Gateway 委譲済み）を唯一の経路として確定
+
+判断材料: `dashboardSqliteService.ts` の shallow 関数群が現時点で実害（追加コスト / バグ）を出しているか。出していなければ削除（YAGNI）、出しているなら接続。
+
+## 受け入れ基準
+- [ ] `BrowsingLogRepository.ts` が削除される、または全 dashboard SQLite 呼出しの唯一の経路になる
+- [ ] `ServiceResult` / `isServiceError` の定義が 1 箇所のみ
+- [ ] `dashboardSqliteService.ts` と `BrowsingLogRepository.ts` が同時に存在しない
+
+## 見積もり
+- 削除の場合: 1 pt
+- 接続の場合: 3 pt（caller 移行 + Gateway 整合 + テスト追加）
+
+## Definition of Done
+- [ ] 上記いずれかが完了
+- [ ] `npm run validate` が green
+- [ ] DESIGN_SPECIFICATIONS.md §5.4 の記述と実装が一致


### PR DESCRIPTION
## 概要

Architecture Deepening 0831a（PBI 01〜06、PR #88〜#92）完了後に残ったフォローアップを独立 PBI として切り出す。ドキュメントのみ。

## 追加 PBI

| PBI | 由来 | 見積 | 内容 |
|-----|------|------|------|
| `2026-09-01-01-refactor-recording-pipeline-facade-removal` | PBI 2026-08-31-02 の残余 | 5pt | `RecordingPipeline` facade クラス + `createRecordingPipeline` を撤去し、全 caller（`recordingHandlers` / `offlineQueueProcessor` / `compositionManifest` / ~12 テスト）を `RecordingOrchestrator` 直接利用へ |
| `2026-09-01-02-refactor-browsinglog-repository-decision` | PBI 2026-08-31-05 の残余 | 削除 1pt / 接続 3pt | 未接続の `BrowsingLogRepository.ts`（296 行、consumer / test ゼロ）を接続 or 削除。`ServiceResult` / `isServiceError` の重複を解消 |

PBI 06 の効果確認は「次に AI provider を追加するとき」のトリガーであり PBI ではないため、INDEX の「未 PBI 化のトリガー」節に残す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)