### PR TITLE
refactor(06c): A レイアウトを catalog 駆動の mount 時ビルドに (タスク 7-8)

### DIFF
--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -336,15 +336,7 @@
             <div class="priority-details-content">
               <div class="form-group">
                 <label for="aiProvider" class="sr-only" data-i18n="aiProvider">AI Provider</label>
-                <select id="aiProvider" data-storage-key="ai_provider">
-                  <option value="gemini" data-i18n-opt="googleGemini">Google Gemini</option>
-                  <option value="openai" data-i18n-opt="openaiCompatible">OpenAI Compatible (Groq, etc.)</option>
-                  <option value="openai2" data-i18n-opt="openaiCompatible2">OpenAI Compatible 2 (Local, etc.)</option>
-                  <option value="lm-studio" data-i18n-opt="lmStudio">LM Studio</option>
-                  <option value="ollama" data-i18n-opt="ollama">Ollama</option>
-                  <option value="openai-compatible" data-i18n-opt="openaiCompatibleModelsDev">OpenAI Compatible (Models.dev)</option>
-                  <option value="built-in-ai" data-i18n-opt="builtInAi">Built-in AI (No API Key Required)</option>
-                </select>
+                <select id="aiProvider" data-storage-key="ai_provider"></select>
               </div>
               <div id="priority1ProviderSettings"></div>
               <div class="form-group">
@@ -364,16 +356,7 @@
             <div class="priority-details-content">
               <div class="form-group">
                 <label for="aiProviderPriority2" class="sr-only" data-i18n="aiProvider">AI Provider</label>
-                <select id="aiProviderPriority2">
-                  <option value="" data-i18n-opt="providerPriorityNone">Not set</option>
-                  <option value="gemini" data-i18n-opt="googleGemini">Google Gemini</option>
-                  <option value="openai" data-i18n-opt="openaiCompatible">OpenAI Compatible (Groq, etc.)</option>
-                  <option value="openai2" data-i18n-opt="openaiCompatible2">OpenAI Compatible 2 (Local, etc.)</option>
-                  <option value="lm-studio" data-i18n-opt="lmStudio">LM Studio</option>
-                  <option value="ollama" data-i18n-opt="ollama">Ollama</option>
-                  <option value="openai-compatible" data-i18n-opt="openaiCompatibleModelsDev">OpenAI Compatible (Models.dev)</option>
-                  <option value="built-in-ai" data-i18n-opt="builtInAi">Built-in AI (No API Key Required)</option>
-                </select>
+                <select id="aiProviderPriority2"></select>
               </div>
               <div id="priority2ProviderSettings"></div>
               <div class="form-group">
@@ -393,16 +376,7 @@
             <div class="priority-details-content">
               <div class="form-group">
                 <label for="aiProviderPriority3" class="sr-only" data-i18n="aiProvider">AI Provider</label>
-                <select id="aiProviderPriority3">
-                  <option value="" data-i18n-opt="providerPriorityNone">Not set</option>
-                  <option value="gemini" data-i18n-opt="googleGemini">Google Gemini</option>
-                  <option value="openai" data-i18n-opt="openaiCompatible">OpenAI Compatible (Groq, etc.)</option>
-                  <option value="openai2" data-i18n-opt="openaiCompatible2">OpenAI Compatible 2 (Local, etc.)</option>
-                  <option value="lm-studio" data-i18n-opt="lmStudio">LM Studio</option>
-                  <option value="ollama" data-i18n-opt="ollama">Ollama</option>
-                  <option value="openai-compatible" data-i18n-opt="openaiCompatibleModelsDev">OpenAI Compatible (Models.dev)</option>
-                  <option value="built-in-ai" data-i18n-opt="builtInAi">Built-in AI (No API Key Required)</option>
-                </select>
+                <select id="aiProviderPriority3"></select>
               </div>
               <div id="priority3ProviderSettings"></div>
               <div class="form-group">
@@ -412,127 +386,9 @@
             </div>
           </details>
 
