### PR TITLE
feat(dashboard): catalog 駆動の provider UI builder を追加 (PBI 06c-1)

### DIFF
--- a/src/background/ai/__tests__/providerCatalog.test.ts
+++ b/src/background/ai/__tests__/providerCatalog.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { PROVIDER_CATALOG, ProviderCatalog, UnknownProviderError } from '../providerCatalog.js';
 import { StorageKeys } from '../../../utils/storage/types.js';
 import type { ProviderId } from '../../../utils/storage/types.js';
+import { getMessage } from '../../../utils/i18n.js';
 
 // The full ProviderId union, spelled out because a union type is not
 // runtime-available. If ProviderId changes this list must change with it —
@@ -97,6 +98,41 @@ describe('ProviderCatalog conformance', () => {
     // so adding a provider does not force a test edit here.
     for (const key of providerKeys) {
       expect(KNOWN_STORAGE_KEYS.has(key), key).toBe(true);
+    }
+  });
+
+  // --- 06c UI metadata ---
+
+  it('every entry has a labelI18nKey that resolves to a message', () => {
+    for (const [id, entry] of PROVIDER_CATALOG) {
+      expect(entry.labelI18nKey, id).toBeTruthy();
+      expect(getMessage(entry.labelI18nKey), `${id}: ${entry.labelI18nKey}`).toBeTruthy();
+    }
+  });
+
+  it('fieldPlaceholders, when present, resolve to messages', () => {
+    for (const [id, entry] of PROVIDER_CATALOG) {
+      if (!entry.fieldPlaceholders) continue;
+      for (const key of Object.values(entry.fieldPlaceholders)) {
+        if (key) expect(getMessage(key), `${id}: ${key}`).toBeTruthy();
+      }
+    }
+  });
+
+  it('supportsCustomPrompt is true exactly for gemini/openai/openai2/lm-studio/ollama', () => {
+    const yes = [...PROVIDER_CATALOG].filter(([, e]) => e.supportsCustomPrompt).map(([id]) => id).sort();
+    expect(yes).toEqual(['gemini', 'lm-studio', 'ollama', 'openai', 'openai2'].sort());
+  });
+
+  it('dropdown order is gemini, openai, openai2, lm-studio, ollama, openai-compatible, built-in-ai', () => {
+    expect([...PROVIDER_CATALOG.keys()]).toEqual([
+      'gemini', 'openai', 'openai2', 'lm-studio', 'ollama', 'openai-compatible', 'built-in-ai',
+    ]);
+  });
+
+  it('settingsBlockKind is set on every entry', () => {
+    for (const [id, entry] of PROVIDER_CATALOG) {
+      expect(['generic', 'models-dev', 'built-in-ai'], id).toContain(entry.settingsBlockKind);
     }
   });
 });

--- a/src/background/ai/providerRegistry.ts
+++ b/src/background/ai/providerRegistry.ts
@@ -23,15 +23,44 @@ export interface ProviderRegistryEntry {
     readonly defaultModel?: string;
     readonly requiresApiKey: boolean;
     readonly isLocal: boolean;
-    /** Brand display name (not localized). */
+    /** Brand display name (not localized) — fallback if labelI18nKey resolves to nothing. */
     readonly label: string;
     /** CSP origin to allow when this provider is active; undefined for user-configured / no-network providers. */
     readonly cspDomain?: string;
     /** Storage key for the per-provider send-content char limit. */
     readonly contentCharsKey?: string;
+    /** i18n key NAME (stable id, not localized text) for the options-page dropdown label. */
+    readonly labelI18nKey: string;
+    /** i18n key names for the settings-form input placeholders; only present fields need entries. */
+    readonly fieldPlaceholders?: {
+        readonly apiKey?: string;
+        readonly baseUrl?: string;
+        readonly model?: string;
+    };
+    /** Offered in the custom-prompt "Apply to Provider" select. */
+    readonly supportsCustomPrompt: boolean;
+    /** How the per-provider settings block renders on the options page. */
+    readonly settingsBlockKind?: 'generic' | 'models-dev' | 'built-in-ai';
 }
 
