### PR TITLE
chore: DoD 乖離監査で見つかった残債 2 件を掃除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- コンテンツクレンジングのキーワード設定 UI が既定/リセット時に表示するキーワードを、実際の strip ロジックが使う全リスト（約52語）に合わせた。従来は古い17語のサブセットがハードコードされており、`contentCleaner.DEFAULT_KEYWORDS` からドリフトしていた（archived PBI 2026-08-27-10 の効果確認で発見）
+- archived PBI 2026-08-27-06 の掃除: `opfsWorker/statusHandlers.ts` の到達不能なデッドコード `handleSqlExec` / `handleSqlQuery`（メッセージ型からは削除済みだが export だけ残存）を削除
 - E2Eテスト5件失敗を修正。`dashboard.fixture.ts` に `ai_provider_layout: 'a'` を追加しダッシュボードBレイアウトで `#aiProvider` が非表示になる問題を解消（built-in-ai 3件）、`wasm-boundary-comprehensive.spec.ts` を `create_confirm_token` API 経由に変更し 06b 以降の `dashboardSqliteConfirmToken` 不整合を解消（1件）、`recording-traceId.spec.ts` は logger buffer flush タイミング依存の pre-existing な flaky であることを明記して skip（1件）
 - `trustDb.repairDatabase` の型安全性を改善。`as unknown as Record<string, unknown>` キャストを `as unknown as Record<string, unknown>` に統一し、各サブオブジェクトを明示的に再代入する形に変更
 - `settingsMigration.ts` の未使用 `deriveKey` import を削除（lint エラー修正）

--- a/dev-docs/archived/pbi/2026-08-27-06-fix-opfs-worker-sql-exec.md
+++ b/dev-docs/archived/pbi/2026-08-27-06-fix-opfs-worker-sql-exec.md
@@ -41,3 +41,15 @@ Scenario: 攻撃 — 外部から任意SQLは拒否される
 - [x] 全BDDシナリオが自動テストとして実装されパスする
 - [x] コードレビュー完了
 - [x] ドキュメント更新済み
+
+## 実装メモ（効果確認: 2026-09-01 の DoD 乖離監査 + 掃除）
+
+- `WORKER_MESSAGE_TYPES` からの削除・ルーティングからの除去は達成済みで、生 SQL 注入経路は
+  実際に断たれている（PBI の主目的は達成）。
+- 受け入れ基準の「case が削除されている」に対し、`src/offscreen/opfsWorker/statusHandlers.ts`
+  に `handleSqlExec` / `handleSqlQuery` が **export されたまま到達不能なデッドコード**として
+  残っていた（`src/` から一切 import されず）。2026-09-01 の掃除 PR で両関数と
+  未使用になった `SqliteValue` / `SqliteRow` import を削除。
+- `opfsWorkerProxy.ts` の汎用 `sendToOpfsWorker` の allowlist 検証（受け入れ基準 3 番目）は
+  未実装のまま。ただしワーカ側ルータが未知 type を拒否するため実害はない。将来
+  `sendToOpfsWorker` を拡張する場合の要注意点として残置。

--- a/dev-docs/archived/pbi/2026-08-27-10-fix-page-state-duplicate.md
+++ b/dev-docs/archived/pbi/2026-08-27-10-fix-page-state-duplicate.md
@@ -40,3 +40,14 @@ Scenario: エッジケース — 将来キーワード追加時の更新漏れ�
 - [x] 全BDDシナリオが自動テストとして実装されパスする
 - [x] コードレビュー完了
 - [x] ドキュメント更新済み
+
+## 実装メモ（効果確認: 2026-09-01 の DoD 乖離監査 + 掃除）
+
+本 PBI のスコープ（`pageState.ts` ↔ `contentCleaner.ts`）は達成済み。
+2026-09-01 の監査で **スコープ外**の 3 つ目のコピーが見つかった:
+`src/dashboard/settings/contentSettings.ts` にダッシュボード設定 UI 用の
+`DEFAULT_KEYWORDS`（17 語）がハードコードされており、`contentCleaner.DEFAULT_KEYWORDS`
+（~52 語）の古い前半サブセットだった。strip ロジックは全 52 語を使うため、
+設定 UI のデフォルト表示・リセットだけが狭かった。同日の掃除 PR で
+`contentSettings.ts` を `contentCleaner.DEFAULT_KEYWORDS` の import に置換
+（設定 UI のデフォルト/リセットが全 52 語に広がる = 正しい挙動への修正）。

--- a/src/dashboard/settings/__tests__/contentSettings.test.ts
+++ b/src/dashboard/settings/__tests__/contentSettings.test.ts
@@ -252,6 +252,7 @@ vi.mock('../../../utils/logger.js', () => ({
 }));
 
 import { loadContentSettings, init } from '../contentSettings.js';
+import { DEFAULT_KEYWORDS } from '../../../utils/contentCleaner.js';
 
 // ============================================================================
 // Helpers
