### PR TITLE
docs(pbi): archived PBI の DoD 乖離訂正 + crypto-policy-ssot フォローアップ起票

### DIFF
--- a/dev-docs/archived/pbi/2026-08-24-03-refactor-sqlite-consolidation.md
+++ b/dev-docs/archived/pbi/2026-08-24-03-refactor-sqlite-consolidation.md
@@ -68,13 +68,36 @@ Effort: 0.7w (Medium)
 
 ## DoD
 
-- [ ] 4 helperが`callInternal` genericに集約され重複が解消されている
+- [~] 4 helperの重複解消 — `callInternal` genericではなく、`SqliteClient` の
+  `query`/`mutate`/`maintain`/`getStatus` を `SqliteGateway`（PBI 2026-08-31-05）への
+  薄い委譲に置換する別アプローチで実質達成。try/catch・`recordSqliteFailure`・
+  `categorizeError` の verbatim 重複は SqliteClient から消滅。`callInternal` シンボルは未作成
 - [ ] `storageMaintenance.ts`から`await import('../../background/sqliteClient.js')`と`new SqliteClient()`が削除されている
-- [ ] `createBackgroundServices.ts`でhealthCheckが`getSharedSqliteClient`経由で注入されている
-- [ ] `sqliteMessageHandlers` Mapに`satisfies Record<SqliteMessageType, Handler>`で静的保証が付与されている
-- [ ] `npm run type-check` PASS
-- [ ] 既存テスト全PASS（sqliteClient 13ファイル + storageMaintenance）
+  — **未達**。`src/utils/storage/storageMaintenance.ts:34-37` に `getDefaultSqliteHealthCheck()` が現存し、
+  `await import('../../background/sqliteClient.js')` + `new SqliteClient()` を実行。
+  `:61` で `sqliteHealthCheck ?? getSqliteHealthCheck() ?? (await getDefaultSqliteHealthCheck())` と
+  本番フォールバック経路として現役参照（popup/options 等 `setSqliteHealthCheck` 未実行コンテキスト向け）
+- [x] `createBackgroundServices.ts`でhealthCheckが注入されている
+  — `compositionManifest.ts:92` の `onReady` で `setSqliteHealthCheck(...)` を配線、
+  `createBackgroundServices.ts` が resolve。ただし動的 import フォールバックと併存
+- [x] `sqliteMessageHandlers` Mapに`satisfies Record<SqliteMessageType, SqliteHandler>`
+  （`src/offscreen/sqliteMessageHandlers.ts:313`）
+- [x] `npm run type-check` PASS
+- [x] 既存テスト全PASS
 - [ ] `grep -rn "await import.*sqliteClient" src/utils/` が0件
+  — **未達**（`storageMaintenance.ts:36` が 1 件ヒット）
+
+## 実装メモ（効果確認: 2026-09-01 の DoD 乖離監査）
+
+**部分実装**。摩擦A（4 helper の重複）は PBI 2026-08-31-05（SqliteGateway 統合）で
+別アプローチにより実質解消。摩擦B（utils→background の逆依存 = `storageMaintenance.ts` の
+動的 import + `new SqliteClient()`）は**未解消のまま archived 入り**。
+
+実害は低い（動的 import は `setSqliteHealthCheck` 未実行コンテキスト専用のフォールバックで、
+通常経路は composition root で注入済み）。逆依存を完全に断つには
+`getDefaultSqliteHealthCheck` を廃し `ensureStorageQuota` の healthCheck 引数を必須化する
+必要があるが、フォールバックを失う popup/options コンテキストの扱いを先に決める設計が要る。
+現時点で追加 PBI 化は見送り（`dev-docs/LAYERS.md` の storageMaintenance 例外条項は維持）。
 
 ## 技術メモ
 

--- a/dev-docs/archived/pbi/2026-08-29-12-fix-crypto-policy-ssot.md
+++ b/dev-docs/archived/pbi/2026-08-29-12-fix-crypto-policy-ssot.md
@@ -127,8 +127,35 @@ sed -n '30,98p' src/utils/RateLimitService.ts
 - RateLimit の local 永続化はストレージ障害時に fail-open にならないよう（成功時のみリセット）をテストで固定
 
 ## Definition of Done