-          <!-- Gemini Settings -->
-          <div id="geminiSettings">
-            <div class="form-group">
-              <label for="geminiApiKey" data-i18n="geminiApiKey">Gemini API Key</label>
-              <input type="password" id="geminiApiKey" data-storage-key="gemini_api_key" data-i18n-input-placeholder="geminiApiKeyPlaceholder">
-              <div class="help-text">
-                <span data-i18n="geminiApiKeyHelp">Get it from Google AI Studio.</span>
-                <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener noreferrer" data-i18n="apiKeyCreateLink">Create API Key →</a>
-              </div>
-            </div>
-
-            <div class="form-group">
-              <label for="geminiModel" data-i18n="modelName">Model Name (e.g. gemini-3.1-flash-lite)</label>
-              <input type="text" id="geminiModel" data-storage-key="gemini_model" value="gemini-3.1-flash-lite">
-            </div>
-
-            <div class="form-group">
-              <label for="geminiApiVersion" data-i18n="label_gemini_api_version">Gemini API Version</label>
-              <input type="text" id="geminiApiVersion" data-storage-key="gemini_api_version" placeholder="v1beta" aria-invalid="false"
-                aria-describedby="geminiApiVersionNote geminiApiVersionError">
-              <p class="help-text" id="geminiApiVersionNote" data-i18n="note_gemini_api_version">Gemini API version (v1 or v1beta).</p>
-              <div id="geminiApiVersionError" class="field-error" role="alert"></div>
-            </div>
-          </div>
-
-          <!-- OpenAI Settings -->
-          <div id="openaiSettings" class="openai-settings">
-            <div class="form-group">
-              <label for="openaiBaseUrl" data-i18n="baseUrl">Base URL</label>
-              <input type="text" id="openaiBaseUrl" data-storage-key="openai_base_url" data-i18n-input-placeholder="openaiBaseUrlPlaceholder">
-            </div>
-
-            <div class="form-group">
-              <label for="openaiApiKey" data-i18n="aiApiKey">API Key</label>
-              <input type="password" id="openaiApiKey" data-storage-key="openai_api_key" data-i18n-input-placeholder="openaiApiKeyPlaceholder">
-            </div>
-
-            <div class="form-group">
-              <label for="openaiModel" data-i18n="modelName">Model Name</label>
-              <input type="text" id="openaiModel" data-storage-key="openai_model" data-i18n-input-placeholder="openaiModelPlaceholder">
-            </div>
-          </div>
-
-          <!-- OpenAI 2 Settings -->
-          <div id="openai2Settings" class="openai-settings">
-            <div class="form-group">
-              <label for="openai2BaseUrl" data-i18n="baseUrl">Base URL</label>
-              <input type="text" id="openai2BaseUrl" data-storage-key="openai_2_base_url" data-i18n-input-placeholder="openai2BaseUrlPlaceholder">
-            </div>
-
-            <div class="form-group">
-              <label for="openai2ApiKey" data-i18n="aiApiKey">API Key</label>
-              <input type="password" id="openai2ApiKey" data-storage-key="openai_2_api_key" data-i18n-input-placeholder="openai2ApiKeyPlaceholder">
-            </div>
-
-            <div class="form-group">
-              <label for="openai2Model" data-i18n="modelName">Model Name</label>
-              <input type="text" id="openai2Model" data-storage-key="openai_2_model" data-i18n-input-placeholder="openai2ModelPlaceholder">
-            </div>
-          </div>
-
-          <!-- LM Studio Settings -->
-          <div id="lm-studioSettings" class="openai-settings">
-            <div class="form-group">
-              <label for="lmStudioBaseUrl" data-i18n="baseUrl">Base URL</label>
-              <input type="text" id="lmStudioBaseUrl" data-storage-key="lm_studio_base_url" data-i18n-input-placeholder="lmStudioBaseUrlPlaceholder">
-            </div>
-
-            <div class="form-group">
-              <label for="lmStudioModel" data-i18n="modelName">Model Name</label>
-              <input type="text" id="lmStudioModel" data-storage-key="lm_studio_model" data-i18n-input-placeholder="lmStudioModelPlaceholder">
-            </div>
-          </div>
-
-          <!-- Ollama Settings -->
-          <div id="ollamaSettings" class="openai-settings">
-            <div class="form-group">
-              <label for="ollamaBaseUrl" data-i18n="baseUrl">Base URL</label>
-              <input type="text" id="ollamaBaseUrl" data-storage-key="ollama_base_url" data-i18n-input-placeholder="ollamaBaseUrlPlaceholder">
-            </div>
-
-            <div class="form-group">
-              <label for="ollamaModel" data-i18n="modelName">Model Name</label>
-              <input type="text" id="ollamaModel" data-storage-key="ollama_model" data-i18n-input-placeholder="ollamaModelPlaceholder">
-            </div>
-          </div>
-
-          <!-- OpenAI-Compatible (Models.dev) Settings -->
-          <div id="openai-compatibleSettings" class="openai-settings">
-            <div class="form-group">
-              <label data-i18n="modelsDevDescription">Select from 70+ OpenAI-compatible providers (OpenRouter, Perplexity, DeepSeek, etc.)</label>
-              <button type="button" id="openModelsDevDialogBtn" class="secondary-btn" data-i18n="selectProvider">Select Provider</button>
-            </div>
-
-            <div id="selectedProviderInfo" class="selected-provider-info hidden">
-              <label data-i18n="selectedProviderInfo">Selected Provider:</label>
-              <div id="providerInfoDisplay" class="provider-display"></div>
-            </div>
-
-            <div class="form-group">
-              <label for="providerBaseUrl" data-i18n="baseUrl">Base URL</label>
-              <input type="text" id="providerBaseUrl" data-storage-key="provider_base_url" data-i18n-input-placeholder="providerBaseUrlPlaceholder">
-              <button type="button" id="lmStudioPresetBtn" class="small-btn" data-i18n="lmStudioPreset">LM Studio</button>
-              <button type="button" id="ollamaPresetBtn" class="small-btn" data-i18n="ollamaPreset">Ollama</button>
-            </div>
-
-            <div class="form-group">
-              <label for="providerApiKey" data-i18n="apiKey">API Key</label>
-              <input type="password" id="providerApiKey" data-storage-key="provider_api_key" data-i18n-input-placeholder="providerApiKeyPlaceholder">
-            </div>
-
-            <div class="form-group">
-              <label for="providerModel" data-i18n="modelName">Model Name (optional)</label>
-              <input type="text" id="providerModel" data-storage-key="provider_model" data-i18n-input-placeholder="providerModelPlaceholder">
-            </div>
-          </div>
-
-          <!-- Built-in AI Settings (no API key needed) -->
-          <div id="built-in-aiSettings" class="openai-settings">
-            <p class="help-text" data-i18n="builtInAiHelp">Uses Chrome's on-device AI (Gemini Nano). No API key required. Availability depends on your Chrome version and downloaded model.</p>
-          </div>
+          <!-- Provider settings blocks are built from the catalog at mount
+               (generalSettingsPanel.ts). Each becomes `#<providerId>Settings`. -->
+          <div id="providerSettingsMount"></div>
         </div>
 
         <!-- 記録条件・AI設定 -->
