### PR TITLE
fix(dashboard): B レイアウトの provider 設定破損 + 保存時の空値上書きガード

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - **B レイアウト（分離型）の AI プロバイダー設定が壊れていた不具合を修正**。06c の catalog 駆動化で B レイアウトのアコーディオンが自前の `#<id>Settings` ブロックを持つようになった一方、mount 時に A レイアウトの `#providerSettingsMount` も同じ id で構築・値読込していたため、保存済みの `openai_base_url` / `openai_api_key` / `openai_model` が優先度コンテナ側に流れ込み、アコーディオン内は空プレースホルダのまま、AI テストも失敗していた。B モードでは `#providerSettingsMount` を構築せず、アコーディオン生成後に `loadSettingsToInputs` で値を流し込むよう修正。A↔B トグル時の再構築も対応
+- **保存時に AI プロバイダーの接続設定（Base URL / モデル名 / API キー）が空値で上書きされない保護を追加**。上記の表示バグのように何らかの理由でフォームの入力欄が空のまま「保存する」を押しても、`_base_url` / `_model` / `_api_key` で終わるキーは保存済みの値が非空なら空文字で潰さないよう `settingsPipeline` にガードを入れた（API キーは従来から保護済み、Base URL / モデル名を追加）
 - コンテンツクレンジングのキーワード設定 UI が既定/リセット時に表示するキーワードを、実際の strip ロジックが使う全リスト（約52語）に合わせた。従来は古い17語のサブセットがハードコードされており、`contentCleaner.DEFAULT_KEYWORDS` からドリフトしていた（archived PBI 2026-08-27-10 の効果確認で発見）
 - archived PBI 2026-08-27-06 の掃除: `opfsWorker/statusHandlers.ts` の到達不能なデッドコード `handleSqlExec` / `handleSqlQuery`（メッセージ型からは削除済みだが export だけ残存）を削除
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **B レイアウト（分離型）の AI プロバイダー設定が壊れていた不具合を修正**。06c の catalog 駆動化で B レイアウトのアコーディオンが自前の `#<id>Settings` ブロックを持つようになった一方、mount 時に A レイアウトの `#providerSettingsMount` も同じ id で構築・値読込していたため、保存済みの `openai_base_url` / `openai_api_key` / `openai_model` が優先度コンテナ側に流れ込み、アコーディオン内は空プレースホルダのまま、AI テストも失敗していた。B モードでは `#providerSettingsMount` を構築せず、アコーディオン生成後に `loadSettingsToInputs` で値を流し込むよう修正。A↔B トグル時の再構築も対応
 - コンテンツクレンジングのキーワード設定 UI が既定/リセット時に表示するキーワードを、実際の strip ロジックが使う全リスト（約52語）に合わせた。従来は古い17語のサブセットがハードコードされており、`contentCleaner.DEFAULT_KEYWORDS` からドリフトしていた（archived PBI 2026-08-27-10 の効果確認で発見）
 - archived PBI 2026-08-27-06 の掃除: `opfsWorker/statusHandlers.ts` の到達不能なデッドコード `handleSqlExec` / `handleSqlQuery`（メッセージ型からは削除済みだが export だけ残存）を削除
 

