### PR TITLE
fix(security): VULN-004 — bound forwarded-log entry sizes

### DIFF
--- a/src/background/handlers/__tests__/systemHandlers.test.ts
+++ b/src/background/handlers/__tests__/systemHandlers.test.ts
@@ -35,7 +35,7 @@ vi.mock('../../../utils/storage/savedUrlRepository.js', () => ({
 import { validateUrlForFilterImport, fetchWithTimeout } from '../../../utils/fetch.js';
 import { updateSavedUrlEntry } from '../../../utils/storage/savedUrlRepository.js';
 import type { SavedUrlEntry } from '../../../utils/urlEntry.js';
-import { logError } from '../../../utils/logger.js';
+import { logError, logWarn } from '../../../utils/logger.js';
 
 describe('createFetchUrlHandler', () => {
   beforeEach(() => {
@@ -480,5 +480,58 @@ describe('createLogForwardHandler', () => {
 
     await handler({ payload: { level: 'info', message: 'Hello', source: 'offscreen' } } as any, {} as any, sendResponse);
     expect(sendResponse).toHaveBeenCalledWith({ success: true });
+  });
+});
+const MB = 1024 * 1024;
+
+async function forward(payload: {
+  level: 'warn' | 'error' | 'info';
+  message: string;
+  details?: Record<string, unknown>;
+  source: string;
+}) {
+  const handler = createLogForwardHandler();
+  const sendResponse = vi.fn();
+  await handler(
+    { type: 'LOG_FORWARD', protocolVersion: 1, payload } as never,
+    { id: 'chrome-runtime-id' } as unknown as chrome.runtime.MessageSender,
+    sendResponse,
+  );
+  return sendResponse;
+}
+
+describe('VULN-004: LOG_FORWARD enforces per-entry size caps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('truncates an oversized logMessage before the logger pipeline', async () => {
+    await forward({ level: 'error', message: 'A'.repeat(10 * MB), source: 'offscreen' });
+    const logged = vi.mocked(logError).mock.calls[0]?.[0] as string;
+    expect(logged.length).toBeLessThanOrEqual(64 * 1024);
+  });
+
+  it('caps the details key count', async () => {
+    const many: Record<string, unknown> = {};
+    for (let i = 0; i < 500; i++) many[`k${i}`] = i;
+    await forward({ level: 'error', message: 'm', details: many, source: 'offscreen' });
+    const details = vi.mocked(logError).mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(Object.keys(details).length).toBeLessThanOrEqual(65); // 64 cap + _sourceHintUntrusted
+  });
+
+  it('caps the serialized details size', async () => {
+    await forward({
+      level: 'error',
+      message: 'm',
+      details: { blob: 'B'.repeat(4 * MB) },
+      source: 'offscreen',
+    });
+    const details = vi.mocked(logError).mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(JSON.stringify(details)?.length ?? 0).toBeLessThanOrEqual(256 * 1024 + 1024);
+  });
+
+  it('still forwards normal logs verbatim', async () => {
+    await forward({ level: 'warn', message: 'hello', details: { a: 1 }, source: 'offscreen' });
+    expect(vi.mocked(logWarn).mock.calls[0]?.[0]).toBe('hello');
   });
 });

--- a/src/background/handlers/systemHandlers.ts
+++ b/src/background/handlers/systemHandlers.ts
@@ -284,6 +284,13 @@ export function deriveLogSource(sender: chrome.runtime.MessageSender): string {
   }
 }
 
+// Per-entry size bounds for forwarded logs (VULN-004). Count caps in
+// LogBuffer / storageAdapter bound entry COUNT, not per-entry size or CPU;
+// the trust boundary is this handler, so the bounds live here.
+const MAX_LOG_FORWARD_MESSAGE_CHARS = 64 * 1024;
+const MAX_LOG_FORWARD_DETAILS_KEYS = 64;
+const MAX_LOG_FORWARD_SERIALIZED_CHARS = 256 * 1024;
+
 export function createLogForwardHandler() {
   return async (
     message: LogForwardMessage,
@@ -294,20 +301,30 @@ export function createLogForwardHandler() {
     // offscreen document is the expected caller.
     const { level, message: logMessage, details, source } = message.payload;
     const derivedSource = deriveLogSource(sender);
+    const boundedMessage =
+      typeof logMessage === 'string' && logMessage.length > MAX_LOG_FORWARD_MESSAGE_CHARS
+        ? logMessage.slice(0, MAX_LOG_FORWARD_MESSAGE_CHARS)
+        : logMessage;
+    const detailEntries = Object.entries(details ?? {}).slice(0, MAX_LOG_FORWARD_DETAILS_KEYS);
+    const serialized = JSON.stringify(detailEntries) ?? '';
+    const boundedDetails: Record<string, unknown> =
+      serialized.length > MAX_LOG_FORWARD_SERIALIZED_CHARS
+        ? { truncated: true, preview: serialized.slice(0, MAX_LOG_FORWARD_SERIALIZED_CHARS) }
+        : Object.fromEntries(detailEntries);
     // payload.source is an untrusted display hint only; it must not decide
     // attribution. The neutralization boundary in logger/core.ts strips control
     // chars / ANSI / newlines from logMessage and every string in details
     // (VULN-044 co-parameter).
     const enrichedDetails = {
-      ...(details ?? {}),
+      ...boundedDetails,
       _sourceHintUntrusted: source,
     };
     if (level === 'error') {
-      await logError(logMessage, enrichedDetails, ErrorCode.INTERNAL_ERROR, derivedSource);
+      await logError(boundedMessage, enrichedDetails, ErrorCode.INTERNAL_ERROR, derivedSource);
     } else if (level === 'warn') {
-      await logWarn(logMessage, enrichedDetails, undefined, derivedSource);
+      await logWarn(boundedMessage, enrichedDetails, undefined, derivedSource);
     } else {
-      await logDebug(logMessage, enrichedDetails, derivedSource);
+      await logDebug(boundedMessage, enrichedDetails, derivedSource);
     }
     sendResponse({ success: true });
   };


### PR DESCRIPTION
## Security Fix: VULN-004 — Unbounded forwarded-log allocation (LOG_FORWARD, size-uncapped)

<!-- vulnfix-key: 6b01d70407ca5f56 -->
<!-- vulnhunt-finding-id: VULN-004 -->
<!-- vulnhunt-results-dir: obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418 -->

Addresses VULN-004 per `/Users/yaar/Playground/obsidian-smart-history/obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418` (no source issues published on origin at scan time).

## Finding Summary

| VULN | CWE | Severity | Location | Source issue |
|------|-----|----------|----------|--------------|
| VULN-004 | CWE-400 | Low | `src/background/handlers/systemHandlers.ts:createLogForwardHandler` | — (local scan) |

## Attacker Capability

An extension-page context (XSS) sends LOG_FORWARD with a multi-megabyte message/details; the trust boundary passed it verbatim into the logger pipeline (attacker-scalable CPU and storage-quota pressure).

## Security Test

src/background/handlers/__tests__/systemHandlers.test.ts (describe "VULN-004: LOG_FORWARD enforces per-entry size caps") — RED pre-fix (3 failed | 1 passed), GREEN post-fix (4 passed).

The committed test failed against pre-fix code and passes against this fix
(discrimination evidence: stash-and-run, recorded in
`.vulnhunter-fix/discrimination/VULN-004.json`).

## Fix Description

#### VULN-004 — Unbounded forwarded-log allocation (LOG_FORWARD, size-uncapped)

Per-entry caps at the handler: logMessage truncated at 64K chars, details capped at 64 keys and 256K serialized chars (oversized replaced with a bounded preview). Count caps remain second layers.

## Verification Results

| State | Security tests | Regression suite |
|-------|---------------|-----------------|
| Before fix | FAIL — the security test was RED against the vulnerable code | PASS |
| After fix | PASS — test GREEN | PASS — no regressions (full suite) |

## Verification Table

| # | VULN-NNN | Stated vector closed? | Test exercises real attack? | Default fail-closed? | Residual risk documented? | All call sites covered? | Sweep complete? | Verdict |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | VULN-004 | yes (src/background/handlers/systemHandlers.ts:304) | yes (src/background/handlers/__tests__/systemHandlers.test.ts:508) | yes (src/background/handlers/systemHandlers.ts:290) | yes (src/background/handlers/systemHandlers.ts:287) | yes (src/background/handlers/MessageRouter.ts:.constructor) | yes (n/a) (src/background/handlers/systemHandlers.ts:287) | FULL |

## Residual Risk

Slow-and-low within caps remains possible (capped-size entries at high rate); count caps bound persistence. Tier MITIGATION (length/complexity cap).

## Sweep Summary

| VULN | Root cause | Pattern | Found | Captured | Mitigated | Remaining |
|------|-----------|---------|-------|----------|-----------|-----------|
| VULN-004 | see report | root-cause sweep (AST graph) | 0 | 0 | 0 | 0 |

## Breaking Change

None — no interface/signature changes; callers unchanged.

## Setup Required (Draft PR)

None — non-breaking at the code level; takes effect on merge.

---

Finding: VULN-004
VulnHunter-Run: obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418
Co-Authored-By: Claude Code (VulnFix)