@@ -801,14 +657,7 @@
 
           <div class="form-group">
             <label for="promptProvider" data-i18n="promptProvider">Apply to Provider</label>
-            <select id="promptProvider">
-              <option value="all" data-i18n-opt="promptProviderAll">All Providers</option>
-              <option value="gemini" data-i18n-opt="googleGemini">Google Gemini</option>
-              <option value="openai" data-i18n-opt="openaiCompatible">OpenAI Compatible</option>
-              <option value="openai2" data-i18n-opt="openaiCompatible2">OpenAI Compatible 2</option>
-              <option value="lm-studio" data-i18n-opt="lmStudio">LM Studio</option>
-              <option value="ollama" data-i18n-opt="ollama">Ollama</option>
-            </select>
+            <select id="promptProvider"></select>
           </div>
 
           <div class="form-group">

--- a/src/background/ai/__tests__/providerCatalog.test.ts
+++ b/src/background/ai/__tests__/providerCatalog.test.ts
@@ -12,6 +12,7 @@ import { PROVIDER_CATALOG, ProviderCatalog, UnknownProviderError } from '../prov
 import { StorageKeys } from '../../../utils/storage/types.js';
 import type { ProviderId } from '../../../utils/storage/types.js';
 import { getMessage } from '../../../utils/i18n.js';
+import { GENERAL_SETTINGS_SCHEMA } from '../../../utils/settingsSchemas.js';
 
 // The full ProviderId union, spelled out because a union type is not
 // runtime-available. If ProviderId changes this list must change with it —