+// Insertion order == the options-page provider dropdown order.
 export const PROVIDER_REGISTRY: ReadonlyMap<ProviderId, ProviderRegistryEntry> = new Map<ProviderId, ProviderRegistryEntry>([
+    [
+        'gemini',
+        {
+            apiKeyKey: StorageKeys.GEMINI_API_KEY,
+            modelKey: StorageKeys.GEMINI_MODEL,
+            requiresApiKey: true,
+            isLocal: false,
+            label: 'Google Gemini',
+            cspDomain: 'https://generativelanguage.googleapis.com',
+            contentCharsKey: StorageKeys.GEMINI_CONTENT_CHARS,
+            labelI18nKey: 'googleGemini',
+            fieldPlaceholders: { apiKey: 'geminiApiKeyPlaceholder', model: 'geminiModelPlaceholder' },
+            supportsCustomPrompt: true,
+            settingsBlockKind: 'generic',
+        },
+    ],
     [
         'openai',
         {
@@ -45,6 +74,14 @@ export const PROVIDER_REGISTRY: ReadonlyMap<ProviderId, ProviderRegistryEntry> =
             label: 'OpenAI Compatible',
             cspDomain: 'https://api.openai.com',
             contentCharsKey: StorageKeys.OPENAI_CONTENT_CHARS,
+            labelI18nKey: 'openaiCompatible',
+            fieldPlaceholders: {
+                apiKey: 'openaiApiKeyPlaceholder',
+                baseUrl: 'openaiBaseUrlPlaceholder',
+                model: 'openaiModelPlaceholder',
+            },
+            supportsCustomPrompt: true,
+            settingsBlockKind: 'generic',
         },
     ],
     [
@@ -60,18 +97,14 @@ export const PROVIDER_REGISTRY: ReadonlyMap<ProviderId, ProviderRegistryEntry> =
             label: 'OpenAI Compatible 2',
             cspDomain: 'https://api.openai.com',
             contentCharsKey: StorageKeys.OPENAI_CONTENT_CHARS,
-        },
-    ],
-    [
-        'openai-compatible',
-        {
-            baseUrlKey: StorageKeys.PROVIDER_BASE_URL,
-            apiKeyKey: StorageKeys.PROVIDER_API_KEY,
-            modelKey: StorageKeys.PROVIDER_MODEL,
-            requiresApiKey: true,
-            isLocal: false,
-            label: 'OpenAI Compatible',
-            contentCharsKey: StorageKeys.OPENAI_CONTENT_CHARS,
+            labelI18nKey: 'openaiCompatible2',
+            fieldPlaceholders: {
+                apiKey: 'openai2ApiKeyPlaceholder',
+                baseUrl: 'openai2BaseUrlPlaceholder',
+                model: 'openai2ModelPlaceholder',
+            },
+            supportsCustomPrompt: true,
+            settingsBlockKind: 'generic',
         },
     ],
     [
@@ -84,6 +117,10 @@ export const PROVIDER_REGISTRY: ReadonlyMap<ProviderId, ProviderRegistryEntry> =
             isLocal: true,
             label: 'LM Studio',
             cspDomain: 'http://127.0.0.1:1234',
+            labelI18nKey: 'lmStudio',
+            fieldPlaceholders: { baseUrl: 'lmStudioBaseUrlPlaceholder', model: 'lmStudioModelPlaceholder' },
+            supportsCustomPrompt: true,
+            settingsBlockKind: 'generic',
         },
     ],
     [
@@ -96,18 +133,30 @@ export const PROVIDER_REGISTRY: ReadonlyMap<ProviderId, ProviderRegistryEntry> =
             isLocal: true,
             label: 'Ollama',
             cspDomain: 'http://localhost:11434',
+            labelI18nKey: 'ollama',
+            fieldPlaceholders: { baseUrl: 'ollamaBaseUrlPlaceholder', model: 'ollamaModelPlaceholder' },
+            supportsCustomPrompt: true,
+            settingsBlockKind: 'generic',
         },
     ],
     [
-        'gemini',
+        'openai-compatible',
         {
-            apiKeyKey: StorageKeys.GEMINI_API_KEY,
-            modelKey: StorageKeys.GEMINI_MODEL,
+            baseUrlKey: StorageKeys.PROVIDER_BASE_URL,
+            apiKeyKey: StorageKeys.PROVIDER_API_KEY,
+            modelKey: StorageKeys.PROVIDER_MODEL,
             requiresApiKey: true,
             isLocal: false,
-            label: 'Google Gemini',
-            cspDomain: 'https://generativelanguage.googleapis.com',
-            contentCharsKey: StorageKeys.GEMINI_CONTENT_CHARS,
+            label: 'OpenAI Compatible',
+            contentCharsKey: StorageKeys.OPENAI_CONTENT_CHARS,
+            labelI18nKey: 'openaiCompatibleModelsDev',
+            fieldPlaceholders: {
+                apiKey: 'providerApiKeyPlaceholder',
+                baseUrl: 'providerBaseUrlPlaceholder',
+                model: 'providerModelPlaceholder',
+            },
+            supportsCustomPrompt: false,
+            settingsBlockKind: 'models-dev',
         },
     ],
     [
@@ -117,6 +166,9 @@ export const PROVIDER_REGISTRY: ReadonlyMap<ProviderId, ProviderRegistryEntry> =
             requiresApiKey: false,
             isLocal: true,
             label: 'Built-in AI',
+            labelI18nKey: 'builtInAi',
+            supportsCustomPrompt: false,
+            settingsBlockKind: 'built-in-ai',
         },
     ],
 ]);

