### PR TITLE
fix(security): VULN-001 — bare ".." daily-path traversal to Obsidian REST URL

### DIFF
--- a/src/utils/__tests__/dailyNotePathBuilder-security.test.ts
+++ b/src/utils/__tests__/dailyNotePathBuilder-security.test.ts
@@ -6,7 +6,7 @@
  * 修正後: 無効なパス入力はエラーをスローする
  */
 
-import { buildDailyNotePath } from '../dailyNotePathBuilder.js';
+import { buildDailyNotePath, sanitizePathComponent } from '../dailyNotePathBuilder.js';
 
 describe('buildDailyNotePath - セキュリティテスト（パートラバーサル対策済み）', () => {
   const testDate = new Date('2026-02-07');
@@ -199,6 +199,36 @@ describe('buildDailyNotePath - セキュリティテスト（パートラバー�
       const result = buildDailyNotePath('my folder/YYYY-MM-DD', testDate);
       expect(result).toBe('my folder/2026-02-07');
     });
+  });
+});
+
+describe('VULN-001: bare dot segments must be rejected (path traversal)', () => {
+  it('rejects bare `..` as a path component', () => {
+    // VULN-001 PoC payload: settings value `..` (no trailing separator).
+    expect(() => sanitizePathComponent('..')).toThrow();
+  });
+
+  it('rejects bare `.` as a path component', () => {
+    expect(() => sanitizePathComponent('.')).toThrow();
+  });
+
+  it('rejects dot segments padded with whitespace', () => {
+    expect(() => sanitizePathComponent(' .. ')).toThrow();
+  });
+
+  it('never produces a URL that escapes /vault/ via dot-segment normalization', () => {
+    let dailyPath: string;
+    try {
+      dailyPath = buildDailyNotePath('..');
+    } catch {
+      return; // thrown at the boundary = secure
+    }
+    const normalized = new URL(`https://127.0.0.1:27124/vault/${dailyPath}/2026-09-10.md`).toString();
+    expect(normalized.includes('/vault/')).toBe(true);
+  });
+
+  it('still accepts legitimate path components', () => {
+    expect(sanitizePathComponent('Daily Notes')).toBe('Daily Notes');
   });
 });
 

--- a/src/utils/dailyNotePathBuilder.ts
+++ b/src/utils/dailyNotePathBuilder.ts
@@ -25,6 +25,18 @@ export function sanitizePathComponent(component: string): string {
         return component;
     }
 
+    // Bare dot segments (`.` / `..`) are rejected as exact components:
+    // the URL sink (ENDPOINTS.dailyNote in obsidianClient.ts) normalizes
+    // dot-segments, so `..` alone escapes /vault/ even though the
+    // separator-anchored forms below are already blocked (VULN-001).
+    // Bare dot segments (`.` / `..`) must be rejected as exact components:
+    // the URL sink (ENDPOINTS.dailyNote in obsidianClient.ts) normalizes
+    // dot-segments, so `..` alone escapes /vault/ even though the
+    // separator-anchored forms below are already blocked (VULN-001).
+    if (component.trim() === '.' || component.trim() === '..') {
+        throw new Error('Invalid path component: dot segment detected');
+    }
+
     // 親ディレクトリ参照（../, ./）をブロック
     if (/\.\.?\//u.test(component) || /\.\.[\\/]/u.test(component)) {
         throw new Error('Invalid path component: path traversal detected');


### PR DESCRIPTION
## Security Fix: VULN-001 — Bare-`..` daily-path traversal to Obsidian REST URL (second-order)

<!-- vulnfix-key: 4e12c77ce4dd7c9d -->
<!-- vulnhunt-finding-id: VULN-001 -->
<!-- vulnhunt-results-dir: obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418 -->

Addresses VULN-001 per `/Users/yaar/Playground/obsidian-smart-history/obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418` (no source issues published on origin at scan time).

## Finding Summary

| VULN | CWE | Severity | Location | Source issue |
|------|-----|----------|----------|--------------|
| VULN-001 | CWE-22 | Low | `src/utils/dailyNotePathBuilder.ts:sanitizePathComponent -> src/background/obsidianClient.ts:134` | — (local scan) |

## Attacker Capability

A settings writer (extension-page XSS or local access) sets OBSIDIAN_DAILY_PATH = ".."; the Obsidian REST URL sink normalizes dot-segments so the PUT escapes /vault/ on the user's server.

## Security Test

src/utils/__tests__/dailyNotePathBuilder-security.test.ts (describe "VULN-001: bare dot segments must be rejected (path traversal)") — RED pre-fix (4 failed | 1 passed), GREEN post-fix (5 passed); exploit demo throw-confirmed, deleted pre-commit.

The committed test failed against pre-fix code and passes against this fix
(discrimination evidence: stash-and-run, recorded in
`.vulnhunter-fix/discrimination/VULN-001.json`).

## Fix Description

#### VULN-001 — Bare-`..` daily-path traversal to Obsidian REST URL (second-order)

sanitizePathComponent now rejects whole dot-segment components (`.` / `..`, after trimming) before the separator-anchored checks; the URL can never carry a trailing dot-segment to normalize away.

## Verification Results

| State | Security tests | Regression suite |
|-------|---------------|-----------------|
| Before fix | FAIL — the security test was RED against the vulnerable code | PASS |
| After fix | PASS — test GREEN | PASS — no regressions (full suite) |

## Verification Table

| # | VULN-NNN | Stated vector closed? | Test exercises real attack? | Default fail-closed? | Residual risk documented? | All call sites covered? | Sweep complete? | Verdict |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | VULN-001 | yes (src/utils/dailyNotePathBuilder.ts:37) | yes (src/utils/__tests__/dailyNotePathBuilder-security.test.ts:206) | yes (src/utils/dailyNotePathBuilder.ts:37) | yes (src/utils/dailyNotePathBuilder.ts:32) | yes (src/utils/dailyNotePathBuilder.ts:buildDailyNotePath) | yes (n/a) (src/utils/dailyNotePathBuilder.ts:32) | FULL |

## Residual Risk

None in the stated vector; tier bounded by plan/verify evidence rules (sink signature unchanged). See state/VULN-001/result.json residual_vectors.

## Sweep Summary

| VULN | Root cause | Pattern | Found | Captured | Mitigated | Remaining |
|------|-----------|---------|-------|----------|-----------|-----------|
| VULN-001 | see report | root-cause sweep (AST graph) | 0 | 0 | 0 | 0 |

## Breaking Change

None — no interface/signature changes; callers unchanged.

## Setup Required (Draft PR)

None — non-breaking at the code level; takes effect on merge.

---

Finding: VULN-001
VulnHunter-Run: obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418
Co-Authored-By: Claude Code (VulnFix)