-- [ ] 全 BDD シナリオが自動テストとして実装されパスする
-- [ ] テストカバレッジが基準を満たす
-- [ ] コードレビュー完了
-- [ ] リファクタリング完了（グリーン後）
-- [ ] VulnHunter 再スキャンで VULN-010/037/038/039/040/052 が解消されること
+- [x] 全 BDD シナリオが自動テストとして実装されパスする（KEK session化 / iterations SSOT / RateLimit 永続化 / strict ポリシー / settings export v2 HMAC。get-or-create 単一生成は encryptionSession のみ — 下記「未達」参照）
+- [x] テストカバレッジが基準を満たす（`cryptoParamsSSOT.test.ts` 他）
+- [x] コードレビュー完了
+- [x] リファクタリング完了（グリーン後）
+- [x] VulnHunter 再スキャンで VULN-010/037/038/040/052 が解消されること（VULN-039 は一部、下記参照）
+
+## 実装メモ（効果確認: 2026-09-01 の DoD 乖離監査）
+
+本 PBI は archived に置かれたが、着手時に受け入れ基準を `[x]` にする運用が漏れていた。
+2026-09-01 の `autonomous-task-closer` 監査で **中核は実装済み、2 項目が未達**と判定した。
+
+### 実装済み（実コードで確認）
+- `src/utils/crypto/cryptoParams.ts` — 暗号パラメータ SSOT（`PBKDF2_ITERATIONS: 600_000` /
+  `LEGACY_PBKDF2_ITERATIONS: 100_000` / strict `validatePasswordPolicy`）。
+  `primitives.ts` / `envelope.ts` / `hmacKeyStore.ts` / `masterPassword.ts` /
+  `settingsExportImport.ts` が参照
+- KEK の `chrome.storage.session` 化（`hmacKeyStore.ts:137`。local は読み取り後方互換のみ）
+- `RateLimitService` の FAILED_ATTEMPTS / LOCKED_UNTIL を `storage.local` 永続化、成功時のみリセット
+- `masterPassword.validatePasswordRequirements` が `cryptoParams.validatePasswordPolicy` に一本化
+  （弱い length≥8 実装は削除）
+- settings 暗号エクスポート version:2（ciphertext HMAC、復号前検証、v1 後方互換）。
+  `ENCRYPTED_EXPORT_VERSION = '2'`（`settingsExportImport.ts:21`）
+- `encryptionSession.ts` の `encryptionKeyMutex` パターン
+
+### 未達（→ フォローアップ PBI `pbi/2026-09-01-05-fix-crypto-policy-ssot-followup.md`）
+1. **受け入れ基準 L61（get-or-create 排他 / VULN-039 の残り）**: `encryptionSession.ts` のみ
+   `encryptionKeyMutex` 適用済み。`hmacKeyStore.getOrCreateWrappedHmacKey`（`:215`）と
+   `confirmTokenManager`（`src/background/confirmTokenManager.ts`、PBI が指したパスとも異なる）は
+   Mutex なし
+2. **「29-13 から統合したスコープ」L70（log export/import 署名 / VULN-035）**: 完全未実装。
+   `src/dashboard/exportLogsService.ts` / `importLogsService.ts` に HMAC 署名の痕跡ゼロ。
+   settings 側（`settingsExportImport.exportSettings` / `importSettings`）には署名パターンが実在するため移植で対応可

--- a/dev-docs/archived/pbi/2026-08-30-05-feat-cleansing-offscreen-delegation.md
+++ b/dev-docs/archived/pbi/2026-08-30-05-feat-cleansing-offscreen-delegation.md
@@ -39,11 +39,35 @@ Scenario: 従来の削除結果と一致する
 
 ## 受け入れ基準
 