--- a/src/dashboard/__tests__/aiProviderCatalogView.test.ts
+++ b/src/dashboard/__tests__/aiProviderCatalogView.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ * aiProviderCatalogView.test.ts — catalog-driven provider UI builders.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  renderProviderOptions,
+  renderProviderSettings,
+  providerIdsInOrder,
+} from '../aiProviderCatalogView.js';
+
+describe('providerIdsInOrder', () => {
+  it('returns the dropdown order', () => {
+    expect(providerIdsInOrder()).toEqual([
+      'gemini', 'openai', 'openai2', 'lm-studio', 'ollama', 'openai-compatible', 'built-in-ai',
+    ]);
+  });
+});
+
+describe('renderProviderOptions', () => {
+  let sel: HTMLSelectElement;
+  beforeEach(() => { sel = document.createElement('select'); });
+
+  it('renders all 7 providers in catalog order with localized text', () => {
+    renderProviderOptions(sel);
+    expect([...sel.options].map((o) => o.value)).toEqual([
+      'gemini', 'openai', 'openai2', 'lm-studio', 'ollama', 'openai-compatible', 'built-in-ai',
+    ]);
+    expect(sel.options[0].textContent).toBe('Google Gemini');
+    expect(sel.options[6].textContent).toContain('Built-in AI');
+  });
+
+  it('includeNone prepends an empty option', () => {
+    renderProviderOptions(sel, { includeNone: true });
+    expect(sel.options[0].value).toBe('');
+    expect(sel.options.length).toBe(8);
+  });
+
+  it('customPrompt keeps only gemini/openai/openai2/lm-studio/ollama and prepends "all"', () => {
+    renderProviderOptions(sel, { customPrompt: true });
+    expect([...sel.options].map((o) => o.value)).toEqual(['all', 'gemini', 'openai', 'openai2', 'lm-studio', 'ollama']);
+  });
+
+  it('preserves the current value when the option still exists', () => {
+    sel.innerHTML = '<option value="ollama">x</option>';
+    sel.value = 'ollama';
+    renderProviderOptions(sel);
+    expect(sel.value).toBe('ollama');
+  });
+});
+
+describe('renderProviderSettings', () => {
+  let c: HTMLElement;
+  beforeEach(() => { c = document.createElement('div'); document.body.appendChild(c); });
+
+  it('gemini: password api key + model + api version rows', () => {
+    renderProviderSettings(c, 'gemini');
+    expect(c.id).toBe('geminiSettings');
+    expect(c.querySelector('input[data-storage-key="gemini_api_key"]')?.getAttribute('type')).toBe('password');
+    expect(c.querySelector('#geminiModel')?.getAttribute('data-storage-key')).toBe('gemini_model');
+    expect(c.querySelector('#geminiApiVersion')?.getAttribute('data-storage-key')).toBe('gemini_api_version');
+    expect(c.querySelector('#geminiApiVersionNote')).not.toBeNull();
+    expect(c.querySelector('#geminiApiVersionError')).not.toBeNull();
+  });
+
+  it('openai: base url + api key + model with correct storage keys', () => {
+    renderProviderSettings(c, 'openai');
+    expect(c.id).toBe('openaiSettings');
+    expect(c.classList.contains('openai-settings')).toBe(true);
+    expect(c.querySelector('#openaiBaseUrl')?.getAttribute('data-storage-key')).toBe('openai_base_url');
+    expect(c.querySelector('#openaiApiKey')?.getAttribute('type')).toBe('password');
+    expect(c.querySelector('#openaiModel')?.getAttribute('data-storage-key')).toBe('openai_model');
+  });
+
+  it('lm-studio: no api key row (requiresApiKey false)', () => {
+    renderProviderSettings(c, 'lm-studio');
+    expect(c.querySelector('input[type="password"]')).toBeNull();
+    expect(c.querySelector('#lmStudioBaseUrl')).not.toBeNull();
+    expect(c.querySelector('#lmStudioModel')).not.toBeNull();
+  });
+
+  it('built-in-ai: help text only, no inputs', () => {
+    renderProviderSettings(c, 'built-in-ai');
+    expect(c.querySelector('.help-text')).not.toBeNull();
+    expect(c.querySelector('input')).toBeNull();
+  });
+
+  it('openai-compatible: models-dev button + preset buttons + provider_* inputs', () => {
+    renderProviderSettings(c, 'openai-compatible');
+    expect(c.querySelector('#openModelsDevDialogBtn')).not.toBeNull();
+    expect(c.querySelector('#lmStudioPresetBtn')).not.toBeNull();
+    expect(c.querySelector('#ollamaPresetBtn')).not.toBeNull();
+    expect(c.querySelector('#selectedProviderInfo')).not.toBeNull();
+    expect(c.querySelector('#providerInfoDisplay')).not.toBeNull();
+    expect(c.querySelector('#providerBaseUrl')?.getAttribute('data-storage-key')).toBe('provider_base_url');
+    expect(c.querySelector('#providerApiKey')?.getAttribute('type')).toBe('password');
+    expect(c.querySelector('#providerModel')?.getAttribute('data-storage-key')).toBe('provider_model');
+  });
+
+  it('applies i18n placeholders to the generated inputs', () => {
+    renderProviderSettings(c, 'openai');
+    const baseUrl = c.querySelector('#openaiBaseUrl') as HTMLInputElement;
+    expect(baseUrl.placeholder.length).toBeGreaterThan(0);
+  });
+
+  it('rebuilds cleanly on a second call', () => {
+    renderProviderSettings(c, 'openai');
+    renderProviderSettings(c, 'gemini');
+    expect(c.id).toBe('geminiSettings');
+    expect(c.querySelector('#openaiBaseUrl')).toBeNull();
+    expect(c.querySelector('#geminiApiVersion')).not.toBeNull();
+  });
+});