@@ -133,6 +134,24 @@ describe('ProviderCatalog conformance', () => {
   it('settingsBlockKind is set on every entry', () => {
     for (const [id, entry] of PROVIDER_CATALOG) {
       expect(['generic', 'models-dev', 'built-in-ai'], id).toContain(entry.settingsBlockKind);
+    }
+  });
+
+  it('every provider detail key is bound in GENERAL_SETTINGS_SCHEMA with the right type', () => {
+    // The catalog-driven settings-form builder renders inputs for these keys;
+    // GENERAL_SETTINGS_SCHEMA must bind each one (password for api keys) or
+    // save/load silently drops the field.
+    const schemaByKey = new Map(GENERAL_SETTINGS_SCHEMA.map((f) => [f.key as string, f.type]));
+    for (const [id, entry] of PROVIDER_CATALOG) {
+      if (entry.baseUrlKey) {
+        expect(schemaByKey.get(entry.baseUrlKey), `${id}: ${entry.baseUrlKey}`).toBe('text');
+      }
+      if (entry.apiKeyKey && entry.requiresApiKey) {
+        expect(schemaByKey.get(entry.apiKeyKey), `${id}: ${entry.apiKeyKey}`).toBe('password');
+      }
+      if (entry.modelKey) {
+        expect(schemaByKey.get(entry.modelKey), `${id}: ${entry.modelKey}`).toBe('text');
+      }
     }
   });
 });

--- a/src/dashboard/generalSettings/settingsForm.ts
+++ b/src/dashboard/generalSettings/settingsForm.ts
@@ -15,6 +15,7 @@ import { GENERAL_SETTINGS_SCHEMA } from '../../utils/settingsSchemas.js';
 import { getMessage } from '../../utils/i18n.js';
 import { getPluralKey } from '../../utils/i18nPlural.js';
 import { getAiProviderElements, updateAIProviderVisibilityMulti } from '../settings/aiProvider.js';
+import { providerIdsInOrder } from '../aiProviderCatalogView.js';
 import { updateProviderSettingsLayout } from '../aiProviderLayoutManager.js';
 import { purgeOldRecordsNow, purgeContentNow, isServiceError } from '../dashboardSqliteService.js';
 import { collectBProviderPrioritySlots } from '../aiProviderB/priorityListView.js';