--- a/src/dashboard/__tests__/settingsPipeline.test.ts
+++ b/src/dashboard/__tests__/settingsPipeline.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../utils/storage/domainFilterCache.js', async (importOriginal) => {
 vi.mock('../../utils/settingsFormBinding.js', () => ({
   extractSettingsFromInputs: vi.fn(),
   extractLocalMarkdownExportTiming: vi.fn(),
+  isProviderConnectionField: (key: string) => /_(base_url|model|api_key)$/i.test(key),
 }));
 
 vi.mock('../../utils/settingsSchemas.js', () => ({
@@ -129,6 +130,36 @@ describe('saveDashboardSettings', () => {
         content_max_records: 500,
       }),
     );
+  });
+
+  it('does not blank a stored provider connection field with an empty extracted value', async () => {
+    setupInputs('https');
+    mockGetSettings.mockResolvedValue({
+      openai_base_url: 'https://api.ai.sakura.ad.jp/v1',
+      openai_model: 'preview/gemma-4-31B-it',
+      openai_api_key: { iv: 'x', ciphertext: 'y' },
+      openai_2_base_url: '',
+    });
+    // A broken form yields empty strings for provider fields.
+    mockExtract.mockReturnValue({
+      openai_base_url: '',
+      openai_model: '',
+      openai_api_key: '',
+      openai_2_base_url: '',
+      openai_2_model: 'llama-3',
+    });
+
+    await saveDashboardSettings();
+
+    const saved = mockSaveSettings.mock.calls[0][0] as Record<string, unknown>;
+    // Stored non-empty values are preserved
+    expect(saved.openai_base_url).toBe('https://api.ai.sakura.ad.jp/v1');
+    expect(saved.openai_model).toBe('preview/gemma-4-31B-it');
+    expect(saved.openai_api_key).toEqual({ iv: 'x', ciphertext: 'y' });
+    // A genuinely new non-empty value is still written
+    expect(saved.openai_2_model).toBe('llama-3');
+    // Empty over empty is harmless
+    expect(saved.openai_2_base_url).toBe('');
   });
 
   it('calls onSuccess callback when provided', async () => {

--- a/src/dashboard/panels/staticForm/__tests__/generalSettingsPanel-bLayout.test.ts
+++ b/src/dashboard/panels/staticForm/__tests__/generalSettingsPanel-bLayout.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+/**
+ * generalSettingsPanel-bLayout.test.ts
+ * Regression for the B-layout provider-settings bug (2026-09-02):
+ * with AI_PROVIDER_LAYOUT='b', mount() built the A #providerSettingsMount blocks
+ * AND the B accordion — duplicate #<id>Settings ids. loadSettingsToInputs then
+ * populated the A blocks (which updateProviderSettingsLayout un-hid and moved
+ * into the priority containers), while the accordion showed empty placeholders.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createGeneralSettingsPanel } from '../generalSettingsPanel.js';
+
+const AI_SECTION = `
+  <section id="panel-general" class="panel active">
+    <div id="aiProviderSection" class="settings-section">
+      <h3 class="settings-section-title">AI Provider</h3>
+      <div id="bPrioritySection" hidden>
+        <div id="bPriorityList"></div>
+        <div id="bProviderAccordion"></div>
+      </div>
+      <details class="priority-details" open>
+        <div class="priority-details-content">
+          <select id="aiProvider" data-storage-key="ai_provider"></select>
+          <div id="priority1ProviderSettings"></div>
+          <input type="text" id="aiProviderPriority1Model">
+        </div>
+      </details>
+      <details class="priority-details">
+        <div class="priority-details-content">
+          <select id="aiProviderPriority2"></select>
+          <div id="priority2ProviderSettings"></div>
+          <input type="text" id="aiProviderPriority2Model">
+        </div>
+      </details>
+      <details class="priority-details">
+        <div class="priority-details-content">
+          <select id="aiProviderPriority3"></select>
+          <div id="priority3ProviderSettings"></div>
+          <input type="text" id="aiProviderPriority3Model">
+        </div>
+      </details>
+      <div id="providerSettingsMount"></div>
+    </div>
+  </section>`;
+
+async function seedSettings(extra: Record<string, unknown>): Promise<void> {
+  await chrome.storage.local.clear();
+  await chrome.storage.session.clear();
+  await chrome.storage.local.set({
+    settings: {
+      ai_provider: 'openai',
+      ai_provider_priority_list: [{ provider: 'openai' }],
+      openai_base_url: 'https://api.ai.sakura.ad.jp/v1',
+      openai_api_key: 'sk-secret',
+      openai_model: 'preview/gemma-4-31B-it',
+      ...extra,
+    },
+    settings_migrated: true,
+  });
+}
+
+describe('generalSettingsPanel — B layout provider settings', () => {
+  beforeEach(() => {
+    document.body.innerHTML = AI_SECTION;
+  });
+
+  it('B layout: openai_* values land in the accordion, not the priority container', async () => {
+    await seedSettings({ ai_provider_layout: 'b' });
+
+    const panel = createGeneralSettingsPanel();
+    await panel.mount(document.getElementById('panel-general')!);
+
+    // Exactly one #openaiSettings, inside the accordion
+    const openaiBlocks = document.querySelectorAll('#openaiSettings');
+    expect(openaiBlocks.length).toBe(1);
+    expect(document.getElementById('bProviderAccordion')?.contains(openaiBlocks[0])).toBe(true);
+
+    // A mount stays empty in B
+    expect(document.getElementById('providerSettingsMount')?.children.length).toBe(0);
+    // Priority container not populated with a provider block
+    expect(document.getElementById('priority1ProviderSettings')?.querySelector('#openaiSettings')).toBeNull();
+
+    // Accordion fields carry the saved values
+    const baseUrl = document.querySelector('#openaiSettings input[data-storage-key="openai_base_url"]') as HTMLInputElement;
+    const model = document.querySelector('#openaiSettings input[data-storage-key="openai_model"]') as HTMLInputElement;
+    expect(baseUrl.value).toBe('https://api.ai.sakura.ad.jp/v1');
+    expect(model.value).toBe('preview/gemma-4-31B-it');
+  });
+
+  it('A layout: #providerSettingsMount is built and populated', async () => {
+    await seedSettings({ ai_provider_layout: 'a' });
+
+    const panel = createGeneralSettingsPanel();
+    await panel.mount(document.getElementById('panel-general')!);
+
+    const mount = document.getElementById('providerSettingsMount')!;
+    expect(mount.children.length).toBeGreaterThan(0);
+    // openaiSettings gets moved into priority1 by updateProviderSettingsLayout
+    const openai = document.getElementById('openaiSettings');
+    expect(openai).not.toBeNull();
+    const baseUrl = openai!.querySelector('input[data-storage-key="openai_base_url"]') as HTMLInputElement;
+    expect(baseUrl.value).toBe('https://api.ai.sakura.ad.jp/v1');
+  });
+});

--- a/src/dashboard/panels/staticForm/generalSettingsPanel.ts
+++ b/src/dashboard/panels/staticForm/generalSettingsPanel.ts
@@ -53,16 +53,25 @@ export function createGeneralSettingsPanel(): PanelLifecycle & { refresh?: () =>
       panelContainer = container;
       const settings = await settingsRepository.getAll();
 
-      // A layout: build the provider <option> lists and per-provider settings
-      // blocks from the catalog before any value binding runs.
+      const layoutRepo = new SettingsRepository(new ChromeStoragePort());
+      let currentLayout = await resolveInitialLayout(layoutRepo) as 'a' | 'b';
+
+      // Provider <option> lists are shared by both layouts.
       const providerSelect = container.querySelector('#aiProvider') as HTMLSelectElement | null;
       if (providerSelect) renderProviderOptions(providerSelect);
       for (const priorityId of ['aiProviderPriority2', 'aiProviderPriority3']) {
         const sel = container.querySelector(`#${priorityId}`) as HTMLSelectElement | null;
         if (sel) renderProviderOptions(sel, { includeNone: true });
       }
+
       const providerMount = container.querySelector('#providerSettingsMount') as HTMLElement | null;
-      if (providerMount) {
+      // Build the A-layout per-provider settings blocks (#<id>Settings) into
+      // #providerSettingsMount. In B layout the accordion owns its own blocks
+      // with the same ids, so building these here too would create duplicate
+      // ids — the A block wins every querySelector and B never gets its values.
+      // rebuildProviderSettingsMount() is also called on an A<-B toggle.
+      const rebuildProviderSettingsMount = (): void => {
+        if (!providerMount) return;
         providerMount.textContent = '';
         for (const id of providerIdsInOrder()) {
           const block = document.createElement('div');
@@ -70,7 +79,8 @@ export function createGeneralSettingsPanel(): PanelLifecycle & { refresh?: () =>
           renderProviderSettings(block, id);
           providerMount.appendChild(block);
         }
-      }
+      };
+      if (currentLayout === 'a') rebuildProviderSettingsMount();
 
       loadSettingsToInputs(container, settings, GENERAL_SETTINGS_SCHEMA);
       await loadGeneralSettings();
@@ -108,6 +118,8 @@ export function createGeneralSettingsPanel(): PanelLifecycle & { refresh?: () =>
       }
 
       const refreshMultiVisibility = (): void => {
+        // A-layout only: B owns its accordion DOM and never reparents #*Settings.
+        if (currentLayout === 'b') return;
         const aiProviderSelect = document.getElementById('aiProvider') as HTMLSelectElement | null;
         const aiProviderPriority2Select = document.getElementById('aiProviderPriority2') as HTMLSelectElement | null;
         const aiProviderPriority3Select = document.getElementById('aiProviderPriority3') as HTMLSelectElement | null;
@@ -138,8 +150,6 @@ export function createGeneralSettingsPanel(): PanelLifecycle & { refresh?: () =>
       document.getElementById('aiProviderPriority2')?.addEventListener('change', refreshMultiVisibility);
       document.getElementById('aiProviderPriority3')?.addEventListener('change', refreshMultiVisibility);
 
-      const layoutRepo = new SettingsRepository(new ChromeStoragePort());
-      let currentLayout = await resolveInitialLayout(layoutRepo) as 'a' | 'b';
       let bPriorityView: ReturnType<typeof createBPriorityListView> | null = null;
       let bAccordionView: ReturnType<typeof createBProviderAccordionView> | null = null;
 
@@ -153,6 +163,10 @@ export function createGeneralSettingsPanel(): PanelLifecycle & { refresh?: () =>
         if (isB) {
           // Aの移動を戻してからBを構築（hideAllはBでは不要 — アコーディオン側で可視化するため）
           restoreOriginalProviderSettingsLayout();
+          // In B, the accordion owns the #<id>Settings blocks; the A mount must
+          // not carry duplicates or its (loaded) fields leak into the priority
+          // containers and the accordion shows empty placeholders.
+          if (providerMount) providerMount.textContent = '';
           const bListContainer = container.querySelector('#bPriorityList') as HTMLElement | null;
           const bAccordionContainer = container.querySelector('#bProviderAccordion') as HTMLElement | null;
           if (bListContainer && !bPriorityView) {
@@ -172,12 +186,17 @@ export function createGeneralSettingsPanel(): PanelLifecycle & { refresh?: () =>
           }
           if (bAccordionContainer && !bAccordionView) {
             bAccordionView = createBProviderAccordionView(bAccordionContainer);
+            // The accordion's inputs were just created empty — populate them.
+            loadSettingsToInputs(bAccordionContainer, settings, GENERAL_SETTINGS_SCHEMA);
           }
         } else {
           bPriorityView?.container?.querySelectorAll('.b-priority-warn, .b-priority-req-warn').forEach((el) => el.remove());
           bAccordionView?.destroy();
           bPriorityView = null;
           bAccordionView = null;
+          // Rebuild the A mount (empty in B) and reload its values.
+          rebuildProviderSettingsMount();
+          loadSettingsToInputs(container, settings, GENERAL_SETTINGS_SCHEMA);
           hideAllProviderSettings();
           refreshMultiVisibility();
         }

--- a/src/dashboard/settingsPipeline.ts
+++ b/src/dashboard/settingsPipeline.ts
@@ -9,12 +9,13 @@
 import { settingsRepository } from '../utils/storage/SettingsRepository.js';
 import { StorageKeys } from '../utils/storage/types.js';
 import { updateDomainFilterCache } from '../utils/storage/domainFilterCache.js';
-import { extractSettingsFromInputs, extractLocalMarkdownExportTiming, type ValidationSchema } from '../utils/settingsFormBinding.js';
+import { extractSettingsFromInputs, extractLocalMarkdownExportTiming, isProviderConnectionField, type ValidationSchema } from '../utils/settingsFormBinding.js';
 import { GENERAL_SETTINGS_SCHEMA } from '../utils/settingsSchemas.js';
 import { collectProviderPrioritySlots } from './generalSettings/settingsForm.js';
 import { collectBProviderPrioritySlots, validateBContainer } from './aiProviderB/priorityListView.js';
 import { clearAllFieldErrors, validateAllFields, validateObsidianHost, validateGeminiApiVersion, ErrorPair } from './settings/fieldValidation.js';
 import { getMessage } from '../utils/i18n.js';
+import { logInfo } from '../utils/logger.js';
 import { showConfirmDialog } from './utils/confirmDialog.js';
 import { syncStatusToTop } from './statusView.js';
 
@@ -197,6 +198,28 @@ export async function saveDashboardSettings(options: SaveSettingsOptions = {}): 
     contentMaxRaw === '' || contentMaxRaw === undefined ? null : Number(contentMaxRaw);
 
   const currentSettings = await settingsRepository.getAll();
+
+  // Guard: never blank a stored provider connection field (base URL / model /
+  // API key) with an empty extracted value. An empty input on save means the
+  // field was not populated (a UI-desync bug — e.g. the B-layout accordion
+  // regression), not an intentional clear. Without this, "Save" wiped
+  // openai_base_url / openai_model for users who opened a broken form.
+  for (const key of Object.keys(newSettings)) {
+    if (!isProviderConnectionField(key)) continue;
+    const next = newSettings[key];
+    const cur = (currentSettings as Record<string, unknown>)[key];
+    const nextEmpty = next === '' || next === undefined || next === null;
+    const curPresent = cur !== '' && cur !== undefined && cur !== null;
+    if (nextEmpty && curPresent) {
+      delete newSettings[key];
+      logInfo(
+        'settingsPipeline',
+        { key },
+        'Skipped overwriting a stored provider connection field with an empty value',
+      );
+    }
+  }
+
   const mergedSettings = { ...currentSettings, ...newSettings };
 
   await settingsRepository.setAll(mergedSettings);

--- a/src/utils/settingsFormBinding.ts
+++ b/src/utils/settingsFormBinding.ts
@@ -59,6 +59,19 @@ function isApiKeyField(key: string): boolean {
   return API_KEY_PATTERN.test(key);
 }
 
+/**
+ * Provider connection fields (base URL / model / API key). An empty value in
+ * one of these on save almost always means "the input was never populated"
+ * (a UI-desync bug), not "the user wants it blank" — these keys have working
+ * defaults and are set once. Callers must NOT overwrite a non-empty stored
+ * value with an empty extracted one for these keys. Guarded at the save
+ * orchestration layer where the current stored value is available.
+ */
+const PROVIDER_CONNECTION_FIELD_PATTERN = /_(base_url|model|api_key)$/i;
+export function isProviderConnectionField(key: string): boolean {
+  return PROVIDER_CONNECTION_FIELD_PATTERN.test(key);
+}
+
 function isMaskedValue(value: string): boolean {
   return value === '' || MASKED_PLACEHOLDER_PATTERN.test(value);
 }

--- a/tests/dashboard/aiProviderB/accordionValueBinding.test.ts
+++ b/tests/dashboard/aiProviderB/accordionValueBinding.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+/**
+ * accordionValueBinding.test.ts
+ * Regression for the B-layout bug where the "OpenAI互換 (Groq)" accordion body
+ * showed empty placeholders while the saved openai_* values leaked into the A
+ * layout's priority containers. The accordion owns its own #<id>Settings blocks;
+ * loadSettingsToInputs must populate THOSE, and there must be no duplicate ids.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createBProviderAccordionView } from '../../../src/dashboard/aiProviderB/providerAccordionView.js';
+import { loadSettingsToInputs } from '../../../src/utils/settingsFormBinding.js';
+import { GENERAL_SETTINGS_SCHEMA } from '../../../src/utils/settingsSchemas.js';
+
+function panel(): HTMLElement {
+  document.body.innerHTML = `
+    <section id="panel-general">
+      <div id="providerSettingsMount"></div>
+      <div id="bProviderAccordion"></div>
+    </section>`;
+  return document.getElementById('panel-general') as HTMLElement;
+}
+
+const SETTINGS = {
+  openai_base_url: 'https://api.ai.sakura.ad.jp/v1',
+  openai_api_key: 'sk-secret',
+  openai_model: 'preview/gemma-4-31B-it',
+  gemini_model: 'gemini-3.1-flash-lite',
+};
+
+describe('B accordion value binding', () => {
+  beforeEach(() => { panel(); });
+
+  it('loads openai_* values into the accordion body, not empty placeholders', () => {
+    const accordion = document.getElementById('bProviderAccordion') as HTMLElement;
+    createBProviderAccordionView(accordion);
+    loadSettingsToInputs(accordion, SETTINGS, GENERAL_SETTINGS_SCHEMA);
+
+    const baseUrl = accordion.querySelector('#openaiSettings input[data-storage-key="openai_base_url"]') as HTMLInputElement;
+    const model = accordion.querySelector('#openaiSettings input[data-storage-key="openai_model"]') as HTMLInputElement;
+    const apiKey = accordion.querySelector('#openaiSettings input[data-storage-key="openai_api_key"]') as HTMLInputElement;
+
+    expect(baseUrl.value).toBe('https://api.ai.sakura.ad.jp/v1');
+    expect(model.value).toBe('preview/gemma-4-31B-it');
+    // password field: value cleared, "(Already set)" placeholder
+    expect(apiKey.value).toBe('');
+    expect(apiKey.placeholder).toContain('Already set');
+  });
+
+  it('does not create #openaiSettings twice (A mount stays empty in B)', () => {
+    const accordion = document.getElementById('bProviderAccordion') as HTMLElement;
+    createBProviderAccordionView(accordion);
+    // The panel is responsible for keeping #providerSettingsMount empty in B;
+    // assert the accordion is the only owner of the id.
+    expect(document.querySelectorAll('#openaiSettings').length).toBe(1);
+    expect(document.getElementById('providerSettingsMount')?.children.length).toBe(0);
+  });
+
+  it('openai-compatible (models-dev) body keeps its own provider_* fields separate from openai_*', () => {
+    const accordion = document.getElementById('bProviderAccordion') as HTMLElement;
+    createBProviderAccordionView(accordion);
+    loadSettingsToInputs(accordion, SETTINGS, GENERAL_SETTINGS_SCHEMA);
+
+    // The Sakura URL belongs to openai_base_url, NOT provider_base_url.
+    const modelsDevBaseUrl = accordion.querySelector('#openai-compatibleSettings input[data-storage-key="provider_base_url"]') as HTMLInputElement;
+    expect(modelsDevBaseUrl.value).toBe('');
+  });
+});


### PR DESCRIPTION
## 概要

ユーザー報告のバグ 2 件の修正（#108 の再作成 — base の `chore/release-6.7.99` が #107 でマージ・削除されたため）。

### 症状（報告）
- B レイアウト（分離型、新規ユーザーの既定）で「OpenAI互換 (Groq, etc.)」アコーディオンを開くと Base URL / API Key / モデル名が空プレースホルダ
- 保存済みの値（Sakura Cloud URL、`preview/gemma-4-31B-it`）が優先度コンテナ側に表示される
- AI テストが 401
- **壊れた画面で「保存する」を押すと `openai_base_url` / `openai_model` が空文字で上書き保存され、再設定を強いられる**（実際に発生）

## 修正 1: B レイアウト表示バグ

06c で B アコーディオンが catalog から自前の `#<id>Settings` を構築する一方、`generalSettingsPanel.mount()` が B モードでも A の `#providerSettingsMount` を同じ id で構築・値読込 → DOM 重複 id。`querySelector` は先に構築された A ブロックにヒットし `updateProviderSettingsLayout` がそれを可視化・移動。

修正: A モードのみ `#providerSettingsMount` を構築。B モードはアコーディオン生成後に `loadSettingsToInputs(bAccordionContainer, ...)`。`refreshMultiVisibility` は B で no-op。A↔B トグル時は該当側を再構築。

## 修正 2: 保存時の空値上書きガード（再発防止の本命）

- `settingsFormBinding.isProviderConnectionField()` — `_base_url` / `_model` / `_api_key` で終わるキー
- `settingsPipeline`: merge 前に、extract 値が空かつ保存済み値が非空の provider 接続キーを除外。API キーは従来から保護済み、Base URL / モデル名を追加

## テスト

- `generalSettingsPanel-bLayout.test.ts`（新規、実 DOM + seeded storage）— fix なしで fail 確認済み
- `accordionValueBinding.test.ts`（新規）
- `settingsPipeline.test.ts`（拡張）— 壊れたフォームで保存しても値が残ることを検証、ガードなしで fail 確認済み
- type-check / lint / build green、vitest 11122 passed、e2e 全 pass

## リリース

6.7.99（#107 マージ済み）の追加修正。この回帰は 6.7.98 リリース後（06c マージ後）に main へ入ったもので、まだリリース版には配布されていない。本 PR をマージしてから 6.7.99 をタグ付け・リリースすれば被害ユーザーはゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)