--- a/src/dashboard/aiProviderCatalogView.ts
+++ b/src/dashboard/aiProviderCatalogView.ts
@@ -1,0 +1,237 @@
+/**
+ * aiProviderCatalogView.ts
+ * Catalog-driven builders for the options-page AI provider UI.
+ *
+ * Both layouts (A: unified, B: per-provider accordion) call these instead of
+ * hand-maintaining `<option>` groups, per-provider `<div>`s, and visibility
+ * if-chains. Adding a provider = one PROVIDER_REGISTRY row + i18n keys.
+ *
+ * Element ids and data-* attributes match the former static markup in
+ * entrypoints/options/index.html exactly, so existing binding
+ * (settingsFormBinding, fieldValidation, preset/models-dev handlers) is
+ * untouched. Every builder calls applyI18n() on its subtree because the
+ * page-level applyI18n ran at load, before these nodes existed.
+ */
+
+import { PROVIDER_CATALOG, type ProviderCatalogEntry } from '../background/ai/providerCatalog.js';
+import type { ProviderId } from '../utils/storage/types.js';
+import { getMessage } from '../utils/i18n.js';
+import { applyI18n } from '../utils/i18n-dom.js';
+
+/** storage key → the input element id the former static markup used. */
+const KEY_TO_INPUT_ID: Record<string, string> = {
+  gemini_api_key: 'geminiApiKey',
+  gemini_model: 'geminiModel',
+  openai_base_url: 'openaiBaseUrl',
+  openai_api_key: 'openaiApiKey',
+  openai_model: 'openaiModel',
+  openai_2_base_url: 'openai2BaseUrl',
+  openai_2_api_key: 'openai2ApiKey',
+  openai_2_model: 'openai2Model',
+  lm_studio_base_url: 'lmStudioBaseUrl',
+  lm_studio_model: 'lmStudioModel',
+  ollama_base_url: 'ollamaBaseUrl',
+  ollama_model: 'ollamaModel',
+  provider_base_url: 'providerBaseUrl',
+  provider_api_key: 'providerApiKey',
+  provider_model: 'providerModel',
+};
+
+export function providerIdsInOrder(): ProviderId[] {
+  return [...PROVIDER_CATALOG.keys()];
+}
+
+export interface RenderOptionsConfig {
+  /** Prepend `<option value="">` (Not set). */
+  includeNone?: boolean;
+  /** Only entries with supportsCustomPrompt, and prepend `<option value="all">`. */
+  customPrompt?: boolean;
+}
+
+/**
+ * Rebuild a provider `<select>`'s `<option>` list from the catalog, preserving
+ * the current value when the option still exists.
+ */
+export function renderProviderOptions(sel: HTMLSelectElement, cfg: RenderOptionsConfig = {}): void {
+  const prev = sel.value;
+  sel.textContent = '';
+
+  if (cfg.customPrompt) {
+    sel.appendChild(makeOption('all', getMessage('promptProviderAll') || 'All Providers'));
+  } else if (cfg.includeNone) {
+    sel.appendChild(makeOption('', getMessage('providerPriorityNone') || 'Not set'));
+  }
+
+  for (const [id, entry] of PROVIDER_CATALOG) {
+    if (cfg.customPrompt && !entry.supportsCustomPrompt) continue;
+    sel.appendChild(makeOption(id, getMessage(entry.labelI18nKey) || entry.label));
+  }
+
+  if ([...sel.options].some((o) => o.value === prev)) sel.value = prev;
+}
+
+/**
+ * Render one provider's settings form into `container`. Sets
+ * `container.id = "<providerId>Settings"` to match the former markup.
+ */
+export function renderProviderSettings(container: HTMLElement, providerId: ProviderId): void {
+  const entry = PROVIDER_CATALOG.get(providerId);
+  if (!entry) return;
+
+  container.textContent = '';
+  container.id = `${providerId}Settings`;
+  if (providerId !== 'gemini') container.classList.add('openai-settings');
+
+  switch (entry.settingsBlockKind) {
+    case 'built-in-ai':
+      container.appendChild(helpText('builtInAiHelp'));
+      break;
+    case 'models-dev':
+      buildModelsDevBlock(container, entry);
+      break;
+    default:
+      buildGenericBlock(container, entry, providerId);
+  }
+
+  applyI18n(container);
+}
+
+// ---------------------------------------------------------------------------
+
+function makeOption(value: string, text: string): HTMLOptionElement {
+  const o = document.createElement('option');
+  o.value = value;
+  o.textContent = text;
+  return o;
+}
+
+function formGroup(...children: HTMLElement[]): HTMLDivElement {
+  const g = document.createElement('div');
+  g.className = 'form-group';
+  g.append(...children);
+  return g;
+}
+
+function label(forId: string, i18nKey: string): HTMLLabelElement {
+  const l = document.createElement('label');
+  l.htmlFor = forId;
+  l.setAttribute('data-i18n', i18nKey);
+  return l;
+}
+
+function input(opts: {
+  id: string;
+  type: 'text' | 'password';
+  storageKey: string;
+  placeholderKey?: string | undefined;
+}): HTMLInputElement {
+  const el = document.createElement('input');
+  el.type = opts.type;
+  el.id = opts.id;
+  el.setAttribute('data-storage-key', opts.storageKey);
+  if (opts.placeholderKey) el.setAttribute('data-i18n-input-placeholder', opts.placeholderKey);
+  return el;
+}
+
+function helpText(i18nKey: string): HTMLParagraphElement {
+  const p = document.createElement('p');
+  p.className = 'help-text';
+  p.setAttribute('data-i18n', i18nKey);
+  return p;
+}
+
+function buildGenericBlock(container: HTMLElement, entry: ProviderCatalogEntry, providerId: ProviderId): void {
+  if (entry.baseUrlKey) {
+    const id = KEY_TO_INPUT_ID[entry.baseUrlKey] ?? entry.baseUrlKey;
+    container.appendChild(formGroup(
+      label(id, 'baseUrl'),
+      input({ id, type: 'text', storageKey: entry.baseUrlKey, placeholderKey: entry.fieldPlaceholders?.baseUrl }),
+    ));
+  }
+  if (entry.apiKeyKey && entry.requiresApiKey) {
+    const id = KEY_TO_INPUT_ID[entry.apiKeyKey] ?? entry.apiKeyKey;
+    // gemini uses its own label key; the rest use the shared "aiApiKey"
+    const labelKey = providerId === 'gemini' ? 'geminiApiKey' : 'aiApiKey';
+    container.appendChild(formGroup(
+      label(id, labelKey),
+      input({ id, type: 'password', storageKey: entry.apiKeyKey, placeholderKey: entry.fieldPlaceholders?.apiKey }),
+    ));
+  }
+  if (entry.modelKey) {
+    const id = KEY_TO_INPUT_ID[entry.modelKey] ?? entry.modelKey;
+    container.appendChild(formGroup(
+      label(id, 'modelName'),
+      input({ id, type: 'text', storageKey: entry.modelKey, placeholderKey: entry.fieldPlaceholders?.model }),
+    ));
+  }
+
+  if (providerId === 'gemini') {
+    const versionInput = input({ id: 'geminiApiVersion', type: 'text', storageKey: 'gemini_api_version' });
+    versionInput.placeholder = 'v1beta';
+    versionInput.setAttribute('aria-invalid', 'false');
+    versionInput.setAttribute('aria-describedby', 'geminiApiVersionNote geminiApiVersionError');
+    const note = helpText('note_gemini_api_version');
+    note.id = 'geminiApiVersionNote';
+    const err = document.createElement('div');
+    err.id = 'geminiApiVersionError';
+    err.className = 'field-error';
+    err.setAttribute('role', 'alert');
+    container.appendChild(formGroup(label('geminiApiVersion', 'label_gemini_api_version'), versionInput, note, err));
+  }
+}
+
+function buildModelsDevBlock(container: HTMLElement, entry: ProviderCatalogEntry): void {
+  // Description + "Select Provider" button
+  const descLabel = document.createElement('label');
+  descLabel.setAttribute('data-i18n', 'modelsDevDescription');
+  const selectBtn = document.createElement('button');
+  selectBtn.type = 'button';
+  selectBtn.id = 'openModelsDevDialogBtn';
+  selectBtn.className = 'secondary-btn';
+  selectBtn.setAttribute('data-i18n', 'selectProvider');
+  container.appendChild(formGroup(descLabel, selectBtn));
+
+  // Selected provider info (hidden until a provider is picked)
+  const info = document.createElement('div');
+  info.id = 'selectedProviderInfo';
+  info.className = 'selected-provider-info hidden';
+  const infoLabel = document.createElement('label');
+  infoLabel.setAttribute('data-i18n', 'selectedProviderInfo');
+  const infoDisplay = document.createElement('div');
+  infoDisplay.id = 'providerInfoDisplay';
+  infoDisplay.className = 'provider-display';
+  info.append(infoLabel, infoDisplay);
+  container.appendChild(info);
+
+  // Base URL + presets
+  const baseUrlKey = entry.baseUrlKey ?? 'provider_base_url';
+  const baseInput = input({ id: 'providerBaseUrl', type: 'text', storageKey: baseUrlKey, placeholderKey: entry.fieldPlaceholders?.baseUrl });
+  const lmBtn = presetButton('lmStudioPresetBtn', 'lmStudioPreset');
+  const ollamaBtn = presetButton('ollamaPresetBtn', 'ollamaPreset');
+  container.appendChild(formGroup(label('providerBaseUrl', 'baseUrl'), baseInput, lmBtn, ollamaBtn));
+
+  // API key
+  if (entry.apiKeyKey) {
+    container.appendChild(formGroup(
+      label('providerApiKey', 'apiKey'),
+      input({ id: 'providerApiKey', type: 'password', storageKey: entry.apiKeyKey, placeholderKey: entry.fieldPlaceholders?.apiKey }),
+    ));
+  }
+
+  // Model (optional)
+  if (entry.modelKey) {
+    container.appendChild(formGroup(
+      label('providerModel', 'modelName'),
+      input({ id: 'providerModel', type: 'text', storageKey: entry.modelKey, placeholderKey: entry.fieldPlaceholders?.model }),
+    ));
+  }
+}
+
+function presetButton(id: string, i18nKey: string): HTMLButtonElement {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.id = id;
+  b.className = 'small-btn';
+  b.setAttribute('data-i18n', i18nKey);
+  return b;
+}