-- [ ] `src/offscreen/offscreen.ts` にクレンジング実行ハンドラが追加される
-- [ ] `src/content/contentKernel.ts` または `src/utils/pageContentPipeline.ts` が Offscreen 委譲を試み、失敗時にフォールバックする
-- [ ] Offscreen 委譲時と従来同期実行時で削除結果が一致することをテストで保証
+- [x] `src/offscreen/offscreen.ts` にクレンジング実行ハンドラが追加される
+  — `src/offscreen/cleansingOffscreen.ts`（`CLEANSING_OFFSCREEN_TYPE` /
+  `handleCleansingOffscreenPayload` / `cleanseHtmlOffscreen`）新設。`offscreen.ts:102` でディスパッチ
+- [x] `src/content/contentKernel.ts` または `src/utils/pageContentPipeline.ts` が Offscreen 委譲を試み、失敗時にフォールバックする
+  — `src/content/cleansingOffscreenDelegate.ts` の `cleanseViaOffscreen`（feature flag
+  `cleansing_offscreen_enabled`、既定 false → `cleanseHtmlSync` フォールバック）。
+  `contentKernel.ts` / `pageContentPipeline.ts` が re-export。**ただし実際の抽出パイプラインからは未 invoke（PoC 分岐点）**
+- [x] Offscreen 委譲時と従来同期実行時で削除結果が一致することをテストで保証
+  — 両者とも純粋関数 `cleanseHtmlOffscreen` を呼ぶ設計。`src/offscreen/__tests__/cleansingOffscreen.test.ts`
 - [ ] Offscreen Document のライフサイクル(生成/破棄/再生成)が考慮され、`chrome.offscreen.hasDocument` チェックがある
-- [ ] `npm run validate` が通る
+  — **未達**。`cleansingOffscreenDelegate.ts` は `chrome.runtime.sendMessage` を投げるのみ。
+  `chrome.offscreen.hasDocument` / `createDocument` の呼び出しなし。Document 不在時は
+  sendMessage 失敗 → catch で同期フォールバックという消極的対応のみ
+- [x] `npm run validate` が通る
+
+## 実装メモ（効果確認: 2026-09-01 の DoD 乖離監査）
+
+**実装済み（チェック漏れ）だが PoC 品質**。コード（`cleansingOffscreen.ts` /
+`cleansingOffscreenDelegate.ts`）とテストは PR #87 で導入済み。ファイル内コメントも一貫して
+「PoC」「計測するための分岐点」と明記。
+
+未達 2 点:
+1. feature flag `cleansing_offscreen_enabled` 既定 OFF で、本番の抽出パイプラインからは事実上未使用
+   （`contentKernel.cleanseViaOffscreen` は公開されるが記録フローで invoke なし）
+2. 受け入れ基準の `chrome.offscreen.hasDocument` ライフサイクル管理が未実装
+
+誤アーカイブというより「PoC を feat として archived した」状態。本番挙動に影響はない（flag OFF）。
+将来 Offscreen クレンジングを本番化する場合は、ライフサイクル管理と実パイプライン接続を
+新規 PBI で扱う。現時点では追加 PBI 化を見送り。
 
 ## テスト戦略
 

--- a/pbi/00-INDEX.md
+++ b/pbi/00-INDEX.md
@@ -14,10 +14,18 @@
 
 ## 進行中 ⬜ 未着手 / 🔶 部分実装
 
-**進行中の PBI は 0 件。** `pbi/` には INDEX と backlog のみが残る。
+| PBI | 種別 | 副作用 | 状態 | 概要 |
+|-----|------|--------|------|------|
+| [2026-09-01-05-fix-crypto-policy-ssot-followup](2026-09-01-05-fix-crypto-policy-ssot-followup.md) | 🔧 fix | 🟡 | ⬜ 未着手 | archived PBI 2026-08-29-12 の DoD 未達 2 項目: log export/import の HMAC 署名（VULN-035）と `hmacKeyStore`/`confirmTokenManager` の get-or-create 排他（VULN-039 残り） |
 
 ### 未 PBI 化のトリガー
 - **なし。** PBI 06 の効果確認は 2026-09-01 に実施済み（未達 → 06b/06c を実装し達成）。残債は `2026-08-31-00-backlog.md` の「06d 候補」に記録（次 provider 追加時などに着手検討）
+
+### archived PBI の DoD 乖離監査（2026-09-01）
+`autonomous-task-closer` で archived PBI のチェックボックスと実コードを照合。実害ありは PBI-22（対応済み）のみ。表記のみの乖離を各 archived PBI の実装メモに追記済み。特記:
+- `2026-08-29-12-fix-crypto-policy-ssot` — 中核実装済み、2 項目未達 → 上記 2026-09-01-05 に切り出し
+- `2026-08-24-03-refactor-sqlite-consolidation` — 部分実装（`storageMaintenance.ts` の動的 import 未解消、実害低）。追加 PBI 化は見送り
+- `2026-08-30-05-feat-cleansing-offscreen-delegation` — PoC 品質（flag OFF で本番未使用）。追加 PBI 化は見送り
 
 ---
 

