### PR TITLE
fix(security): VULN-005 — quarantine legacy simpleHash blobs in trust filter

### DIFF
--- a/src/utils/__tests__/bloomFilter-performance.test.ts
+++ b/src/utils/__tests__/bloomFilter-performance.test.ts
@@ -84,13 +84,31 @@ describe('BloomFilter Performance Tests', () => {
 
     const data = bloom.toData();
 
-    // Should throw when hash is corrupted
+    // Should throw when a SHA-256-format hash is corrupted (VULN-005 keeps
+    // this contract: valid-format, wrong-value hashes still fail closed)
     expect(() => {
       bloomFilterFromData({
         ...data,
-        hash: 'invalid-hash'
+        hash: `${'a'.repeat(63)}b`
       });
     }).toThrow('hash mismatch');
+  });
+
+  test('bloomFilterFromData quarantines legacy-format hashes (VULN-005)', () => {
+    const domainCount = 100;
+    const domains = Array.from({ length: domainCount }, (_, i) => `domain${i}.org`);
+    const bloom = bloomFilterFromDomains(domains, 0.01);
+
+    const data = bloom.toData();
+
+    // Legacy (non-SHA-256) hashes are no longer verified via simpleHash; the
+    // blob is quarantined to the untrusted default (empty filter) instead.
+    const quarantined = bloomFilterFromData({
+      ...data,
+      hash: 'invalid-hash'
+    });
+    expect(quarantined.getParams().expectedDomainCount).toBe(0);
+    expect(quarantined.mightContain('domain0.org')).toBe(false);
   });
 
   test('encoding handles empty bloom filter', () => {

--- a/src/utils/trustDb/__tests__/bloomFilter.test.ts
+++ b/src/utils/trustDb/__tests__/bloomFilter.test.ts
@@ -1,0 +1,45 @@
+// Transient RED→GREEN scaffold for VULN-005.
+// Final committed name: src/utils/trustDb/__tests__/bloomFilter.test.ts
+import { describe, expect, it, vi } from 'vitest';
+import { bloomFilterFromData, createBloomFilter } from '../bloomFilter.js';
+import type { BloomFilterData } from '../trustDbSchema.js';
+
+// Exact mirror of the deprecated module-private simpleHash (32-bit FNV-style).
+function simpleHashMirror(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash;
+  }
+  return Math.abs(hash).toString(16);
+}
+
+function realBlob(): BloomFilterData {
+  const real = createBloomFilter({ expectedDomainCount: 10 });
+  real.add('trusted.example');
+  return real.toData();
+}
+
+describe('VULN-005: legacy weak hashes must not pass integrity verification', () => {
+  it('quarantines a legacy simpleHash blob to the untrusted default', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const forged: BloomFilterData = { ...realBlob(), hash: simpleHashMirror(realBlob().data) };
+
+    const restored = bloomFilterFromData(forged);
+
+    expect(restored.getParams().expectedDomainCount).toBe(0); // empty/untrusted default
+    expect(restored.mightContain('trusted.example')).toBe(false);
+    warn.mockRestore();
+  });
+
+  it('still rejects a mismatched SHA-256 hash', () => {
+    const forged: BloomFilterData = { ...realBlob(), hash: `${'a'.repeat(63)}b` };
+    expect(() => bloomFilterFromData(forged)).toThrow('hash mismatch');
+  });
+
+  it('still restores a valid SHA-256 blob correctly', () => {
+    const restored = bloomFilterFromData(realBlob());
+    expect(restored.mightContain('trusted.example')).toBe(true);
+  });
+});

--- a/src/utils/trustDb/bloomFilter.ts
+++ b/src/utils/trustDb/bloomFilter.ts
@@ -8,7 +8,7 @@
  * 2. なぜ非暗号ハッシュを採用したか: 初期実装で「データ破損検出のみ」目的とコメント (セキュリティ用途ではない) し暗号学的完全性を不要と判断
  * 3. なぜ見過ごされたか: TrustDb の脅威モデルで「ローカルストレージ改ざん」を想定せず Bloomデータは信頼できる前提で設計
  * 4. なぜWebCryptoを使わなかったか: SubtleCrypto が async のため toData()/bloomFilterFromData() の同期API維持を優先し簡易ハッシュを選択
- * 5. 解: 衝突耐性のある SHA-256 (WebCrypto crypto.subtle.digest('SHA-256') と同一出力の同期実装) に置換。旧 simpleHash は移行期間のみ警告付きで許容し、次回保存時に SHA-256 へ自動移行
+ * 5. 解: 衝突耐性のある SHA-256 (WebCrypto crypto.subtle.digest('SHA-256') と同一出力の同期実装) に置換。旧 simpleHash データは信頼できないため復元時に隔離 (空フィルタ) し、次回保存時に SHA-256 へ自動移行
  *
  * 選定理由 (ADR):
  * - SHA-256 を第一段階とし HMAC は見送り。鍵管理 (chrome.storage へのHMAC鍵保存) が別PBIを要するため