### PR DESCRIPTION
## 概要

06c（ダッシュボード UI provider 層の catalog 駆動化）の基盤 PR。`aiProviderCatalogView.ts` と registry の UI メタデータフィールドを追加。**consumer は未接続**なので低リスク。前提 PR #96（06b）。

## 変更

### `ProviderRegistryEntry` に UI メタデータ
- `labelI18nKey`（i18n キー名、局所化文字列ではない）/ `fieldPlaceholders?` / `supportsCustomPrompt` / `settingsBlockKind`
- Map 挿入順を **dropdown 順**（gemini, openai, openai2, lm-studio, ollama, openai-compatible, built-in-ai）に
- `supportsCustomPrompt` を 5 provider に（lm-studio/ollama は `OpenAIProvider.applyCustomPrompt(settings, providerName)` 経由でランタイムは既に custom prompt を適用可能。型と UI form だけが 3 に限定されていた — バグ修正の下準備）

### `src/dashboard/aiProviderCatalogView.ts`（新規）
- `renderProviderOptions(sel, { includeNone?, customPrompt? })` — 現在値を保持しつつ `<option>` 再生成
- `renderProviderSettings(container, providerId)` — generic / models-dev / built-in-ai の 3 variant を旧 `index.html` の id / `data-storage-key` / `data-i18n` / class 完全一致で生成、末尾で `applyI18n(subtree)`
- `providerIdsInOrder()` / `KEY_TO_INPUT_ID`

### テスト
- `providerCatalog.test.ts` に 06c conformance ケース 5 件
- `aiProviderCatalogView.test.ts`（jsdom、12 ケース）

## 検証

- `npm run type-check` / `npm run lint` green
- `npm test` — 11140 passed / 20 skipped / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)