@@ -62,7 +63,7 @@ export function applyProviderPrioritySlots(slots: ProviderSlot[]): void {
   const aiProviderPriority3ModelInput = document.getElementById('aiProviderPriority3Model') as HTMLInputElement | null;
 
   if (aiProviderSelect) {
-    aiProviderSelect.value = slot1?.provider ?? 'gemini';
+    aiProviderSelect.value = slot1?.provider ?? providerIdsInOrder()[0] ?? 'gemini';
   }
   if (aiProviderPriority1ModelInput) {
     aiProviderPriority1ModelInput.value = slot1?.model ?? '';

--- a/src/dashboard/panels/staticForm/generalSettingsPanel.ts
+++ b/src/dashboard/panels/staticForm/generalSettingsPanel.ts
@@ -17,6 +17,7 @@ import { generateReviewSummary } from '../../reviewSummaryHandler.js';
 import { syncStatusToTop } from '../../statusView.js';
 import { updateProviderSettingsLayout, hideAllProviderSettings, restoreOriginalProviderSettingsLayout } from '../../aiProviderLayoutManager.js';
 import { getAiProviderElements, setupAIProviderChangeListener, updateAIProviderVisibilityMulti } from '../../settings/aiProvider.js';
+import { providerIdsInOrder, renderProviderOptions, renderProviderSettings } from '../../aiProviderCatalogView.js';
 import { resolveInitialLayout, mountLayoutToggle } from '../../aiProviderLayoutToggle.js';
 import { createBPriorityListView } from '../../aiProviderB/priorityListView.js';
 import { createBProviderAccordionView } from '../../aiProviderB/providerAccordionView.js';
@@ -51,6 +52,26 @@ export function createGeneralSettingsPanel(): PanelLifecycle & { refresh?: () =>
     async mount(container) {
       panelContainer = container;
       const settings = await settingsRepository.getAll();
+
+      // A layout: build the provider <option> lists and per-provider settings
+      // blocks from the catalog before any value binding runs.
+      const providerSelect = container.querySelector('#aiProvider') as HTMLSelectElement | null;
+      if (providerSelect) renderProviderOptions(providerSelect);
+      for (const priorityId of ['aiProviderPriority2', 'aiProviderPriority3']) {
+        const sel = container.querySelector(`#${priorityId}`) as HTMLSelectElement | null;
+        if (sel) renderProviderOptions(sel, { includeNone: true });
+      }
+      const providerMount = container.querySelector('#providerSettingsMount') as HTMLElement | null;
+      if (providerMount) {
+        providerMount.textContent = '';
+        for (const id of providerIdsInOrder()) {
+          const block = document.createElement('div');
+          block.style.display = 'none';
+          renderProviderSettings(block, id);
+          providerMount.appendChild(block);
+        }
+      }
+
       loadSettingsToInputs(container, settings, GENERAL_SETTINGS_SCHEMA);
       await loadGeneralSettings();
 

--- a/src/dashboard/settings/__tests__/customPromptManager-r2.test.ts
+++ b/src/dashboard/settings/__tests__/customPromptManager-r2.test.ts
@@ -684,15 +684,15 @@ describe('customPromptManager - r2 missed branches', () => {
   });
 
   describe('uncovered branches: provider labels and getProviderLabel fallback', () => {
-    it('should return OpenAI label for openai provider', async () => {
+    it('should resolve the catalog label i18n key for openai provider', async () => {
       const { initCustomPromptManager } = await import('../customPromptManager.js');
       initCustomPromptManager({ custom_prompts: [createTestPrompt({ id: 'openai_p', provider: 'openai', name: 'OA' })] } as any);
-      expect(document.getElementById('promptList')!.innerHTML).toContain('OpenAI');
+      expect(document.getElementById('promptList')!.innerHTML).toContain('openaiCompatible');
     });
-    it('should return OpenAI 2 label for openai2 provider', async () => {
+    it('should resolve the catalog label i18n key for openai2 provider', async () => {
       const { initCustomPromptManager } = await import('../customPromptManager.js');
       initCustomPromptManager({ custom_prompts: [createTestPrompt({ id: 'openai2_p', provider: 'openai2', name: 'OA2' })] } as any);
-      expect(document.getElementById('promptList')!.innerHTML).toContain('OpenAI 2');
+      expect(document.getElementById('promptList')!.innerHTML).toContain('openaiCompatible2');
     });
     it('should fallback to All Providers when getMessage returns falsy', async () => {
       const { getMessage } = await import('../../../utils/i18n.js');

--- a/src/dashboard/settings/__tests__/customPromptManager-r3.test.ts
+++ b/src/dashboard/settings/__tests__/customPromptManager-r3.test.ts
@@ -446,9 +446,9 @@ describe('customPromptManager - r3 remaining branches', () => {
     } as any);
     const html = document.getElementById('promptList')!.innerHTML;
     expect(html).toContain('All Providers');
-    expect(html).toContain('Gemini');
-    expect(html).toContain('OpenAI');
-    expect(html).toContain('OpenAI 2');
+    expect(html).toContain('googleGemini');
+    expect(html).toContain('openaiCompatible');
+    expect(html).toContain('openaiCompatible2');
     expect(html).toContain('customProvider');
   });
 

--- a/src/dashboard/settings/customPromptManager.ts
+++ b/src/dashboard/settings/customPromptManager.ts
@@ -21,6 +21,8 @@ import {
 } from '../../utils/customPromptUtils.js';
 import { pickDefined } from '../../utils/objectUtils.js';
 import { getMessage } from '../../utils/i18n.js';
+import { renderProviderOptions } from '../aiProviderCatalogView.js';
+import { tryResolveCatalogEntry } from '../../background/ai/providerCatalog.js';
 import { applyI18n } from '../../utils/i18n-dom.js';
 import { escapeHtml } from '../../popup/errorUtils.js';
 import { showStatus } from '../../utils/ui/settingsUiHelper.js';
@@ -69,6 +71,7 @@ export function initCustomPromptManager(settings: Settings): void {
     noPromptsMessage = document.getElementById('noPromptsMessage');
     promptNameInput = document.getElementById('promptName') as HTMLInputElement;
     promptProviderSelect = document.getElementById('promptProvider') as HTMLSelectElement;
+    if (promptProviderSelect) renderProviderOptions(promptProviderSelect, { customPrompt: true });
     promptSystemInput = document.getElementById('promptSystem') as HTMLInputElement;
     promptTextInput = document.getElementById('promptText') as HTMLTextAreaElement;
     editingPromptIdInput = document.getElementById('editingPromptId') as HTMLInputElement;
@@ -254,13 +257,10 @@ function createPromptListItem(prompt: CustomPrompt): string {
  * @returns {string} Display label
  */
 function getProviderLabel(provider: string): string {
-    const labels: Record<string, string> = {
-        'all': getMessage('promptProviderAll') || 'All Providers',
-        'gemini': 'Gemini',
-        'openai': 'OpenAI',
-        'openai2': 'OpenAI 2'
-    };
-    return labels[provider] || provider;
+    if (provider === 'all') return getMessage('promptProviderAll') || 'All Providers';
+    const entry = tryResolveCatalogEntry(provider);
+    if (!entry) return provider;
+    return getMessage(entry.labelI18nKey) || entry.label || provider;
 }
 
 /**

--- a/src/utils/customPromptUtils.ts
+++ b/src/utils/customPromptUtils.ts
@@ -263,7 +263,7 @@ export function validatePrompt(prompt: string): { valid: boolean; error?: string
 /**
  * 設定からアクティブなカスタムプロンプトを取得
  * @param {Settings} settings - 設定オブジェクト
- * @param {string} providerName - プロバイダー名 ('gemini' | 'openai' | 'openai2')
+ * @param {string} providerName - プロバイダー名 ('gemini' | 'openai' | 'openai2' | 'lm-studio' | 'ollama')
  * @returns {CustomPrompt | null} アクティブなプロンプト、またはnull
  */
 export function getActivePrompt(settings: Settings, providerName: string): CustomPrompt | null {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -30,7 +30,7 @@ export interface CustomPrompt {
     name: string;
     prompt: string;           // ユーザープロンプト（{{content}}プレースホルダーを含む）
     systemPrompt?: string;    // OpenAI用システムプロンプト（オプション）
-    provider: 'gemini' | 'openai' | 'openai2' | 'all';
+    provider: 'gemini' | 'openai' | 'openai2' | 'lm-studio' | 'ollama' | 'all';
     isActive: boolean;
     createdAt: number;
     updatedAt: number;

--- a/testDir/e2e/dashboard-built-in-ai.spec.ts
+++ b/testDir/e2e/dashboard-built-in-ai.spec.ts
@@ -8,47 +8,25 @@ const __dirname = path.dirname(__filename);
 const OPTIONS_PATH = path.join(__dirname, '../../dist/chromium-mv3/options.html');
 
 /**
- * Built-in AI Provider UI テスト (PBI-32)
+ * Built-in AI Provider UI テスト (PBI-32 / PBI-06c)
  *
  * 対象: dist/chromium-mv3/options.html
- * プロトコル: file:// (静的HTML、UI構造確認のみ)
+ * プロトコル: file:// (静的HTML)
  *
- * 実際のBuilt-in AI呼び出し（LanguageModel.availability/create/prompt）の
- * 動作確認は @interaction タグの拡張機能コンテキストテストで行う。
+ * PBI-06c 以降、provider の <option> リストと per-provider 設定ブロックは
+ * catalog から panel mount 時に JS で構築される（静的 HTML には
+ * <select> シェルと #providerSettingsMount のみ）。file:// では拡張機能
+ * ランタイムが無く panel が mount されないため、@ui では構築先の存在だけを
+ * 確認し、実際の option/panel は @interaction（拡張機能コンテキスト）で検証する。
  */
 test.describe('Dashboard - Built-in AI Provider Option @ui', () => {
-  test('Priority 1 select has built-in-ai option', async ({ page }) => {
+  test('provider select shells and settings mount point exist', async ({ page }) => {
     await page.goto(`file://${OPTIONS_PATH}`);
 
-    const option = page.locator('#aiProvider option[value="built-in-ai"]');
-    await expect(option).toBeAttached();
-  });
-
-  test('Priority 2 select has built-in-ai option', async ({ page }) => {
-    await page.goto(`file://${OPTIONS_PATH}`);
-
-    const option = page.locator('#aiProviderPriority2 option[value="built-in-ai"]');
-    await expect(option).toBeAttached();
-  });
-
-  test('Priority 3 select has built-in-ai option', async ({ page }) => {
-    await page.goto(`file://${OPTIONS_PATH}`);
-
-    const option = page.locator('#aiProviderPriority3 option[value="built-in-ai"]');
-    await expect(option).toBeAttached();
-  });
-
-  test('built-in-ai settings panel exists and is present in DOM', async ({ page }) => {
-    await page.goto(`file://${OPTIONS_PATH}`);
-
-    await expect(page.locator('#built-in-aiSettings')).toBeAttached();
-  });
-
-  test('built-in-ai settings panel shows no-API-key help text', async ({ page }) => {
-    await page.goto(`file://${OPTIONS_PATH}`);
-
-    const helpText = page.locator('#built-in-aiSettings .help-text');
-    await expect(helpText).toBeAttached();
+    await expect(page.locator('#aiProvider')).toBeAttached();
+    await expect(page.locator('#aiProviderPriority2')).toBeAttached();
+    await expect(page.locator('#aiProviderPriority3')).toBeAttached();
+    await expect(page.locator('#providerSettingsMount')).toBeAttached();
   });
 });
 

--- a/testDir/e2e/dashboard-ui.spec.ts
+++ b/testDir/e2e/dashboard-ui.spec.ts
@@ -146,8 +146,10 @@ test.describe('Dashboard - Initial Settings Panel @ui', () => {
     await expect(panel.getByRole('heading', { name: 'AI Provider', exact: true })).toBeVisible();
   });
 
-  test('has Gemini API key input', async ({ page }) => {
-    await expect(page.locator('#geminiApiKey')).toBeAttached();
+  test('has provider settings mount point', async ({ page }) => {
+    // Per-provider settings blocks (incl. #geminiApiKey) are built from the
+    // catalog at panel mount; the static HTML carries only the mount point.
+    await expect(page.locator('#providerSettingsMount')).toBeAttached();
   });
 
   test('has retention policy section', async ({ page }) => {


### PR DESCRIPTION
## 概要

PBI 06c の PR#D。A レイアウトの provider UI を静的 HTML から catalog 駆動の mount 時ビルドに移行し、6 個所目のコピペ元だった `index.html` の静的マークアップを削除する。

- **`entrypoints/options/index.html`**: `#aiProvider` / `#aiProviderPriority2` / `#aiProviderPriority3` / `#promptProvider` の `<option>` グループと、7 個の `<div id="*Settings">` ブロックを削除。`<select>` シェルと `<div id="providerSettingsMount">` のみ残す。
- **`generalSettingsPanel.mount()`**: `renderProviderOptions` / `renderProviderSettings` で catalog から構築（`loadSettingsToInputs` の前）。
- **`customPromptManager.ts`**: select を `renderProviderOptions(sel, { customPrompt: true })` で生成、`getProviderLabel` を catalog lookup（`getMessage(labelI18nKey)`）に。
- **`CustomPrompt.provider` 型**: `'lm-studio'` / `'ollama'` を追加。`OpenAIProvider` はランタイムで既に文字列一致で custom prompt を適用するため、型と UI form だけが不完全だった = バグ修正。
- **`settingsForm.ts`**: default provider を `providerIdsInOrder()[0]` に。
- **conformance test**: `providerCatalog.test.ts` に「各 detail key が `GENERAL_SETTINGS_SCHEMA` に正しい type でバインドされている」を追加。
- **e2e**: `file://` 前提の `@ui` テスト（静的 `#geminiApiKey` 等を assert）を mount 点の存在確認に変更。provider 実体は `@interaction`（拡張機能コンテキスト）で検証。

## 検証

- `npm run type-check` / `npm run lint` green
- `npx vitest run`: 11136 passed
- `npm run build` green
- `npm run test:e2e`: 185 passed / 8 skipped（全 spec）

## スタック

PR#C (`feat/pbi-06c-consumers`) の上に積む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)