@@ -154,7 +154,7 @@ function isSha256Hex(hash: string): boolean {
 
 /**
  * BloomFilterData から復元
- * 新データは SHA-256 で検証。旧 simpleHash データは警告ログの上で許容し次回保存時に SHA-256 へ移行する
+ * 新データは SHA-256 で検証。旧 simpleHash データは信頼できないため復元時に隔離 (空フィルタ) し、次回保存時に SHA-256 へ移行する
  */
 export function bloomFilterFromData(data: BloomFilterData): TrustBloomFilter {
   // ハッシュ検証（データ整合性チェック）
@@ -165,14 +165,13 @@ export function bloomFilterFromData(data: BloomFilterData): TrustBloomFilter {
         throw new Error('Bloom Filter data integrity check failed: hash mismatch');
       }
     } else {
-      // 旧データ移行パス: simpleHash で検証し警告を出す
-      const computedLegacy = simpleHash(data.data);
-      if (computedLegacy !== data.hash) {
-        throw new Error('Bloom Filter data integrity check failed: hash mismatch');
-      }
-      console.warn(
-        '[TrustBloomFilter] Legacy simpleHash detected. Data integrity is verified with deprecated hash. It will be upgraded to SHA-256 on next save.'
-      );
+      // Legacy simpleHash blobs are no longer trusted (VULN-005): an unkeyed
+      // 32-bit hash is trivially forgeable, so accepting the blob would honor
+      // a broken protection mechanism in a security-sensitive check.
+      // Quarantine to the untrusted default (empty filter) instead of
+      // restoring; the domain verifier treats it as unknown and the next
+      // save() rebuilds and rotates the blob to SHA-256.
+      return createBloomFilter({ expectedDomainCount: 0 });
     }
   }
 
@@ -181,22 +180,6 @@ export function bloomFilterFromData(data: BloomFilterData): TrustBloomFilter {
     bitCount: data.bitCount,
     expectedDomainCount: data.expectedDomainCount
   });
-}
-
-/**
- * 簡易的なハッシュ関数（整合性チェック用・非推奨）
- * 旧データ移行のために残存。新規データは sha256HexSync を使用
- * @deprecated Use sha256HexSync instead
- */
-function simpleHash(str: string): string {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash = hash & hash; // Convert to 32bit integer
-  }
-  // シフト演算後に文字列に変換
-  return Math.abs(hash).toString(16);
 }
 
 /**


### PR DESCRIPTION
## Security Fix: VULN-005 — Legacy weak hash (simpleHash) accepted in trust Bloom-filter integrity check

<!-- vulnfix-key: 47b6bd3f931765cb -->
<!-- vulnhunt-finding-id: VULN-005 -->
<!-- vulnhunt-results-dir: obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418 -->

Addresses VULN-005 per `/Users/yaar/Playground/obsidian-smart-history/obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418` (no source issues published on origin at scan time).

## Finding Summary

| VULN | CWE | Severity | Location | Source issue |
|------|-----|----------|----------|--------------|
| VULN-005 | CWE-327 | Low | `src/utils/trustDb/bloomFilter.ts:bloomFilterFromData` | — (local scan) |

## Attacker Capability

Anyone with chrome.storage.local write capability forges data + a recomputed 32-bit simpleHash and the restore path ACCEPTED the blob (console.warn only), feeding attacker-chosen trust decisions.

## Security Test

src/utils/trustDb/__tests__/bloomFilter.test.ts — RED pre-fix (1 failed | 2 passed), GREEN post-fix (3 passed); bloomFilter-performance.test.ts updated to the new legacy-quarantine contract.

The committed test failed against pre-fix code and passes against this fix
(discrimination evidence: stash-and-run, recorded in
`.vulnhunter-fix/discrimination/VULN-005.json`).

## Fix Description

#### VULN-005 — Legacy weak hash (simpleHash) accepted in trust Bloom-filter integrity check

Non-SHA-256 hashes quarantine to the untrusted default (empty filter) instead of restoring; the deprecated simpleHash function is deleted. SHA-256 verify/restore contracts unchanged.

## Verification Results

| State | Security tests | Regression suite |
|-------|---------------|-----------------|
| Before fix | FAIL — the security test was RED against the vulnerable code | PASS |
| After fix | PASS — test GREEN | PASS — no regressions (full suite) |

## Verification Table

| # | VULN-NNN | Stated vector closed? | Test exercises real attack? | Default fail-closed? | Residual risk documented? | All call sites covered? | Sweep complete? | Verdict |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | VULN-005 | yes (src/utils/trustDb/bloomFilter.ts:174) | yes (src/utils/trustDb/__tests__/bloomFilter.test.ts:25) | yes (src/utils/trustDb/bloomFilter.ts:174) | yes (src/utils/trustDb/bloomFilter.ts:168) | yes (src/utils/trustDb/TrustDbKernel.ts:.createDefaultDatabase) (src/utils/trustDb/TrustDbKernel.ts:.doInitialize) | yes (n/a) (src/utils/trustDb/bloomFilter.ts:168) | FULL |

## Residual Risk

trust-chain: algorithm not on approved list; key source not approved (Chamber/KMS); rotation not detected; transport encryption not detected — unkeyed SHA-256 integrity remains forgeable by a storage writer until keyed HMAC lands (deferred by file ADR). Quarantine limits impact to untrusted-default state.

## Sweep Summary

| VULN | Root cause | Pattern | Found | Captured | Mitigated | Remaining |
|------|-----------|---------|-------|----------|-----------|-----------|
| VULN-005 | see report | root-cause sweep (AST graph) | 0 | 0 | 0 | 0 |

## Breaking Change

None — no interface/signature changes; callers unchanged.

## Setup Required (Draft PR)

None — non-breaking at the code level; takes effect on merge.

---

Finding: VULN-005
VulnHunter-Run: obsidian-smart-history_VULNHUNT_RESULTS_2026-09-10-141418
Co-Authored-By: Claude Code (VulnFix)