--- a/pbi/2026-09-01-05-fix-crypto-policy-ssot-followup.md
+++ b/pbi/2026-09-01-05-fix-crypto-policy-ssot-followup.md
@@ -1,0 +1,71 @@
+# PBI: 暗号ポリシー SSOT の残余 — log export/import 署名 と get-or-create 排他
+
+## ユーザーストーリー
+利用者として、ブラウジングログのエクスポート/インポートが、設定エクスポートと同じ HMAC 署名で改竄検知されるようにしたい。なぜなら現在 log export ファイルは無署名で、細工したログ JSON をそのまま SQLite に取り込めてしまうから（VULN-035）。あわせて `hmacKeyStore` / `confirmTokenManager` の鍵・トークン生成が未排他で、並行呼び出しが分岐した鍵/トークンを生む余地が残っている（VULN-039 の残り）。
+
+## 背景
+
+archived PBI `2026-08-29-12-fix-crypto-policy-ssot.md`（VULN-010/034/035/037/038/039/040/052）の効果確認（2026-09-01、`autonomous-task-closer` の DoD 乖離監査）で、**中核は実装済みだが受け入れ基準の 2 項目が未達のまま archived 入り**していたことが判明した。
+
+### 実装済み（archived PBI で達成）
+- `src/utils/crypto/cryptoParams.ts` に暗号パラメータ SSOT（`PBKDF2_ITERATIONS: 600_000` / `LEGACY_PBKDF2_ITERATIONS: 100_000` / strict パスワードポリシー validator）。`primitives.ts` / `envelope.ts` / `hmacKeyStore.ts` / `masterPassword.ts` / `settingsExportImport.ts` が参照
+- KEK の `chrome.storage.session` 化（`hmacKeyStore.ts:137`、local は読み取り後方互換のみ）
+- `RateLimitService` の FAILED_ATTEMPTS / LOCKED_UNTIL を `storage.local` 永続化、成功時のみリセット
+- `masterPassword.validatePasswordRequirements` が `cryptoParams.validatePasswordPolicy` に一本化（弱い length≥8 実装は削除）
+- settings 暗号エクスポート version:2（ciphertext HMAC、復号前検証、v1 後方互換）
+- `encryptionSession.ts` の `encryptionKeyMutex` パターン
+
+### 未達（本 PBI のスコープ）
+1. **log export/import の HMAC 署名（archived PBI の受け入れ基準 L70 / VULN-035）**
+   - `src/dashboard/exportLogsService.ts` の `exportJson()` が生成する `{ version: 1, table: 'browsing_logs', rows }` に署名がない
+   - `src/dashboard/importLogsService.ts` の `importFromJson()` に署名ゲートがない（`validateRow` の 9 フィールド検証のみ）
+2. **`hmacKeyStore` / `confirmTokenManager` の get-or-create 未排他（archived PBI の受け入れ基準 L61 / VULN-039 の残り）**
+   - `src/utils/crypto/hmacKeyStore.ts:215` `getOrCreateWrappedHmacKey` が Mutex なし
+   - `src/background/confirmTokenManager.ts:62` `generateToken()` → set が排他なし
+
+## 受け入れ基準
+
+### log export/import 署名
+- [ ] `exportLogsService.exportJson()` が、`settingsExportImport.exportSettings()` と同じパターンで `getOrCreateHmacSecret()` + `computeHMAC(secret, json)` の署名を付与し、`{ version, table, rows, signature }` を書き出す
+- [ ] `importLogsService.importFromJson()` が、パース後・`importLogs` 呼び出し前に `signature` を検証する。`signature` 欠落は拒否（`constantTimeCompare`）。verification 失敗も無条件で拒否
+- [ ] 署名対象バイト列を export/import で厳密一致させ（`signature` を除いた `JSON.stringify(data, null, 2)`）、正当ファイルの round-trip がテストで壊れないことを保証
+- [ ] 旧無署名 log ファイルの扱いを決定（移行期間フラグ or 即時拒否）。settings import が「即時拒否＋i18n 警告」を採っているため揃えるのが既定案
+- [ ] `CHANGELOG.md` と `public/PRIVACY.md` + `docs/PRIVACY.md`（同一に保つ）を更新
+
+### get-or-create 排他
+- [ ] `hmacKeyStore.getOrCreateWrappedHmacKey` が `Mutex`（`src/background/Mutex.ts` 相当、または `encryptionSession` の `encryptionKeyMutex` パターン）で generate+wrap+persist+cache を 1 locked section にする
+- [ ] `confirmTokenManager` のトークン生成→保存を排他化する
+- [ ] 並行 2 コンテキスト呼び出しで単一の鍵/トークンが生成されることを統合テストで固定
+
+### 共通
+- [ ] `npm run type-check` / `npm run lint` / `npm run validate` が成功する
+- [ ] VulnHunter 再検証: VULN-035（log 署名）と VULN-039（get-or-create 排他）の再現テストが失敗する
+
+## テスト戦略
+
+### 単体
+- 新規 `src/dashboard/__tests__/exportImportLogsSignature.test.ts` — export→import の round-trip / 署名欠落拒否 / 改竄検知
+- 更新 `src/dashboard/__tests__/importLogsService.test.ts` / `importLogsService-validateRow.test.ts` — 署名フィクスチャ追加
+
+### 統合
+- `hmacKeyStore` × 2 コンテキスト同時 `getOrCreateWrappedHmacKey` → 単一鍵
+- `confirmTokenManager` × 並行 `issue` → 単一トークン
+
+## 実装アプローチ
+- Outside-In: 署名 round-trip テスト（Red）→ export に署名付与 → import に署名ゲート → 旧形式の扱い決定
+- `settingsExportImport.ts:310-352`（`exportSettings`）と `:440-490`（`importSettings`）を参照実装とする。secret 取得は `getOrCreateHmacSecret`（`encryptionSession.ts`）
+
+## 見積もり
+3pt — 署名パターンは settings 側に実在するため移植中心。get-or-create 排他は Mutex 適用 2 箇所 + 並行テスト
+
+## Definition of Done
+- [ ] 全受け入れ基準を満たす
+- [ ] log export/import の署名 round-trip テストがパス
+- [ ] get-or-create 排他の並行テストがパス
+- [ ] `npm run validate` green
+- [ ] archived PBI `2026-08-29-12` の該当項目が本 PBI で解消されたことを追記
+
+## 技術的考慮事項
+- 行番号は 2026-09-01 時点。着手時にシンボルで再確認
+- log export の JSON は現状 `version: 1`。署名導入で `version: 2` に上げるか、`signature` の有無で判定するかを決める（settings 側は `signature` フィールドの有無で分岐）
+- `hmacKeyStore` は content/offscreen からも呼ばれうるため、`Mutex` の import 経路が層を跨がないか確認（`encryptionSession` の mutex は utils 内で完結）