@@ -359,9 +360,7 @@ describe('contentSettings', () => {
       expect(getKeywordEnabledCheckbox()?.checked).toBe(true);
 
       // CONTENT_STRIP_KEYWORDS: defaults when not set
-      expect(getKeywordsTextarea()?.value).toBe(
-        ['balance', 'account', 'meisai', 'login', 'card-number', 'keiyaku', 'password', 'payment', 'transaction', 'billing', 'invoice', 'receipt', 'rireki', 'torihiki', 'zandaka', 'hoken', 'address'].join('\n')
-      );
+      expect(getKeywordsTextarea()?.value).toBe([...DEFAULT_KEYWORDS].join('\n'));
 
       // CONTENT_DEDUP_ENABLED: default true
       expect(getDedupEnabledCheckbox()?.checked).toBe(true);
@@ -565,7 +564,7 @@ describe('contentSettings', () => {
       await vi.waitFor(() => {
         expect(mockSaveSettings).toHaveBeenCalledWith(
           expect.objectContaining({
-            content_strip_keywords: ['balance', 'account', 'meisai', 'login', 'card-number', 'keiyaku', 'password', 'payment', 'transaction', 'billing', 'invoice', 'receipt', 'rireki', 'torihiki', 'zandaka', 'hoken', 'address'],
+            content_strip_keywords: [...DEFAULT_KEYWORDS],
           })
         );
       });

--- a/src/dashboard/settings/contentSettings.ts
+++ b/src/dashboard/settings/contentSettings.ts
@@ -9,9 +9,10 @@ import { errorMessage } from '../../utils/errorUtils.js';
 import { showStatus } from '../../utils/ui/settingsUiHelper.js';
 import { getMessage } from '../../utils/i18n.js';
 import { logError, ErrorCode } from '../../utils/logger.js';
-
-// デフォルトキーワードリスト
-const DEFAULT_KEYWORDS = ['balance', 'account', 'meisai', 'login', 'card-number', 'keiyaku', 'password', 'payment', 'transaction', 'billing', 'invoice', 'receipt', 'rireki', 'torihiki', 'zandaka', 'hoken', 'address'];
+// Single source of truth for the default keyword list — the strip logic in
+// contentCleaner already uses this full set; the dashboard's local copy had
+// drifted to a stale 17-word subset.
+import { DEFAULT_KEYWORDS } from '../../utils/contentCleaner.js';
 
 // DOM Elements (lazily resolved for testability)
 function getSaveBtn(): HTMLElement | null { return document.getElementById('saveContentSettings'); }
@@ -91,7 +92,7 @@ async function saveContentSettings(): Promise<void> {
                 .map(k => k.trim())
                 .filter(k => k.length > 0); // 空行を除外
 
-            settings[StorageKeys.CONTENT_STRIP_KEYWORDS] = keywords.length > 0 ? keywords : DEFAULT_KEYWORDS;
+            settings[StorageKeys.CONTENT_STRIP_KEYWORDS] = keywords.length > 0 ? keywords : [...DEFAULT_KEYWORDS];
         }
 
         // テキスト品質設定

--- a/src/offscreen/opfsWorker/statusHandlers.ts
+++ b/src/offscreen/opfsWorker/statusHandlers.ts
@@ -1,9 +1,8 @@
 /**
  * statusHandlers.ts
- * Status, diagnostics, and migration-escape-hatch SQL handlers.
+ * Status and diagnostics handlers.
  */
 
-import type { SqliteValue, SqliteRow } from '../sqliteEngine.js';
 import { sqlQuery, type HandlerContext } from './handlers.js';
 import { pickDefined } from '../../utils/objectUtils.js';
 
@@ -33,27 +32,4 @@ export async function handleFtsIndexSize(ctx: HandlerContext, fts5Available: boo
   let count = 0;
   await sqlQuery(ctx, 'SELECT COUNT(*) AS c FROM browsing_logs_fts', [], (row) => { count = Number(row.c); });
   return { count };
-}
-
-/**
- * SQL_EXEC and SQL_QUERY are migration escape hatches — kept isolated here.
- * WARNING: They accept raw SQL strings. Use ONLY for schema migrations
- * (MigrationEngine). Never expose to user input.
- */
-export async function handleSqlExec(
-  ctx: HandlerContext,
-  sql: string,
-  params: SqliteValue[],
-): Promise<{ changes: number }> {
-  await ctx.engine.exec(sql, params);
-  return { changes: 0 };
-}
-
-export async function handleSqlQuery(
-  ctx: HandlerContext,
-  sql: string,
-  params: SqliteValue[],
-): Promise<{ rows: SqliteRow[] }> {
-  const rows = await ctx.engine.query(sql, params);
-  return { rows };
 }


### PR DESCRIPTION
## 概要

archived PBI の DoD 乖離監査（2026-09-01、`autonomous-task-closer`）で見つかった **表記のみの乖離 2 件** を解消する。いずれも実害はないが、archived PBI の受け入れ基準と実コードの食い違いを残さないための掃除。

## 変更

### 1. `2026-08-27-06-fix-opfs-worker-sql-exec` — デッドコード削除

`opfsWorker/statusHandlers.ts` の `handleSqlExec` / `handleSqlQuery` を削除。`WORKER_MESSAGE_TYPES` からは削除済みで `src/` から一切 import されない到達不能なデッドコードだった（生 SQL 注入経路は既に断たれている）。未使用になった `SqliteValue` / `SqliteRow` import も削除。

### 2. `2026-08-27-10-fix-page-state-duplicate` — キーワード SSOT ドリフト解消

`dashboard/settings/contentSettings.ts` の `DEFAULT_KEYWORDS` ハードコード（17語）を `contentCleaner.DEFAULT_KEYWORDS`（約52語）の import に置換。strip ロジックは全 52 語を使うため、**設定 UI のデフォルト表示・リセットだけが古い前半サブセットにドリフト**していた。ユーザーに見える挙動変更（設定画面のデフォルトキーワードが広がる = 正しい挙動への修正）。テスト期待値も共有定数参照に更新。

各 archived PBI に実装メモを追記。CHANGELOG の Fixed に 2 項目追加。

## 検証

- `npm run type-check` / `npm run lint` green
- `npx vitest run`: 11116 passed
- `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)