### PR TITLE
fix(security): ログエクスポート HMAC 署名 と get-or-create 排他 (PBI 2026-09-01-05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ All notable changes to this project will be documented in this file.
 
 ## [6.7.98] - 2026-08-31
 
+### Security
+
+- ブラウジングログのエクスポート/インポートに HMAC 署名を導入（VULN-035）。`exportLogsService.exportJson()` が署名付き（`version: 2`）で書き出し、`importLogsService.importFromJson()` がインポート前に署名を検証する。無署名（旧 `version: 1`）または改竄されたログファイルは拒否される。**旧バージョンでエクスポートした無署名のログ JSON は再インポートできなくなる**ため、必要なら本バージョンで再エクスポートすること（`.db` エクスポートは影響なし）
+- `hmacKeyStore` の署名鍵・ラップキー生成と `confirmTokenManager` のトークンマップ更新を Mutex で直列化（VULN-039）。並行コンテキストが分岐した鍵/トークンを生成する余地を解消
+
 ### Fixed
 
 - E2Eテスト5件失敗を修正。`dashboard.fixture.ts` に `ai_provider_layout: 'a'` を追加しダッシュボードBレイアウトで `#aiProvider` が非表示になる問題を解消（built-in-ai 3件）、`wasm-boundary-comprehensive.spec.ts` を `create_confirm_token` API 経由に変更し 06b 以降の `dashboardSqliteConfirmToken` 不整合を解消（1件）、`recording-traceId.spec.ts` は logger buffer flush タイミング依存の pre-existing な flaky であることを明記して skip（1件）

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -111,6 +111,14 @@ Yasumaro（以下「本拡張機能」）は、ユーザーのプライバシー
 - **適用範囲**: エクスポートされたJSONファイルに含まれるすべての設定（APIキーを含む）
   - **注意**: パスワードを忘れた場合、暗号化されたエクスポートファイルを復号することはできません
 
+### ログエクスポートの改竄検知
+
+ブラウジングログを JSON 形式でエクスポートすると、ファイルに **HMAC 署名** が付与されます。インポート時にこの署名が検証され、無署名または改竄されたファイルは取り込まれません。署名鍵はブラウザプロファイルごとにローカル生成され、外部に送信されません。
+
+- **対象**: JSON 形式のログエクスポート/インポート
+- **注意**: 旧バージョン（署名なし）でエクスポートしたログ JSON は再インポートできません。必要な場合は最新バージョンで再エクスポートしてください
+- `.db` 形式のエクスポートは対象外です
+
 #### プライバシー同意の仕組み
 
 初回起動時にデータ収集への同意確認モーダルが表示されます。同意しない場合は制限モードで動作し、記録は行われません。3回連続で拒否すると、以降30日間はモーダルが表示されなくなります。30日経過後、再度同意確認が表示されます（GDPR 第7条「再同意取得」準拠）。
@@ -230,6 +238,14 @@ You can encrypt exported settings files with a **master password**.
 - **Encryption**: AES-GCM (industry standard) + PBKDF2 key derivation (100,000 iterations)
 - **Scope**: All settings in the exported JSON file, including API keys
 - **Note**: If you forget your password, encrypted export files cannot be decrypted
+
+### Log Export Tamper Detection
+
+When you export browsing logs as JSON, the file is **HMAC-signed**. On import the signature is verified, and unsigned or tampered files are rejected. The signing key is generated locally per browser profile and is never transmitted.
+
+- **Scope**: JSON-format log export/import
+- **Note**: Log JSON files exported by an older (unsigned) version cannot be re-imported. Re-export them from the latest version if needed
+- `.db`-format exports are not affected
 
 #### Privacy Consent Mechanism
 

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -111,6 +111,14 @@ Yasumaro（以下「本拡張機能」）は、ユーザーのプライバシー
 - **適用範囲**: エクスポートされたJSONファイルに含まれるすべての設定（APIキーを含む）
   - **注意**: パスワードを忘れた場合、暗号化されたエクスポートファイルを復号することはできません
 
+### ログエクスポートの改竄検知
+
+ブラウジングログを JSON 形式でエクスポートすると、ファイルに **HMAC 署名** が付与されます。インポート時にこの署名が検証され、無署名または改竄されたファイルは取り込まれません。署名鍵はブラウザプロファイルごとにローカル生成され、外部に送信されません。
+
+- **対象**: JSON 形式のログエクスポート/インポート
+- **注意**: 旧バージョン（署名なし）でエクスポートしたログ JSON は再インポートできません。必要な場合は最新バージョンで再エクスポートしてください
+- `.db` 形式のエクスポートは対象外です
+
 #### プライバシー同意の仕組み
 
 初回起動時にデータ収集への同意確認モーダルが表示されます。同意しない場合は制限モードで動作し、記録は行われません。3回連続で拒否すると、以降30日間はモーダルが表示されなくなります。30日経過後、再度同意確認が表示されます（GDPR 第7条「再同意取得」準拠）。
@@ -230,6 +238,14 @@ You can encrypt exported settings files with a **master password**.
 - **Encryption**: AES-GCM (industry standard) + PBKDF2 key derivation (100,000 iterations)
 - **Scope**: All settings in the exported JSON file, including API keys
 - **Note**: If you forget your password, encrypted export files cannot be decrypted
+
+### Log Export Tamper Detection
+
+When you export browsing logs as JSON, the file is **HMAC-signed**. On import the signature is verified, and unsigned or tampered files are rejected. The signing key is generated locally per browser profile and is never transmitted.
+
+- **Scope**: JSON-format log export/import
+- **Note**: Log JSON files exported by an older (unsigned) version cannot be re-imported. Re-export them from the latest version if needed
+- `.db`-format exports are not affected
 
 #### Privacy Consent Mechanism
 

--- a/src/background/confirmTokenManager.ts
+++ b/src/background/confirmTokenManager.ts
@@ -4,8 +4,26 @@
  * Stored only in chrome.storage.session, validated on verify with TTL and single-use consumption.
  */
 
+import { Mutex } from '../utils/Mutex.js';
+
 export const CONFIRM_TOKENS_SESSION_KEY = 'dashboardSqliteConfirmTokens';
 export const CONFIRM_TOKEN_TTL_MS = 60_000;
+
+// Serialises the load -> mutate -> save of the token map so a concurrent
+// create/verify pair cannot lose an entry to a last-write-wins overwrite
+// (VULN-039). All map mutations run through withTokenMap.
+const tokenMapMutex = new Mutex();
+
+async function withTokenMap<T>(fn: (map: TokenMap) => T | Promise<T>): Promise<T> {
+  await tokenMapMutex.acquire();
+  try {
+    const map = await loadMap();
+    const result = await fn(map);
+    return result;
+  } finally {
+    tokenMapMutex.release();
+  }
+}
 
 export interface ConfirmTokenRecord {
   token: string;
@@ -62,11 +80,12 @@ export async function createConfirmToken(action: string, id?: number): Promise<s
   const token = generateToken();
   const expiresAt = Date.now() + CONFIRM_TOKEN_TTL_MS;
   const record: ConfirmTokenRecord = { token, action, expiresAt, ...(id !== undefined ? { id } : {}) };
-  const map = await loadMap();
-  pruneExpired(map);
-  map[token] = record;
-  await saveMap(map);
-  return token;
+  return withTokenMap(async (map) => {
+    pruneExpired(map);
+    map[token] = record;
+    await saveMap(map);
+    return token;
+  });
 }
 
 /**
@@ -75,25 +94,26 @@ export async function createConfirmToken(action: string, id?: number): Promise<s
  */
 export async function verifyConfirmToken(token: string, action: string, id?: number): Promise<boolean> {
   if (!token || typeof token !== 'string') return false;
-  const map = await loadMap();
-  const rec = map[token];
-  if (!rec) return false;
-  if (isExpired(rec)) {
+  return withTokenMap(async (map) => {
+    const rec = map[token];
+    if (!rec) return false;
+    if (isExpired(rec)) {
+      delete map[token];
+      try { await saveMap(map); } catch {}
+      return false;
+    }
+    if (rec.action !== action) return false;
+    const recId = rec.id;
+    const wantId = id;
+    if (recId !== wantId) {
+      // Strict compare: both undefined -> equal, otherwise must match
+      if (!(recId === undefined && wantId === undefined) && recId !== wantId) return false;
+    }
+    // Single-use: consume
     delete map[token];
     try { await saveMap(map); } catch {}
-    return false;
-  }
-  if (rec.action !== action) return false;
-  const recId = rec.id;
-  const wantId = id;
-  if (recId !== wantId) {
-    // Strict compare: both undefined -> equal, otherwise must match
-    if (!(recId === undefined && wantId === undefined) && recId !== wantId) return false;
-  }
-  // Single-use: consume
-  delete map[token];
-  try { await saveMap(map); } catch {}
-  return true;
+    return true;
+  });
 }
 
 /**

--- a/src/background/handlers/dashboardSqlite/__tests__/confirmTokenManager.test.ts
+++ b/src/background/handlers/dashboardSqlite/__tests__/confirmTokenManager.test.ts
@@ -67,4 +67,19 @@ describe('confirmTokenManager per-action single-use TTL', () => {
     expect(localData['dashboardSqliteConfirmTokens']).toBeUndefined();
     expect(await verifyConfirmToken(token, 'migrate')).toBe(true);
   });
+
+  it('parallel createConfirmToken calls do not lose entries to last-write-wins (VULN-039)', async () => {
+    vi.useRealTimers();
+    const tokens = await Promise.all([
+      createConfirmToken('delete', 1),
+      createConfirmToken('delete', 2),
+      createConfirmToken('delete', 3),
+      createConfirmToken('delete', 4),
+      createConfirmToken('delete', 5),
+    ]);
+    // Without serialisation, concurrent load->save would drop all but one.
+    for (let i = 0; i < tokens.length; i++) {
+      expect(await verifyConfirmToken(tokens[i], 'delete', i + 1)).toBe(true);
+    }
+  });
 });

--- a/src/dashboard/__tests__/exportLogsService.test.ts
+++ b/src/dashboard/__tests__/exportLogsService.test.ts
@@ -15,6 +15,13 @@ vi.mock('../dashboardSqliteService.js', () => ({
   queryLogs: (...args: any[]) => mockQueryLogs(...args),
 }));
 
+vi.mock('../../utils/storage/encryptionSession.js', () => ({
+  getOrCreateHmacSecret: vi.fn(async () => 'test-secret'),
+}));
+vi.mock('../../utils/crypto/index.js', () => ({
+  computeHMAC: vi.fn(async (secret: string, payload: string) => `hmac(${secret}):${payload.length}`),
+}));
+
 // ---------------------------------------------------------------------------
 // Import
 // ---------------------------------------------------------------------------
@@ -197,10 +204,21 @@ describe('exportLogsService', () => {
       const text = await blob.text();
       const parsed = JSON.parse(text);
 
-      expect(parsed.version).toBe(1);
+      expect(parsed.version).toBe(2);
       expect(parsed.table).toBe('browsing_logs');
       expect(parsed.rows).toHaveLength(2);
       expect(parsed.rows[0].url).toBe('https://example.com/page1');
+      expect(typeof parsed.signature).toBe('string');
+      expect(parsed.signature.length).toBeGreaterThan(0);
+    });
+
+    it('signs the signature-stripped body so import can verify it', async () => {
+      mockQueryLogs.mockResolvedValue({ data: { rows: SAMPLE_ROWS, total: 2 } });
+      const parsed = JSON.parse(await (await exportJson()).text());
+      const { signature, ...body } = parsed;
+      // mock computeHMAC returns `hmac(secret):<payload length>`
+      const expectedLen = JSON.stringify(body, null, 2).length;
+      expect(signature).toBe(`hmac(test-secret):${expectedLen}`);
     });
 
     it('has correct MIME type', async () => {

--- a/src/dashboard/__tests__/importLogsService-validateRow.test.ts
+++ b/src/dashboard/__tests__/importLogsService-validateRow.test.ts
@@ -9,13 +9,24 @@ vi.mock('../dashboardSqliteService.js', () => ({
   importLogs: vi.fn(),
 }));
 
+vi.mock('../../utils/storage/encryptionSession.js', () => ({
+  getOrCreateHmacSecret: vi.fn(async () => 'test-secret'),
+}));
+vi.mock('../../utils/crypto/index.js', () => ({
+  computeHMAC: vi.fn(async (secret: string, payload: string) => `hmac(${secret}):${payload.length}:${payload.slice(0, 8)}`),
+  constantTimeCompare: vi.fn(async (a: string, b: string) => a === b),
+}));
+
 import { importLogs } from '../dashboardSqliteService.js';
+import { computeHMAC } from '../../utils/crypto/index.js';
 
 const NOW = 1_700_000_000_000;
 
 async function importRows(rows: unknown[]) {
   const { importFromJson } = await import('../importLogsService.js');
-  return importFromJson(JSON.stringify({ rows }));
+  const body = { version: 2, table: 'browsing_logs', rows };
+  const signature = await computeHMAC('test-secret', JSON.stringify(body, null, 2));
+  return importFromJson(JSON.stringify({ ...body, signature }));
 }
 
 describe('validateRow (via importFromJson)', () => {

--- a/src/dashboard/__tests__/importLogsService.test.ts
+++ b/src/dashboard/__tests__/importLogsService.test.ts
@@ -8,7 +8,25 @@ vi.mock('../dashboardSqliteService.js', () => ({
   importLogs: vi.fn(),
 }));
 
+// Deterministic crypto so fixtures can be signed in-test. computeHMAC is a
+// pure function of (secret, payload); constantTimeCompare is a plain equals.
+vi.mock('../../utils/storage/encryptionSession.js', () => ({
+  getOrCreateHmacSecret: vi.fn(async () => 'test-secret'),
+}));
+vi.mock('../../utils/crypto/index.js', () => ({
+  computeHMAC: vi.fn(async (secret: string, payload: string) => `hmac(${secret}):${payload.length}:${payload.slice(0, 8)}`),
+  constantTimeCompare: vi.fn(async (a: string, b: string) => a === b),
+}));
+
 import { importLogs } from '../dashboardSqliteService.js';
+import { computeHMAC } from '../../utils/crypto/index.js';
+
+/** Build a signed log-export JSON string the way exportJson would. */
+async function signedExport(rows: unknown[], overrides: Record<string, unknown> = {}): Promise<string> {
+  const body = { version: 2, table: 'browsing_logs', rows, ...overrides };
+  const signature = await computeHMAC('test-secret', JSON.stringify(body, null, 2));
+  return JSON.stringify({ ...body, signature });
+}
 
 describe('importFromJson', () => {
   beforeEach(() => {
@@ -22,23 +40,46 @@ describe('importFromJson', () => {
     expect(importLogs).not.toHaveBeenCalled();
   });
 
+  it('rejects an unsigned file', async () => {
+    const { importFromJson } = await import('../importLogsService.js');
+    const result = await importFromJson(JSON.stringify({ rows: [{ url: 'https://a.com', created_at: 1 }] }));
+    expect(result).toEqual({
+      error: 'This log file is unsigned and cannot be imported. Re-export it from this extension.',
+    });
+    expect(importLogs).not.toHaveBeenCalled();
+  });
+
+  it('rejects a tampered file (signature mismatch)', async () => {
+    const { importFromJson } = await import('../importLogsService.js');
+    const json = await signedExport([{ url: 'https://a.com', created_at: 1 }]);
+    const tampered = JSON.parse(json);
+    tampered.rows.push({ url: 'https://evil.com', created_at: 2 });
+    const result = await importFromJson(JSON.stringify(tampered));
+    expect(result).toEqual({
+      error: 'Log file signature verification failed. The file may be corrupted or was exported from a different browser profile.',
+    });
+    expect(importLogs).not.toHaveBeenCalled();
+  });
+
   it('returns error when rows array is empty', async () => {
     const { importFromJson } = await import('../importLogsService.js');
-    const result = await importFromJson(JSON.stringify({ rows: [] }));
+    const result = await importFromJson(await signedExport([]));
     expect(result).toEqual({ error: 'No records found in file' });
     expect(importLogs).not.toHaveBeenCalled();
   });
 
   it('returns error when rows field is missing', async () => {
     const { importFromJson } = await import('../importLogsService.js');
-    const result = await importFromJson(JSON.stringify({}));
+    const body = { version: 2, table: 'browsing_logs' };
+    const signature = await computeHMAC('test-secret', JSON.stringify(body, null, 2));
+    const result = await importFromJson(JSON.stringify({ ...body, signature }));
     expect(result).toEqual({ error: 'No records found in file' });
     expect(importLogs).not.toHaveBeenCalled();
   });
 
   it('returns error when all rows are invalid', async () => {
     const { importFromJson } = await import('../importLogsService.js');
-    const json = JSON.stringify({ rows: [{ title: 'no url' }, { url: '', created_at: 100 }] });
+    const json = await signedExport([{ title: 'no url' }, { url: '', created_at: 100 }]);
     const result = await importFromJson(json);
     expect(result).toEqual({ error: 'No valid records found (url and created_at required)' });
     expect(importLogs).not.toHaveBeenCalled();
@@ -47,13 +88,11 @@ describe('importFromJson', () => {
   it('imports valid rows and filters out invalid ones', async () => {
     vi.mocked(importLogs).mockResolvedValue({ data: { inserted: 2, skipped: 0, total: 2 } });
     const { importFromJson } = await import('../importLogsService.js');
-    const json = JSON.stringify({
-      rows: [
-        { url: 'https://example.com', created_at: 1000 },
-        { url: 'https://test.com', created_at: 2000, title: 'Test' },
-        { title: 'no url' },
-      ],
-    });
+    const json = await signedExport([
+      { url: 'https://example.com', created_at: 1000 },
+      { url: 'https://test.com', created_at: 2000, title: 'Test' },
+      { title: 'no url' },
+    ]);
     const result = await importFromJson(json);
     expect(result).toEqual({ inserted: 2, skipped: 0, total: 2 });
     expect(importLogs).toHaveBeenCalledWith([
@@ -70,8 +109,7 @@ describe('importFromJson', () => {
       url: `https://example${i}.com`,
       created_at: 1000 + i,
     }));
-    const json = JSON.stringify({ rows });
-    const result = await importFromJson(json, onProgress);
+    const result = await importFromJson(await signedExport(rows), onProgress);
     expect(result).toEqual({ inserted: 20, skipped: 0, total: 250 });
     expect(onProgress).toHaveBeenCalledTimes(2);
     expect(onProgress).toHaveBeenNthCalledWith(1, 200, 250);
@@ -87,19 +125,14 @@ describe('importFromJson', () => {
       url: `https://example${i}.com`,
       created_at: 1000 + i,
     }));
-    const json = JSON.stringify({ rows });
-    const result = await importFromJson(json);
+    const result = await importFromJson(await signedExport(rows));
     expect(result).toEqual({ inserted: 2, skipped: 50, total: 250 });
   });
 
   it('surfaces the reason when every batch fails', async () => {
-    // Nothing was inserted, so "0 inserted, N skipped" would leave the user
-    // guessing why — the collected batch reasons replace it.
     vi.mocked(importLogs).mockResolvedValue({ error: 'Database is locked' });
     const { importFromJson } = await import('../importLogsService.js');
-    const json = JSON.stringify({
-      rows: [{ url: 'https://example.com', created_at: 1000 }],
-    });
+    const json = await signedExport([{ url: 'https://example.com', created_at: 1000 }]);
     const result = await importFromJson(json);
     expect(result).toEqual({ error: 'Database is locked' });
   });
@@ -113,8 +146,7 @@ describe('importFromJson', () => {
       url: `https://example${i}.com`,
       created_at: 1000 + i,
     }));
-    const json = JSON.stringify({ rows });
-    const result = await importFromJson(json);
+    const result = await importFromJson(await signedExport(rows));
     expect(result).toEqual({ error: 'Database is locked; Batch too large' });
   });
 });

--- a/src/dashboard/__tests__/logExportSignature.test.ts
+++ b/src/dashboard/__tests__/logExportSignature.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+/**
+ * logExportSignature.test.ts
+ * End-to-end: exportJson signs, importFromJson verifies (VULN-035).
+ * Uses the real HMAC primitive and the storage-mock-backed secret, so a
+ * regression in the signed byte range is caught here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQueryLogs = vi.fn();
+const mockImportLogs = vi.fn();
+
+vi.mock('../dashboardSqliteService.js', () => ({
+  queryLogs: (...args: unknown[]) => mockQueryLogs(...args),
+  importLogs: (...args: unknown[]) => mockImportLogs(...args),
+}));
+
+import { exportJson } from '../exportLogsService.js';
+import { importFromJson } from '../importLogsService.js';
+
+const ROWS = [
+  { id: 1, url: 'https://example.com/a', title: 'A', summary: 's1', tags: '["x"]', created_at: 1_700_000_000_000, domain: 'example.com', is_starred: 0 },
+  { id: 2, url: 'https://example.com/b', title: 'B', summary: 's2', tags: '[]', created_at: 1_700_000_100_000, domain: 'example.com', is_starred: 1 },
+];
+
+describe('log export/import signature round-trip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryLogs.mockResolvedValue({ data: { rows: ROWS, total: ROWS.length } });
+    mockImportLogs.mockResolvedValue({ data: { inserted: ROWS.length, skipped: 0, total: ROWS.length } });
+  });
+
+  it('a freshly exported file imports successfully', async () => {
+    const json = await (await exportJson()).text();
+    const result = await importFromJson(json);
+    expect(result).toEqual({ inserted: 2, skipped: 0, total: 2 });
+  });
+
+  it('flipping one byte of the body fails verification', async () => {
+    const parsed = JSON.parse(await (await exportJson()).text());
+    parsed.rows[0].title = 'A-tampered';
+    const result = await importFromJson(JSON.stringify(parsed));
+    expect(result).toHaveProperty('error');
+    expect((result as { error: string }).error).toMatch(/signature verification failed/i);
+    expect(mockImportLogs).not.toHaveBeenCalled();
+  });
+
+  it('stripping the signature is rejected as unsigned', async () => {
+    const parsed = JSON.parse(await (await exportJson()).text());
+    delete parsed.signature;
+    const result = await importFromJson(JSON.stringify(parsed));
+    expect((result as { error: string }).error).toMatch(/unsigned/i);
+    expect(mockImportLogs).not.toHaveBeenCalled();
+  });
+});

--- a/src/dashboard/exportLogsService.ts
+++ b/src/dashboard/exportLogsService.ts
@@ -7,6 +7,15 @@
 import { queryLogs, backupDb } from './dashboardSqliteService.js';
 import { sanitizeForObsidian } from '../utils/markdownSanitizer.js';
 import { yamlQuote, yamlQuoteList } from '../utils/yamlFrontmatter.js';
+import { getOrCreateHmacSecret } from '../utils/storage/encryptionSession.js';
+import { computeHMAC } from '../utils/crypto/index.js';
+
+/**
+ * Log JSON export format version. v2 adds an HMAC `signature` over the
+ * signature-stripped body (VULN-035), mirroring settingsExportImport's
+ * unencrypted export. v1 files (no signature) are rejected on import.
+ */
+export const LOG_EXPORT_VERSION = 2;
 
 // ============================================================================
 // Markdown Export
@@ -111,7 +120,11 @@ export async function exportCsv(): Promise<Blob> {
 
 export async function exportJson(): Promise<Blob> {
   const all = await queryAllData();
-  const json = JSON.stringify({ version: 1, table: 'browsing_logs', rows: all }, null, 2);
+  const body = { version: LOG_EXPORT_VERSION, table: 'browsing_logs', rows: all };
+  // Sign the signature-stripped body; import recomputes over the same bytes.
+  const hmacSecret = await getOrCreateHmacSecret();
+  const signature = await computeHMAC(hmacSecret, JSON.stringify(body, null, 2));
+  const json = JSON.stringify({ ...body, signature }, null, 2);
   return new Blob([json], { type: 'application/json' });
 }
 

--- a/src/dashboard/importLogsService.ts
+++ b/src/dashboard/importLogsService.ts
@@ -4,6 +4,8 @@
  */
 
 import { importLogs } from './dashboardSqliteService.js';
+import { getOrCreateHmacSecret } from '../utils/storage/encryptionSession.js';
+import { computeHMAC, constantTimeCompare } from '../utils/crypto/index.js';
 
 interface ExportedRow {
   url: string;
@@ -22,6 +24,7 @@ interface ExportedData {
   version?: number;
   table?: string;
   rows?: ExportedRow[];
+  signature?: string;
 }
 
 /** Upper bound on rows accepted from a single import file (VULN-023). */
@@ -54,6 +57,23 @@ function isOptionalFiniteInRange(value: unknown, min: number, max: number): bool
 
 function isOptionalFlag(value: unknown): boolean {
   return value === undefined || value === 0 || value === 1;
+}
+
+/**
+ * Verify the HMAC signature over the signature-stripped body. Returns an error
+ * string to abort the import, or `null` when the file is authentic.
+ */
+async function verifyExportSignature(parsed: ExportedData): Promise<string | null> {
+  if (typeof parsed.signature !== 'string' || parsed.signature.length === 0) {
+    return 'This log file is unsigned and cannot be imported. Re-export it from this extension.';
+  }
+  const { signature, ...body } = parsed;
+  const hmacSecret = await getOrCreateHmacSecret();
+  const expected = await computeHMAC(hmacSecret, JSON.stringify(body, null, 2));
+  if (!(await constantTimeCompare(signature, expected))) {
+    return 'Log file signature verification failed. The file may be corrupted or was exported from a different browser profile.';
+  }
+  return null;
 }
 
 function validateRow(row: unknown): row is ExportedRow {
@@ -97,6 +117,14 @@ export async function importFromJson(
     parsed = JSON.parse(jsonText) as ExportedData;
   } catch {
     return { error: 'Invalid JSON format' };
+  }
+
+  // Signature gate (VULN-035): reject unsigned or tampered files before any
+  // row reaches SQLite. Mirrors settingsExportImport.importSettings — v1
+  // (unsigned) files are not accepted.
+  const signatureError = await verifyExportSignature(parsed);
+  if (signatureError) {
+    return { error: signatureError };
   }
 
   const rows = parsed.rows;

--- a/src/utils/crypto/__tests__/hmacKeyStoreConcurrency.test.ts
+++ b/src/utils/crypto/__tests__/hmacKeyStoreConcurrency.test.ts
@@ -1,0 +1,40 @@
+/**
+ * hmacKeyStoreConcurrency.test.ts
+ * VULN-039: parallel get-or-create must converge on a single persisted key,
+ * not race and generate two.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getNotificationHmacKey, generateHmacSignature, verifyHmacSignature } from '../hmacKeyStore.js';
+
+describe('hmacKeyStore get-or-create serialisation', () => {
+  beforeEach(async () => {
+    await chrome.storage.local.clear();
+    await chrome.storage.session.clear();
+  });
+
+  it('two parallel getNotificationHmacKey calls yield interoperable keys', async () => {
+    const [keyA, keyB] = await Promise.all([getNotificationHmacKey(), getNotificationHmacKey()]);
+
+    // If the two calls raced and persisted different key material, a signature
+    // produced under one would not verify under the other.
+    const sig = await generateHmacSignature('payload', keyA);
+    expect(await verifyHmacSignature('payload', sig, keyB)).toBe(true);
+  });
+
+  it('exactly one wrapped key is persisted after a parallel burst', async () => {
+    await Promise.all([
+      getNotificationHmacKey(),
+      getNotificationHmacKey(),
+      getNotificationHmacKey(),
+      getNotificationHmacKey(),
+    ]);
+
+    const stored = await chrome.storage.local.get('notification-signature-key');
+    expect(stored['notification-signature-key']).toBeDefined();
+    // A later single call must resolve to the same key.
+    const key = await getNotificationHmacKey();
+    const sig = await generateHmacSignature('x', key);
+    const again = await getNotificationHmacKey();
+    expect(await verifyHmacSignature('x', sig, again)).toBe(true);
+  });
+});

--- a/src/utils/crypto/hmacKeyStore.ts
+++ b/src/utils/crypto/hmacKeyStore.ts
@@ -7,12 +7,21 @@
  */
 
 import { errorMessage } from '../errorUtils.js';
+import { Mutex } from '../Mutex.js';
 import {
     getWebCrypto,
     ENVELOPE_ITERATIONS,
     bytesToBase64,
     base64ToBytes,
 } from './primitives.js';
+
+// Serialises get-or-create so two contexts calling in parallel converge on a
+// single persisted key instead of each generating its own (VULN-039).
+// Two locks, always acquired outer (signing key) -> inner (wrapping key), so
+// getOrCreateWrappedHmacKey can call getOrCreateHmacWrappingKey while holding
+// the outer lock without a cycle. Contention is negligible (keys created once).
+const signingKeyMutex = new Mutex();
+const wrappingKeyMutex = new Mutex();
 
 const KEY_LENGTH = 256; // bits
 const IV_LENGTH = 12; // bytes (recommended for AES-GCM)
@@ -94,6 +103,15 @@ export async function deriveHmacWrappingKey(password: string, salt: Uint8Array):
  * @returns {Promise<CryptoKey>} AES-GCM wrapping key
  */
 async function getOrCreateHmacWrappingKey(): Promise<CryptoKey> {
+    await wrappingKeyMutex.acquire();
+    try {
+        return await getOrCreateHmacWrappingKeyLocked();
+    } finally {
+        wrappingKeyMutex.release();
+    }
+}
+
+async function getOrCreateHmacWrappingKeyLocked(): Promise<CryptoKey> {
     const webcrypto = getWebCrypto();
 
     try {
@@ -212,6 +230,15 @@ function base64ToUint8Array(base64: string): Uint8Array<ArrayBuffer> {
  * @returns {Promise<CryptoKey>} HMAC-SHA256 signing key
  */
 async function getOrCreateWrappedHmacKey(storageKey: string, versionKey: string): Promise<CryptoKey> {
+    await signingKeyMutex.acquire();
+    try {
+        return await getOrCreateWrappedHmacKeyLocked(storageKey, versionKey);
+    } finally {
+        signingKeyMutex.release();
+    }
+}
+
+async function getOrCreateWrappedHmacKeyLocked(storageKey: string, versionKey: string): Promise<CryptoKey> {
     const webcrypto = getWebCrypto();
 
     try {


### PR DESCRIPTION
## 概要

archived PBI `2026-08-29-12-fix-crypto-policy-ssot.md` の DoD 乖離監査（2026-09-01）で判明した **未達 2 項目** に対応する。フォローアップ PBI: `pbi/2026-09-01-05-fix-crypto-policy-ssot-followup.md`（PR #103 で起票中）。

## VULN-035: ログエクスポートの改竄検知

`exportLogsService.ts` / `importLogsService.ts` に HMAC 署名がなく、細工したログ JSON をそのまま SQLite に取り込めた。

- `exportJson()` が署名付き（`version: 2`）で書き出す。`settingsExportImport.exportSettings` と同じ `getOrCreateHmacSecret()` + `computeHMAC()` パターンで、`signature` を除いた body（`JSON.stringify(body, null, 2)`）に対して署名
- `importFromJson()` がパース後・`importLogs` 前に署名を検証。無署名（旧 `version: 1`）/ 改竄ファイルは `constantTimeCompare` で拒否
- `logExportSignature.test.ts` — 実 crypto での round-trip / 1 バイト改竄検知 / 無署名拒否
- 既存テスト（`importLogsService*.test.ts` / `exportLogsService.test.ts`）を署名フィクスチャに更新

**破壊的変更**: 旧バージョンでエクスポートした無署名のログ JSON は再インポート不可（`.db` エクスポートは影響なし）。CHANGELOG / PRIVACY に明記。

## VULN-039: get-or-create の未排他

archived PBI では `encryptionSession.ts` のみ mutex 適用済みだった。

- **`hmacKeyStore.ts`**: `signingKeyMutex` / `wrappingKeyMutex` の 2 ロック（常に outer → inner の順で取得し reentrancy デッドロックを回避）で `getOrCreateWrappedHmacKey` / `getOrCreateHmacWrappingKey` を直列化
- **`confirmTokenManager.ts`**: `withTokenMap()` でトークンマップの load → mutate → save を `Mutex` 直列化。並行 `create`/`verify` が last-write-wins で entry を失う問題を解消
- 各々 concurrency テストを追加（**fix を revert すると fail することを確認済み**）

## 検証

- `npm run type-check` / `npm run lint` green
- `npx vitest run`: 11116 passed（新規テスト +）
- `npm run build` green
- `npm run test:e2e --grep "diagnostic|export|import|confirm"`: 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)