### PR TITLE
fix(security): VULN-003 — null-prototype accumulator in log sanitizer

### DIFF
--- a/src/utils/logger/__tests__/sanitize.test.ts
+++ b/src/utils/logger/__tests__/sanitize.test.ts
@@ -1,0 +1,45 @@
+// Transient RED→GREEN scaffold for VULN-003.
+// Final committed name: src/utils/logger/__tests__/sanitize.test.ts
+import { describe, expect, it } from 'vitest';
+import { sanitizeLogDetails, sanitizeArray } from '../sanitize.js';
+
+// The scan's exact PoC payload: JSON.parse yields an OWN `__proto__` property
+// that the keyed assignment inside sanitizeLogDetails would re-point.
+function attackDetails(): Record<string, unknown> {
+  return JSON.parse('{"__proto__": {"polluted": "pwned"}}');
+}
+
+describe('VULN-003: log-details sanitizer must not honor __proto__ keys', () => {
+  it('never re-points the prototype of the sanitized entry', async () => {
+    const out = await sanitizeLogDetails(attackDetails());
+    const proto = Object.getPrototypeOf(out);
+    expect(proto === Object.prototype || proto === null).toBe(true);
+    expect((out as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('preserves the __proto__ data as a harmless own property', async () => {
+    const out = await sanitizeLogDetails(attackDetails()) as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(out, '__proto__')).toBe(true);
+  });
+
+  it('is safe for nested object recursion', async () => {
+    const details = JSON.parse('{"outer": {"__proto__": {"deep": true}}}');
+    const out = (await sanitizeLogDetails(details)) as Record<string, unknown>;
+    const nested = out.outer as Record<string, unknown>;
+    expect(Object.getPrototypeOf(nested) === Object.prototype || Object.getPrototypeOf(nested) === null).toBe(true);
+    expect(nested.deep).toBeUndefined();
+  });
+
+  it('is safe for the array variant path', async () => {
+    const arr = await sanitizeArray([JSON.parse('{"__proto__": {"viaArray": 1}}')]);
+    const first = arr[0] as Record<string, unknown>;
+    expect(Object.getPrototypeOf(first) === Object.prototype || Object.getPrototypeOf(first) === null).toBe(true);
+    expect(first.viaArray).toBeUndefined();
+  });
+
+  it('still sanitizes ordinary details', async () => {
+    const out = await sanitizeLogDetails({ user: 'bob', count: 3 });
+    expect(out.user).toBe('bob');
+    expect(out.count).toBe(3);
+  });
+});

--- a/src/utils/logger/sanitize.ts
+++ b/src/utils/logger/sanitize.ts
@@ -55,7 +55,12 @@ async function sanitizeLogDetails(
     visitedObjects.add(details);
   }
 
-  const sanitized: Record<string, unknown> = {};
+  // Null-prototype accumulator (VULN-003): keyed assignment on a plain `{}`
+  // invokes the __proto__ setter for attacker-controlled keys (LOG_FORWARD
+  // details). A dictionary-prototype object has no such setter, so every
+  // `sanitized[key] = ...` below is a plain own-property write and the
+  // returned entry's prototype can never be re-pointed.
+  const sanitized = Object.create(null) as Record<string, unknown>;
 
   for (const [key, value] of Object.entries(details)) {
     if (value === null || value === undefined) {


### PR DESCRIPTION
## Security Fix: VULN-003 — Log-details __proto__ key assignment (per-entry prototype manipulation, reduced scope)

<!-- vulnfix-key: 6b3bad38f08d92ce -->
<!-- vulnhunt-finding-id: VULN-003 -->
<!-- vulnhunt-results-dir: obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418 -->

Addresses VULN-003 per `/Users/yaar/Playground/obsidian-smart-history/obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418` (no source issues published on origin at scan time).

## Finding Summary

| VULN | CWE | Severity | Location | Source issue |
|------|-----|----------|----------|--------------|
| VULN-003 | CWE-1321 | Low | `src/utils/logger/sanitize.ts:sanitizeLogDetails` | — (local scan) |

## Attacker Capability

An extension-page context (XSS) sends LOG_FORWARD with details = {"__proto__": {...}} (own key via JSON.parse); the keyed assignment re-pointed the returned log entry's prototype.

## Security Test

src/utils/logger/__tests__/sanitize.test.ts — RED pre-fix (4 failed | 1 passed), GREEN post-fix (5 passed).

The committed test failed against pre-fix code and passes against this fix
(discrimination evidence: stash-and-run, recorded in
`.vulnhunter-fix/discrimination/VULN-003.json`).

## Fix Description

#### VULN-003 — Log-details `__proto__` key assignment (per-entry prototype manipulation, reduced scope)

sanitizeLogDetails builds its accumulator with Object.create(null): no __proto__ setter exists, so every keyed assignment is a plain own-property write and the entry prototype can never be re-pointed.

## Verification Results

| State | Security tests | Regression suite |
|-------|---------------|-----------------|
| Before fix | FAIL — the security test was RED against the vulnerable code | PASS |
| After fix | PASS — test GREEN | PASS — no regressions (full suite) |

## Verification Table

| # | VULN-NNN | Stated vector closed? | Test exercises real attack? | Default fail-closed? | Residual risk documented? | All call sites covered? | Sweep complete? | Verdict |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | VULN-003 | yes (src/utils/logger/sanitize.ts:63) | yes (src/utils/logger/__tests__/sanitize.test.ts:13) | yes (src/utils/logger/sanitize.ts:63) | yes (src/utils/logger/sanitize.ts:58) | yes (src/utils/logger/core.ts:addLog) (src/utils/logger/sanitize.ts:sanitizeArray) | yes (n/a) (src/utils/logger/sanitize.ts:58) | FULL |

## Residual Risk

Per-entry scope (self-limited, not realm-wide). Tier MITIGATION per evidence rules.

## Sweep Summary

| VULN | Root cause | Pattern | Found | Captured | Mitigated | Remaining |
|------|-----------|---------|-------|----------|-----------|-----------|
| VULN-003 | see report | root-cause sweep (AST graph) | 0 | 0 | 0 | 0 |

## Breaking Change

None — no interface/signature changes; callers unchanged.

## Setup Required (Draft PR)

None — non-breaking at the code level; takes effect on merge.

---

Finding: VULN-003
VulnHunter-Run: obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418
Co-Authored-By: Claude Code (VulnFix)