### PR DESCRIPTION
## 概要

`autonomous-task-closer` による archived PBI の DoD 乖離監査（`[x]` チェックと実コードの照合）の結果を反映するドキュメント PR。

## 監査結果

| 乖離種別 | PBI | 対応 |
|---|---|---|
| 実害あり | PBI-22 messaging transport | 別 PR #102 で対応済み・マージ済み |
| 中核実装済み・2項目未達 | 2026-08-29-12 crypto-policy-ssot | **本 PR でフォローアップ PBI 起票** |
| 部分実装（実害低） | 2026-08-24-03 sqlite-consolidation | 実装メモに明記、追加 PBI 化見送り |
| PoC 品質（flag OFF） | 2026-08-30-05 cleansing-offscreen-delegation | 実装メモに明記、追加 PBI 化見送り |
| 表記のみ | 2026-08-27-06 / 2026-08-31-01 / 2026-08-27-25 / 2026-08-24-03-sqlitevalue-cycle | （前回監査で確認済み。中核達成） |

## 変更

- **新規**: `pbi/2026-09-01-05-fix-crypto-policy-ssot-followup.md` — archived PBI 2026-08-29-12 の未達 2 項目:
  - log export/import の HMAC 署名（`exportLogsService.ts` / `importLogsService.ts` に痕跡ゼロ = VULN-035）
  - `hmacKeyStore.getOrCreateWrappedHmacKey` / `confirmTokenManager` の get-or-create 排他（VULN-039 の残り。`encryptionSession.ts` のみ mutex 適用済み）
- **訂正**: archived PBI 3 件の実装メモを実態に合わせて更新（実装済み分・未達分を明示）
- `pbi/00-INDEX.md` に進行中 PBI と監査サマリを追記

コード変更なし（ドキュメントのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)